### PR TITLE
chore: raise Perl floor to 5.36 (signatures stable) + test the floor in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test the declared floor (5.36 — where subroutine signatures became a
+        # stable, warning-free feature, per cpanfile/Makefile.PL MIN_PERL_VERSION)
+        # AND a current release, so the version we *claim* to support is actually
+        # exercised. Each matrix entry runs on its own runner, so the per-test
+        # mock servers don't contend across versions. fail-fast off so one
+        # version's failure still reports the other's result.
+        perl: ['5.36', '5.38']
     steps:
       - name: Checkout signalwire-perl
         uses: actions/checkout@v5
@@ -48,7 +58,7 @@ jobs:
       - name: Setup Perl
         uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: '5.38'
+          perl-version: ${{ matrix.perl }}
 
       - name: Setup Python (porting-sdk audit scripts + mock servers)
         uses: actions/setup-python@v5

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,7 @@ WriteMakefile(
     ABSTRACT     => 'SignalWire AI Agents SDK for Perl',
     AUTHOR       => 'SignalWire <support@signalwire.com>',
     LICENSE      => 'mit',
-    MIN_PERL_VERSION => '5.026',
+    MIN_PERL_VERSION => '5.036',
     PREREQ_PM => {
         'Moo'               => '2.0',
         'JSON'              => '4.0',

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.026';
+requires 'perl', '5.036';
 
 # Core
 requires 'Moo', '2.0';

--- a/lib/SignalWire/POM/Section.pm
+++ b/lib/SignalWire/POM/Section.pm
@@ -15,11 +15,8 @@ package SignalWire::POM::Section;
 use strict;
 use warnings;
 use Moo;
-# Subroutine signatures (Perl 5.20+; floor 5.026). Must follow `use Moo;`
-# (Moo re-enables the default warning set, which would otherwise
-# un-silence experimental::signatures).
+# Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
-no warnings 'experimental::signatures';
 use Scalar::Util qw(blessed);
 use Carp qw(croak);
 use Tie::IxHash;

--- a/lib/SignalWire/Relay/Action.pm
+++ b/lib/SignalWire/Relay/Action.pm
@@ -2,11 +2,8 @@ package SignalWire::Relay::Action;
 use strict;
 use warnings;
 use Moo;
-# Subroutine signatures (Perl 5.20+; floor 5.026). Must follow `use Moo;`
-# — Moo's import re-enables the default warning set, which would otherwise
-# un-silence experimental::signatures.
+# Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
-no warnings 'experimental::signatures';
 use Scalar::Util ();
 use Carp ();
 
@@ -112,7 +109,6 @@ sub _stop_method { return '' }
 # --- PlayAction ---
 package SignalWire::Relay::Action::Play;
 use Moo;
-no warnings 'experimental::signatures';  # re-silence: use Moo re-enabled it
 extends 'SignalWire::Relay::Action';
 
 sub _stop_method { 'calling.play.stop' }
@@ -139,7 +135,6 @@ sub volume ($self, $vol) {
 # --- RecordAction ---
 package SignalWire::Relay::Action::Record;
 use Moo;
-no warnings 'experimental::signatures';  # re-silence: use Moo re-enabled it
 extends 'SignalWire::Relay::Action';
 
 sub _stop_method { 'calling.record.stop' }
@@ -168,7 +163,6 @@ sub size     { $_[0]->payload->{size}      // 0 }
 # --- DetectAction ---
 package SignalWire::Relay::Action::Detect;
 use Moo;
-no warnings 'experimental::signatures';  # re-silence: use Moo re-enabled it
 extends 'SignalWire::Relay::Action';
 
 sub _stop_method { 'calling.detect.stop' }
@@ -193,7 +187,6 @@ sub _handle_event ($self, $event) {
 # --- CollectAction (used by play_and_collect) ---
 package SignalWire::Relay::Action::Collect;
 use Moo;
-no warnings 'experimental::signatures';  # re-silence: use Moo re-enabled it
 extends 'SignalWire::Relay::Action';
 
 # play_and_collect's stop verb is calling.play_and_collect.stop, not
@@ -250,7 +243,6 @@ sub _stop_method { 'calling.collect.stop' }
 # --- FaxAction ---
 package SignalWire::Relay::Action::Fax;
 use Moo;
-no warnings 'experimental::signatures';  # re-silence: use Moo re-enabled it
 extends 'SignalWire::Relay::Action';
 
 has '_fax_type' => ( is => 'ro', default => sub { 'send' } );

--- a/lib/SignalWire/Relay/Call.pm
+++ b/lib/SignalWire/Relay/Call.pm
@@ -2,11 +2,8 @@ package SignalWire::Relay::Call;
 use strict;
 use warnings;
 use Moo;
-# Subroutine signatures (Perl 5.20+; floor 5.026). Must follow `use Moo;`
-# (Moo's import re-enables the default warning set, which would otherwise
-# un-silence experimental::signatures).
+# Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
-no warnings 'experimental::signatures';
 use Carp ();
 
 use SignalWire::Relay::Action;

--- a/lib/SignalWire/Relay/Client.pm
+++ b/lib/SignalWire/Relay/Client.pm
@@ -2,11 +2,8 @@ package SignalWire::Relay::Client;
 use strict;
 use warnings;
 use Moo;
-# Subroutine signatures (Perl 5.20+; floor 5.026). Must follow `use Moo;`
-# (Moo's import re-enables the default warning set, which would otherwise
-# un-silence experimental::signatures).
+# Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
-no warnings 'experimental::signatures';
 use Carp ();
 
 use JSON qw(encode_json decode_json);

--- a/lib/SignalWire/Relay/Device.pm
+++ b/lib/SignalWire/Relay/Device.pm
@@ -2,11 +2,8 @@ package SignalWire::Relay::Device;
 use strict;
 use warnings;
 use Moo;
-# Subroutine signatures (Perl 5.20+; floor 5.026). Must follow `use Moo;`
-# (Moo's import re-enables the default warning set, which would otherwise
-# un-silence experimental::signatures).
+# Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
-no warnings 'experimental::signatures';
 use Carp ();
 
 # A RELAY "device" object — the { type, params } pair that names one leg of

--- a/lib/SignalWire/Relay/Event.pm
+++ b/lib/SignalWire/Relay/Event.pm
@@ -2,11 +2,9 @@ package SignalWire::Relay::Event;
 use strict;
 use warnings;
 use Moo;
-# Subroutine signatures (Perl 5.20+; floor 5.026), enabled file-wide.
-# Must follow `use Moo;` (Moo re-enables the default warning set). The
-# factory at the bottom re-silences after its package's own `use Moo`.
+# Subroutine signatures (stable since Perl 5.36, the SDK's floor), enabled
+# file-wide.
 use feature 'signatures';
-no warnings 'experimental::signatures';
 
 # Base event class -- all relay events inherit from this.
 has 'event_type' => ( is => 'ro', default => sub { '' } );
@@ -228,7 +226,6 @@ has 'restart' => ( is => 'ro', default => sub { 0 } );
 
 # --- Factory method ---
 package SignalWire::Relay::Event;
-no warnings 'experimental::signatures';  # re-silence after subclass use Moo
 
 # Map event_type string to class name
 my %EVENT_CLASS_MAP = (

--- a/lib/SignalWire/Relay/Message.pm
+++ b/lib/SignalWire/Relay/Message.pm
@@ -2,11 +2,8 @@ package SignalWire::Relay::Message;
 use strict;
 use warnings;
 use Moo;
-# Subroutine signatures (Perl 5.20+; floor 5.026). Placed AFTER `use Moo;`
-# because Moo's import re-enables the default warning set and would
-# otherwise un-silence experimental::signatures.
+# Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
-no warnings 'experimental::signatures';
 use Scalar::Util ();
 use Carp ();
 

--- a/lib/SignalWire/SWAIG/FunctionResult.pm
+++ b/lib/SignalWire/SWAIG/FunctionResult.pm
@@ -2,14 +2,8 @@ package SignalWire::SWAIG::FunctionResult;
 use strict;
 use warnings;
 use Moo;
-# Subroutine signatures (Perl 5.20+). The SDK's declared floor is 5.026
-# (see Makefile.PL / cpanfile), where signatures are still gated behind
-# the experimental warning; silence it so the floor stays green. On 5.36+
-# signatures are non-experimental and this `no warnings` is harmless.
-# NB: must come AFTER `use Moo;` — Moo's import re-enables the default
-# warning set and would otherwise un-silence experimental::signatures.
+# Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
-no warnings 'experimental::signatures';
 use JSON ();
 
 has 'response' => (

--- a/lib/SignalWire/SWAIG/ParameterSchema.pm
+++ b/lib/SignalWire/SWAIG/ParameterSchema.pm
@@ -57,11 +57,8 @@ package SignalWire::SWAIG::ParameterSchema;
 use strict;
 use warnings;
 use Moo;
-# Subroutine signatures (Perl 5.20+; declared floor 5.026). Must come AFTER
-# `use Moo;` — Moo re-enables the default warning set, which would otherwise
-# un-silence experimental::signatures on the 5.026 floor.
+# Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
-no warnings 'experimental::signatures';
 use Carp qw(croak);
 use Scalar::Util qw(blessed reftype);
 use Tie::IxHash;

--- a/lib/SignalWire/Skills/SkillBase.pm
+++ b/lib/SignalWire/Skills/SkillBase.pm
@@ -5,11 +5,8 @@ package SignalWire::Skills::SkillBase;
 use strict;
 use warnings;
 use Moo;
-# Subroutine signatures (Perl 5.20+; floor 5.026). Must follow `use Moo;`
-# (Moo re-enables the default warning set, which would otherwise
-# un-silence experimental::signatures).
+# Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
-no warnings 'experimental::signatures';
 use Carp qw(croak);
 use Scalar::Util ();
 


### PR DESCRIPTION
## Why

The declared floor was `5.026` (2017, long EOL) and **never tested** — CI ran only 5.38. The SDK uses subroutine signatures, **stable since 5.36**; below that they need `no warnings 'experimental::signatures'` boilerplate, carried on 16 sites solely to prop up the stale floor. (Surfaced when Renovate mis-bumped the cpanfile `requires 'perl'` floor to a bogus `5.43.11`.)

## What

- `cpanfile` + `Makefile.PL`: MIN_PERL `5.026` → `5.036`
- Removed all `no warnings 'experimental::signatures'` (10 headers + 6 per-subclass blocks); kept `use feature 'signatures'`. Net −38 lines.
- `test.yml`: perl matrix `['5.36','5.38']` so the **floor is actually tested**. Branch-protection updated to require `test (5.36)` + `test (5.38)`.

Couldn't validate locally (this box has 5.34, below the floor) — CI is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)