### PR TITLE
test: parallel-safe mock session isolation (REST + RELAY)

### DIFF
--- a/lib/SignalWire/Relay/Client.pm
+++ b/lib/SignalWire/Relay/Client.pm
@@ -265,7 +265,12 @@ sub authenticate ($self) {
 
     if (ref $result eq 'HASH') {
         $self->protocol($result->{protocol}) if $result->{protocol};
-        $self->session_id($result->{session_id}) if $result->{session_id};
+        # The RELAY connect handshake returns the server-assigned session id
+        # under the key `sessionid` (no underscore) — see the ConnectResult
+        # wire shape (mock_relay connect_result_payload / production switchblade).
+        # Capturing it lets a test scope its journal/scenario calls to its own
+        # session for parallel-safe isolation.
+        $self->session_id($result->{sessionid}) if $result->{sessionid};
     }
 
     return $result;

--- a/t/lib/MockTest.pm
+++ b/t/lib/MockTest.pm
@@ -5,9 +5,14 @@ package MockTest;
 # Mirrors the Python conftest fixtures and the Go pilot's mocktest package:
 # - On first call to MockTest::client(), probe http://127.0.0.1:8770/__mock__/health
 #   and either reuse a running mock server or spawn one as a subprocess.
-# - Each test calls MockTest::journal_reset() before exercising the SDK so it
-#   only sees its own request, then MockTest::journal_last() to inspect what
-#   the SDK actually sent over the wire.
+# - This process mints a UNIQUE random project (test_proj_<hex>) =>
+#   unique Authorization header. journal_all()/journal_last() filter the shared
+#   global journal client-side by that header, so a test sees ONLY its own
+#   request — making the shared mock safe under file parallelism (`prove -j`)
+#   with no SDK or mock-server change. Inspect the wire request via
+#   MockTest::journal_last(). No reset is needed (the auth-filtered view starts
+#   empty), and a global wipe would race a concurrent test.
+# - Tests assert LAML AccountSid paths against $MockTest::PROJECT.
 # - PORT 8770 is reserved for the Perl rollout (see porting-sdk/test_harness/
 #   mock_signalwire/README.md).
 
@@ -16,6 +21,7 @@ use warnings;
 
 use HTTP::Tiny;
 use JSON qw(encode_json decode_json);
+use MIME::Base64 qw(encode_base64);
 use POSIX ();
 use Time::HiRes qw(sleep);
 use IPC::Open3 ();
@@ -33,8 +39,38 @@ our $PORT = $ENV{MOCK_SIGNALWIRE_PORT} || 8770;
 our $HOST = '127.0.0.1';
 our $BASE_URL = "http://$HOST:$PORT";
 
-our $PROJECT = 'test_proj';
 our $TOKEN   = 'test_tok';
+
+# The per-PROCESS project + its Authorization header. REST is pure
+# request/response with no session handshake, so the isolation key is the
+# Authorization header: each test process mints a UNIQUE random project
+# (test_proj_<12 hex>) => Basic base64(project:token) => a unique header. The
+# harness filters the shared global journal by that header (client-side) and
+# scopes scenario overrides by it (server-side), so a test only ever
+# sees/consumes its own requests and scenarios — parallel-safe under `prove -j`
+# with NO SDK or mock-server change. Random (not a counter) so concurrent
+# processes/machines hitting one shared mock can't collide.
+#
+# Minted at module-load time so $MockTest::PROJECT is final before a test file's
+# top-level `my $BASE = ".../$MockTest::PROJECT/..."` runs. Tests assert LAML
+# AccountSid paths against $MockTest::PROJECT, never a hard-coded test_proj.
+our $ACTIVE_PROJECT;
+our $ACTIVE_AUTH;
+our $PROJECT;
+
+_mint_project();
+
+sub _mint_project {
+    return if defined $ACTIVE_PROJECT;
+    my $rand = '';
+    $rand .= sprintf('%x', int(rand(16))) for 1 .. 12;
+    $ACTIVE_PROJECT = "test_proj_$rand";
+    $PROJECT = $ACTIVE_PROJECT;
+    # Match SignalWire::REST::HttpClient->_build__auth_header exactly:
+    # 'Basic ' . encode_base64("$project:$token", '').
+    $ACTIVE_AUTH = 'Basic ' . encode_base64("$ACTIVE_PROJECT:$TOKEN", '');
+    return;
+}
 
 # Singleton state. The mock server's lifetime is per-process: the first
 # client() call probes for a running instance, then either reuses it or
@@ -47,15 +83,29 @@ our $_SKIP_REASON;
 # Public API ---------------------------------------------------------------
 
 # client() returns a SignalWire::REST::RestClient pointed at the mock.
-# Resets the journal so every test starts clean.
+#
+# Each call mints a UNIQUE per-process random project (test_proj_<12 hex>) on
+# first use and reuses it for the lifetime of the process. REST is pure
+# request/response with no session handshake, so the isolation key is the
+# Authorization header: a unique project => Basic base64(project:token) => a
+# unique header. journal()/journal_last() filter the shared global journal by
+# that header (client-side), so a test only ever sees its own requests even
+# when the shared mock is driven concurrently by other test files under
+# `prove -j` — parallel-safe with NO SDK and NO mock-server change.
+#
+# Mirrors the TS frozen design (tests/rest/mocktest.ts newMockClient): random
+# (not a counter) suffix so concurrent processes/machines can't collide. Tests
+# that assert on the AccountSid in a LAML path read $MockTest::PROJECT instead
+# of hard-coding test_proj.
+#
+# No journal reset is performed: this client starts with zero entries in its
+# auth-filtered view, and a global wipe would race a concurrent test's frames.
 sub client {
     _ensure_server();
     if ($_SKIP_REASON) {
         Test::More::plan(skip_all => "MockTest: $_SKIP_REASON");
         exit 0;
     }
-    journal_reset();
-    scenario_reset();
     return SignalWire::REST::RestClient->new(
         project => $PROJECT,
         token   => $TOKEN,
@@ -63,49 +113,72 @@ sub client {
     );
 }
 
-# journal_reset clears all request entries on the mock.
+# journal_reset clears request entries on the mock. With a per-test scoped
+# project active, this is a NO-OP: the auth-filtered view starts empty for a
+# fresh project and a global wipe would race a concurrent test's in-flight
+# frames on the shared mock. Only an unscoped harness (no client() yet) does
+# the legacy global reset. (Mirrors TS MockHarness.reset.)
 sub journal_reset {
     _ensure_server();
     return if $_SKIP_REASON;
+    return if defined $ACTIVE_AUTH;
     my $resp = _ua()->post("$BASE_URL/__mock__/journal/reset");
     die "journal_reset failed: $resp->{status}" unless $resp->{success};
 }
 
-# scenario_reset clears any one-shot scenarios.
+# scenario_reset clears one-shot scenarios. Scoped to this client's auth header
+# when a project is active (so a concurrent test's armed scenarios are left
+# alone); unscoped harness clears the shared bucket.
 sub scenario_reset {
     _ensure_server();
     return if $_SKIP_REASON;
-    my $resp = _ua()->post("$BASE_URL/__mock__/scenarios/reset");
+    my $q = _scope_query();
+    my $resp = _ua()->post("$BASE_URL/__mock__/scenarios/reset$q");
     die "scenario_reset failed: $resp->{status}" unless $resp->{success};
 }
 
 # scenario_set stages a one-shot response override for the named OperationId.
 # scenario_set("calling.call-commands", 500, { error => "boom" })
+# Scoped to this client's auth header (?session_id=<urlencoded auth>) when a
+# project is active, so a concurrent test can't consume it; unscoped =>
+# shared bucket. Matches the mock's REST session key == Authorization header.
 sub scenario_set {
     my ($endpoint_id, $status, $response_body) = @_;
     _ensure_server();
     return if $_SKIP_REASON;
     my $payload = encode_json({ status => $status, response => $response_body });
     my $resp = _ua()->post(
-        "$BASE_URL/__mock__/scenarios/$endpoint_id",
+        "$BASE_URL/__mock__/scenarios/$endpoint_id" . _scope_query(),
         { content => $payload, headers => { 'Content-Type' => 'application/json' } },
     );
     die "scenario_set failed: $resp->{status} - $resp->{content}" unless $resp->{success};
 }
 
-# journal_all returns the array-of-hashref of every recorded request since
-# the last reset, in arrival order.
+# Build a `?session_id=<urlencoded auth header>` suffix scoping a control-plane
+# call to this client, or '' when no project is active (unscoped/shared).
+sub _scope_query {
+    return '' unless defined $ACTIVE_AUTH;
+    (my $enc = $ACTIVE_AUTH) =~ s/([^A-Za-z0-9_.~-])/sprintf('%%%02X', ord($1))/ge;
+    return "?session_id=$enc";
+}
+
+# journal_all returns the array-of-hashref of recorded requests in arrival
+# order. Scoped to THIS client's Authorization header (client-side filter on
+# the lowercase `authorization` key — Starlette lowercases header names) when a
+# project is active, so a parallel test never sees another test's requests.
 sub journal_all {
     _ensure_server();
     die "MockTest: $_SKIP_REASON" if $_SKIP_REASON;
     my $resp = _ua()->get("$BASE_URL/__mock__/journal");
     die "journal fetch failed: $resp->{status}" unless $resp->{success};
-    return decode_json($resp->{content} || '[]');
+    my $entries = decode_json($resp->{content} || '[]');
+    return $entries unless defined $ACTIVE_AUTH;
+    return [ grep { ($_->{headers}{authorization} // '') eq $ACTIVE_AUTH } @$entries ];
 }
 
-# journal_last returns the most recently recorded request. Dies if the
-# journal is empty - every test that calls a mock-backed SDK method should
-# produce at least one entry.
+# journal_last returns the most recently recorded request for THIS client.
+# Dies if the journal is empty - every test that calls a mock-backed SDK
+# method should produce at least one entry.
 sub journal_last {
     my @entries = @{ journal_all() };
     die "MockTest: journal is empty - SDK call did not reach mock server"
@@ -220,10 +293,18 @@ sub _probe_health {
 }
 
 END {
-    if ($_MOCK_PID && $_MOCK_PID > 0) {
-        # Politely terminate; the OS will clean up either way.
-        eval { kill 'TERM', $_MOCK_PID };
-    }
+    # We deliberately do NOT kill the spawned mock here. Under `prove -jN` the
+    # mock is a per-PORT singleton shared across test-file PROCESSES: the first
+    # file spawns it, the rest probe and REUSE it (only the spawner sets
+    # $_MOCK_PID). If the spawner tore it down at its END, a sibling file still
+    # issuing requests would lose the server mid-suite. So we leave the detached
+    # mock running for the lifetime of the prove run; the next invocation's
+    # probe reuses it (idempotent), and per-client auth-header journal scoping
+    # keeps cross-run state clean. Strays are reaped by the suite's stale-mock
+    # cleanup (`lsof -ti :8770 | xargs kill`). Mirrors the relay harness and the
+    # TS `child.unref()` lifecycle. (REST is quick request/response so the race
+    # is far less likely than the relay WS case, but the fix is identical and
+    # makes both harnesses uniformly parallel-safe.)
 }
 
 1;
@@ -249,7 +330,7 @@ MockTest - test helper for the porting-sdk mock_signalwire HTTP server.
     my $j = MockTest::journal_last();
     is($j->{method}, 'POST', 'POST recorded');
     is($j->{path},
-       '/api/laml/2010-04-01/Accounts/test_proj/Calls/CA_TEST/Streams',
+       "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Calls/CA_TEST/Streams",
        'path matches');
     is($j->{body}{Url}, 'wss://example.com/stream', 'body Url forwarded');
 
@@ -257,9 +338,12 @@ MockTest - test helper for the porting-sdk mock_signalwire HTTP server.
 
 The mock server's lifetime is per-process: the first MockTest::client()
 call probes http://127.0.0.1:8770/__mock__/health and either confirms
-a running server or starts one via `python -m mock_signalwire`. Each
-test that calls C<client()> gets a freshly-reset journal so subsequent
-journal_last() calls return only that test's request.
+a running server or starts one via `python -m mock_signalwire`. The
+process mints a unique random project (C<test_proj_E<lt>hexE<gt>>), so its
+Basic-Auth header is unique; journal_all()/journal_last() filter the shared
+journal by that header and return only this process's requests, making the
+shared mock safe under file parallelism (C<prove -j>) with no reset. Tests
+assert LAML AccountSid paths against C<$MockTest::PROJECT>.
 
 =head1 PORT
 

--- a/t/lib/RelayMockTest.pm
+++ b/t/lib/RelayMockTest.pm
@@ -52,9 +52,22 @@ our $_SKIP_REASON;
 
 # Public API ---------------------------------------------------------------
 
-# client(%opts) returns a SignalWire::Relay::Client pointed at the mock.
-# Resets the journal/scenarios so every test starts clean.
-# Does NOT connect — caller must $client->connect (or connect_ws+authenticate).
+# The client most recently handed out by client(). Journal/scenario calls that
+# aren't given an explicit session_id default to THIS client's handshake
+# session (once it connects), so a test transparently sees only its own frames
+# even when the shared mock is driven by other tests in parallel processes.
+# Within one test file prove runs tests serially, so "the active client" is
+# unambiguous; cross-file isolation is exactly what the session scoping buys.
+our $_ACTIVE_CLIENT;
+
+# client(%opts) returns a SignalWire::Relay::Client pointed at the mock and
+# registers it as the active client for default journal/scenario scoping.
+#
+# NO global journal/scenario reset is performed: each connect yields a brand-new
+# server session whose scoped journal starts empty, so a reset is unnecessary
+# AND a global wipe would race a concurrent test's in-flight frames on the
+# shared mock. (Mirrors the TS frozen design: fresh client + per-session view,
+# no global reset.) Does NOT connect — caller must $client->connect.
 sub client {
     my %opts = @_;
     _ensure_server();
@@ -64,8 +77,6 @@ sub client {
         }
         die "RelayMockTest: $_SKIP_REASON";
     }
-    journal_reset();
-    scenario_reset();
 
     my $client = SignalWire::Relay::Client->new(
         project  => $opts{project}  // $PROJECT,
@@ -76,7 +87,30 @@ sub client {
         contexts => $opts{contexts} // [],
         (exists $opts{agent} ? (agent => $opts{agent}) : ()),
     );
+    $_ACTIVE_CLIENT = $client;
     return $client;
+}
+
+# scope($client) makes $client the active client for default scoping and
+# returns it (so a test can write `my $c = RelayMockTest::scope($mine);`).
+# Use this for clients built by hand (not via client()), or to re-point the
+# default scope at a specific client in a multi-client test.
+sub scope {
+    my ($client) = @_;
+    $_ACTIVE_CLIENT = $client;
+    return $client;
+}
+
+# The session id to scope a control-plane call to: an explicit session_id arg
+# wins; otherwise the active client's handshake session (empty until connect).
+# An empty string means "global view" (unscoped), preserving back-compat for
+# callers that pass session_id => '' or run before any client connected.
+sub _scope_session {
+    my (%opts) = @_;
+    return $opts{session_id} if exists $opts{session_id};
+    return undef unless $_ACTIVE_CLIENT;
+    my $sid = eval { $_ACTIVE_CLIENT->session_id };
+    return (defined $sid && $sid ne '') ? $sid : undef;
 }
 
 # Connect a fresh client (helper that does both connect_ws + authenticate).
@@ -89,65 +123,113 @@ sub connect_client {
     return $r;
 }
 
-# journal_reset clears all journal entries on the mock.
+# Build a `?session_id=<urlencoded id>` query suffix when a session id is
+# supplied, else the empty string. The session id is the server-assigned
+# `sessionid` from the RELAY connect handshake (== $client->session_id).
+# Threading it onto a control-plane call scopes that call to one connection's
+# frames, so concurrent tests against the shared mock never see each other's
+# (parallel-safe). Absent => global view (back-compat, correct under serial).
+sub _session_query {
+    my ($sid) = @_;
+    return '' unless defined $sid && $sid ne '';
+    # Percent-encode anything outside the unreserved set; session ids are hex
+    # in practice, but encode defensively so an arbitrary id is URL-safe.
+    (my $enc = $sid) =~ s/([^A-Za-z0-9_.~-])/sprintf('%%%02X', ord($1))/ge;
+    return "?session_id=$enc";
+}
+
+# Inject $sid into a scenario_play timeline op's push/expect_recv spec when the
+# op doesn't already specify a session_id. Leaves sleep ops untouched. Returns
+# a shallow copy so the caller's ops array is not mutated.
+sub _scope_op {
+    my ($op, $sid) = @_;
+    return $op unless ref $op eq 'HASH';
+    my %out = %$op;
+    for my $key (qw(push expect_recv)) {
+        my $spec = $out{$key};
+        if (ref $spec eq 'HASH' && !exists $spec->{session_id}) {
+            $out{$key} = { %$spec, session_id => $sid };
+        }
+    }
+    return \%out;
+}
+
+# journal_reset clears journal entries on the mock. With session_id => <id>,
+# clears only that session's entries (parallel-safe); absent => clears all.
 sub journal_reset {
+    my (%opts) = @_;
     _ensure_server();
     return if $_SKIP_REASON;
+    my $q = _session_query(_scope_session(%opts));
     # Retry: the mock may be transiently unreachable during cross-test
     # spawn races (HTTP::Tiny 599 = internal connect/timeout).
     my $resp;
     for my $i (1..10) {
-        $resp = _ua()->post("$HTTP_URL/__mock__/journal/reset");
+        $resp = _ua()->post("$HTTP_URL/__mock__/journal/reset$q");
         last if $resp->{success};
         Time::HiRes::sleep(0.1);
     }
     die "journal_reset failed: $resp->{status}" unless $resp->{success};
 }
 
-# scenario_reset clears all queued scenarios on the mock.
+# scenario_reset clears queued scenarios on the mock. With session_id => <id>,
+# clears only that session's armed scenarios (parallel-safe); absent => all.
 sub scenario_reset {
+    my (%opts) = @_;
     _ensure_server();
     return if $_SKIP_REASON;
+    my $q = _session_query(_scope_session(%opts));
     my $resp;
     for my $i (1..10) {
-        $resp = _ua()->post("$HTTP_URL/__mock__/scenarios/reset");
+        $resp = _ua()->post("$HTTP_URL/__mock__/scenarios/reset$q");
         last if $resp->{success};
         Time::HiRes::sleep(0.1);
     }
     die "scenario_reset failed: $resp->{status}" unless $resp->{success};
 }
 
-# journal_all returns the list of all recorded frames since reset.
+# journal_all returns recorded frames since reset. With session_id => <id>,
+# returns only that session's frames (parallel-safe); absent => every frame.
 sub journal_all {
+    my (%opts) = @_;
     _ensure_server();
     die "RelayMockTest: $_SKIP_REASON" if $_SKIP_REASON;
-    my $resp = _ua()->get("$HTTP_URL/__mock__/journal");
+    my $q = _session_query(_scope_session(%opts));
+    my $resp = _ua()->get("$HTTP_URL/__mock__/journal$q");
     die "journal fetch failed: $resp->{status}" unless $resp->{success};
     return decode_json($resp->{content} || '[]');
 }
 
-# journal_last returns the most recently recorded frame.
+# journal_last returns the most recently recorded frame (optionally scoped to
+# session_id => <id>).
 sub journal_last {
-    my @entries = @{ journal_all() };
+    my (%opts) = @_;
+    my @entries = @{ journal_all(%opts) };
     die "RelayMockTest: journal is empty - no SDK frames reached the mock"
         unless @entries;
     return $entries[-1];
 }
 
-# journal_recv returns inbound (SDK→server) frames, optionally filtered by method.
+# journal_recv returns inbound (SDK→server) frames, optionally filtered by
+# method and/or scoped to session_id => <id>.
 sub journal_recv {
     my (%opts) = @_;
-    my @entries = grep { ($_->{direction} // '') eq 'recv' } @{ journal_all() };
+    # Forward an explicit session_id to journal_all; if absent, journal_all
+    # applies the active-client default via _scope_session.
+    my %scope = exists $opts{session_id} ? (session_id => $opts{session_id}) : ();
+    my @entries = grep { ($_->{direction} // '') eq 'recv' } @{ journal_all(%scope) };
     if (defined $opts{method}) {
         @entries = grep { ($_->{method} // '') eq $opts{method} } @entries;
     }
     return \@entries;
 }
 
-# journal_send returns outbound (server→SDK) frames, optionally filtered by event_type.
+# journal_send returns outbound (server→SDK) frames, optionally filtered by
+# event_type and/or scoped to session_id => <id>.
 sub journal_send {
     my (%opts) = @_;
-    my @entries = grep { ($_->{direction} // '') eq 'send' } @{ journal_all() };
+    my %scope = exists $opts{session_id} ? (session_id => $opts{session_id}) : ();
+    my @entries = grep { ($_->{direction} // '') eq 'send' } @{ journal_all(%scope) };
     if (defined $opts{event_type}) {
         my $et = $opts{event_type};
         @entries = grep {
@@ -162,26 +244,34 @@ sub journal_send {
 }
 
 # arm_method queues scripted post-RPC events for `method` (FIFO, consume-once).
+# With session_id => <id>, the scenario is scoped to that session so a parallel
+# test can't consume it; absent => shared bucket.
 sub arm_method {
-    my ($method, $events) = @_;
+    my ($method, $events, %opts) = @_;
     _ensure_server();
     return if $_SKIP_REASON;
+    my $q = _session_query(_scope_session(%opts));
     my $body = encode_json($events);
     my $resp = _ua()->post(
-        "$HTTP_URL/__mock__/scenarios/$method",
+        "$HTTP_URL/__mock__/scenarios/$method$q",
         { content => $body, headers => { 'Content-Type' => 'application/json' } },
     );
     die "arm_method failed: $resp->{status} - $resp->{content}" unless $resp->{success};
 }
 
-# arm_dial queues a dial-dance scenario (winner state events + final dial event).
+# arm_dial queues a dial-dance scenario (winner state events + final dial
+# event). With session_id => <id>, the scenario is scoped to that session;
+# the mock also accepts the id in the body, but we put it on the query string
+# to match the other control-plane endpoints.
 sub arm_dial {
     my (%kwargs) = @_;
     _ensure_server();
     return if $_SKIP_REASON;
+    my %sopt = exists $kwargs{session_id} ? (session_id => delete $kwargs{session_id}) : ();
+    my $q = _session_query(_scope_session(%sopt));
     my $body = encode_json(\%kwargs);
     my $resp = _ua()->post(
-        "$HTTP_URL/__mock__/scenarios/dial",
+        "$HTTP_URL/__mock__/scenarios/dial$q",
         { content => $body, headers => { 'Content-Type' => 'application/json' } },
     );
     die "arm_dial failed: $resp->{status} - $resp->{content}" unless $resp->{success};
@@ -192,10 +282,7 @@ sub push_frame {
     my ($frame, %opts) = @_;
     _ensure_server();
     return if $_SKIP_REASON;
-    my $url = "$HTTP_URL/__mock__/push";
-    if ($opts{session_id}) {
-        $url .= "?session_id=$opts{session_id}";
-    }
+    my $url = "$HTTP_URL/__mock__/push" . _session_query(_scope_session(%opts));
     my $body = encode_json({ frame => $frame });
     my $resp = _ua()->post(
         $url,
@@ -218,7 +305,11 @@ sub inbound_call {
         delay_ms    => $opts{delay_ms}    // 50,
     );
     $body{call_id} = $opts{call_id} if exists $opts{call_id};
-    $body{session_id} = $opts{session_id} if exists $opts{session_id};
+    # Default to the active client's session so the inbound-call sequence is
+    # delivered only to this test's client (parallel-safe); an explicit
+    # session_id wins, and an empty string broadcasts (legacy behavior).
+    my $sid = _scope_session(%opts);
+    $body{session_id} = $sid if defined $sid && $sid ne '';
     my $payload = encode_json(\%body);
     my $resp = _ua()->post(
         "$HTTP_URL/__mock__/inbound_call",
@@ -228,11 +319,19 @@ sub inbound_call {
     return decode_json($resp->{content} // '{}');
 }
 
-# scenario_play runs a scripted timeline (push/sleep/expect_recv ops).
+# scenario_play runs a scripted timeline (push/sleep/expect_recv ops). With
+# session_id => <id>, every push/expect_recv op that doesn't already carry a
+# session_id is stamped with it (mirrors the TS harness's scopeOp), so the
+# timeline targets only that session's client and expect_recv matches only
+# that session's frames — making it parallel-safe. sleep ops are left as-is.
 sub scenario_play {
-    my ($ops) = @_;
+    my ($ops, %opts) = @_;
     _ensure_server();
     return if $_SKIP_REASON;
+    my $sid = _scope_session(%opts);
+    if (defined $sid && $sid ne '') {
+        $ops = [ map { _scope_op($_, $sid) } @$ops ];
+    }
     my $body = encode_json($ops);
     my $ua = _ua();
     # scenario_play can take longer due to expect_recv waits; bump timeout.
@@ -372,22 +471,25 @@ sub _probe_health {
 END {
     # Preserve the test's exit status; waitpid otherwise stomps $?.
     local $?;
-    if ($_MOCK_PID && $_MOCK_PID > 0) {
-        eval {
-            kill 'TERM', $_MOCK_PID;
-            # Wait briefly so the next prove run doesn't race the
-            # python uvicorn shutdown when both ports go idle.
-            for my $i (1..20) {
-                last unless kill 0, $_MOCK_PID;
-                Time::HiRes::sleep(0.05);
-            }
-            # Force-kill if still alive.
-            if (kill 0, $_MOCK_PID) {
-                kill 'KILL', $_MOCK_PID;
-            }
-            waitpid($_MOCK_PID, POSIX::WNOHANG);
-        };
-    }
+    # We deliberately do NOT kill the spawned mock here.
+    #
+    # Under `prove -jN` the mock is a per-PORT singleton shared across test-file
+    # PROCESSES: the first file to run spawns it, every other file probes and
+    # REUSES it (only the spawner sets $_MOCK_PID). If the spawner tore the mock
+    # down at its END, any sibling file still mid-WS-session would have its
+    # socket yanked — surfacing as a process that "passed all subtests" yet
+    # exits 255 (WS drop on teardown) or hangs forever on an expect_recv that
+    # can never arrive. That race is exactly what breaks the suite under -j.
+    #
+    # So we leave the detached (setsid'd, stdio-to-/dev/null) mock running for
+    # the lifetime of the prove run. The next invocation's _ensure_server probe
+    # reuses it (idempotent), and per-session journal/scenario scoping keeps
+    # cross-run state clean. Strays are reaped by the suite's stale-mock cleanup
+    # (`lsof -ti :9780 :8780 | xargs kill`). This mirrors the TS harness's
+    # `child.unref()` lifecycle (tests/relay/mocktest.ts) — detach, never kill.
+    #
+    # $_MOCK_PID is retained only so a *failed* startup (below) can TERM the
+    # half-spawned child; a healthy mock is intentionally left alone.
 }
 
 1;

--- a/t/relay/connect_mock.t
+++ b/t/relay/connect_mock.t
@@ -109,10 +109,17 @@ subtest 'reconnect with protocol string includes protocol in frame' => sub {
     );
     $c2->protocol($issued);
     $c2->connect;
+    # Scope journal reads to c2's session (it was built by hand, not via
+    # client()) and capture the session id before disconnect clears nothing
+    # server-side but keeps the scope pointed at c2.
+    my $c2_session = $c2->session_id;
     $c2->disconnect;
 
-    # The second connect frame must carry that protocol field.
-    my $entries = RelayMockTest::journal_recv(method => 'signalwire.connect');
+    # The second connect frame must carry that protocol field. Read scoped to
+    # c2's session so a parallel test's connect frame is invisible here.
+    my $entries = RelayMockTest::journal_recv(
+        method => 'signalwire.connect', session_id => $c2_session,
+    );
     my @resume = grep { ($_->{frame}{params}{protocol} // '') eq $issued } @$entries;
     ok(scalar @resume, 'resume connect frame carries the protocol')
         or diag "saw protocols: "
@@ -164,8 +171,9 @@ subtest 'unauthenticated raw connect rejected by mock' => sub {
     require Protocol::WebSocket::Client;
     require JSON;
 
-    # Reset journal so this test only sees its own connect.
-    RelayMockTest::journal_reset();
+    # No journal reset needed: this test reads the WebSocket error response
+    # directly off the raw socket, not the mock journal. (A global reset here
+    # would also race a concurrent test's frames under prove -j.)
 
     my $sock = IO::Socket::INET->new(
         PeerHost => '127.0.0.1',
@@ -245,7 +253,6 @@ subtest 'unauthenticated raw connect rejected by mock' => sub {
 # ---------------------------------------------------------------------------
 
 subtest 'connect with jwt carries jwt on wire' => sub {
-    RelayMockTest::journal_reset();
     my $client = SignalWire::Relay::Client->new(
         project   => '',
         token     => '',
@@ -255,9 +262,15 @@ subtest 'connect with jwt carries jwt on wire' => sub {
         path      => '',
     );
     $client->connect;
+    # Scope the journal read to THIS client's session (captured before
+    # disconnect) so a parallel test's connect frame can't be read here.
+    # Mirrors the TS frozen design's `mock.sessionId = sessionIdOf(c)`.
+    my $session = $client->session_id;
     $client->disconnect;
 
-    my $entries = RelayMockTest::journal_recv(method => 'signalwire.connect');
+    my $entries = RelayMockTest::journal_recv(
+        method => 'signalwire.connect', session_id => $session,
+    );
     is(scalar @$entries, 1, 'one connect frame');
     my $auth = $entries->[0]{frame}{params}{authentication};
     is($auth->{jwt_token}, 'fake-jwt-eyJ.AaaA.BbB', 'jwt_token on wire');

--- a/t/relay/inbound_call_mock.t
+++ b/t/relay/inbound_call_mock.t
@@ -336,6 +336,9 @@ subtest 'inbound without handler does not crash' => sub {
         contexts => ['default'],
     );
     $client->connect;
+    # Hand-built client (not via client()): point default scoping at it so the
+    # inbound-call sequence targets THIS client's session.
+    RelayMockTest::scope($client);
     RelayMockTest::inbound_call(call_id => 'c-nohandler', auto_states => ['created']);
     # Pump for ~1s; the receive event should be processed without crashing.
     _pump_until($client, 1, sub { 0 });

--- a/t/relay/outbound_call_mock.t
+++ b/t/relay/outbound_call_mock.t
@@ -92,10 +92,16 @@ use HTTP::Tiny;
 use JSON qw(encode_json decode_json);
 use Time::HiRes qw(sleep);
 my $base = $ENV{RMT_HTTP_URL};
+my $sid  = $ENV{RMT_SESSION_ID} // '';
+# Scope the journal scan to the parent client's session so a stale
+# calling.dial frame left by a prior subtest (we no longer globally reset
+# the journal) can't be mistaken for this subtest's dial.
+my $jurl = $sid ne '' ? "$base/__mock__/journal?session_id=$sid"
+                      : "$base/__mock__/journal";
 my $ua = HTTP::Tiny->new(timeout => 5);
 my $tag;
 for my $i (1..400) {
-    my $r = $ua->get("$base/__mock__/journal");
+    my $r = $ua->get($jurl);
     if ($r->{success}) {
         for my $e (@{ decode_json($r->{content}) }) {
             if (($e->{direction}//'') eq 'recv'
@@ -133,7 +139,9 @@ my $body = encode_json({
         },
     },
 });
-$ua->post("$base/__mock__/push",
+my $purl = $sid ne '' ? "$base/__mock__/push?session_id=$sid"
+                      : "$base/__mock__/push";
+$ua->post($purl,
     { content => $body, headers => { 'Content-Type' => 'application/json' } });
 exit 0;
 PERLEOF
@@ -143,7 +151,8 @@ PERLEOF
     print $fh $watcher_script;
     close $fh;
 
-    local $ENV{RMT_HTTP_URL} = $RelayMockTest::HTTP_URL;
+    local $ENV{RMT_HTTP_URL}   = $RelayMockTest::HTTP_URL;
+    local $ENV{RMT_SESSION_ID} = $client->session_id // '';
     my $pid = fork();
     if ($pid == 0) {
         # Use exec to fully detach (no shared sockets, no Moo state, etc.)

--- a/t/rest/01_compat_calls_streams.t
+++ b/t/rest/01_compat_calls_streams.t
@@ -34,7 +34,7 @@ subtest 'TestCompatCallsStartStream' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'POST', 'POST recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/Calls/CA_JX1/Streams',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Calls/CA_JX1/Streams",
            'path is /Calls/{sid}/Streams');
         is(ref $j->{body}, 'HASH', 'body decoded as hashref');
         is($j->{body}{Url},  'wss://a.b/s', 'body Url forwarded');
@@ -59,7 +59,7 @@ subtest 'TestCompatCallsStopStream' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'POST', 'POST recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/Calls/CA_S1/Streams/ST_S1',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Calls/CA_S1/Streams/ST_S1",
            'path is /Streams/{stream_sid}');
         is(ref $j->{body}, 'HASH', 'body decoded as hashref');
         is($j->{body}{Status}, 'stopped', 'body Status forwarded');
@@ -85,7 +85,7 @@ subtest 'TestCompatCallsUpdateRecording' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'POST', 'POST recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/Calls/CA_R1/Recordings/RE_R1',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Calls/CA_R1/Recordings/RE_R1",
            'path is /Recordings/{recording_sid}');
         is(ref $j->{body}, 'HASH', 'body decoded as hashref');
         is($j->{body}{Status}, 'paused', 'body Status forwarded');

--- a/t/rest/02_compat_messages_faxes.t
+++ b/t/rest/02_compat_messages_faxes.t
@@ -32,7 +32,7 @@ subtest 'TestCompatMessagesUpdate' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'POST', 'POST recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/Messages/MM_U1',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Messages/MM_U1",
            'path is /Messages/{sid}');
         is(ref $j->{body}, 'HASH', 'body is a hashref');
         is($j->{body}{Body},   'x',        'Body forwarded');
@@ -55,7 +55,7 @@ subtest 'TestCompatMessagesGetMedia' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'GET', 'GET recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/Messages/MM_X/Media/ME_X',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Messages/MM_X/Media/ME_X",
            'path is /Messages/{sid}/Media/{media_sid}');
     };
 };
@@ -73,7 +73,7 @@ subtest 'TestCompatMessagesDeleteMedia' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'DELETE', 'DELETE recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/Messages/MM_D/Media/ME_D',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Messages/MM_D/Media/ME_D",
            'DELETE path is /Messages/{sid}/Media/{media_sid}');
     };
 };
@@ -95,7 +95,7 @@ subtest 'TestCompatFaxesUpdate' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'POST', 'POST recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_U2',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Faxes/FX_U2",
            'path is /Faxes/{sid}');
         is(ref $j->{body}, 'HASH', 'body is a hashref');
         is($j->{body}{Status}, 'canceled', 'Status forwarded');
@@ -117,7 +117,7 @@ subtest 'TestCompatFaxesListMedia' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'GET', 'GET recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_LM_X/Media',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Faxes/FX_LM_X/Media",
            'path is /Faxes/{sid}/Media');
     };
 };
@@ -137,7 +137,7 @@ subtest 'TestCompatFaxesGetMedia' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'GET', 'GET recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_G/Media/ME_G',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Faxes/FX_G/Media/ME_G",
            'path is /Faxes/{sid}/Media/{media_sid}');
     };
 };
@@ -155,7 +155,7 @@ subtest 'TestCompatFaxesDeleteMedia' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'DELETE', 'DELETE recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_D/Media/ME_D',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Faxes/FX_D/Media/ME_D",
            'DELETE path is /Faxes/{sid}/Media/{media_sid}');
     };
 };

--- a/t/rest/03_compat_phone_numbers.t
+++ b/t/rest/03_compat_phone_numbers.t
@@ -32,7 +32,7 @@ subtest 'TestCompatPhoneNumbersList' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'GET', 'GET recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/IncomingPhoneNumbers",
            'path is /IncomingPhoneNumbers');
     };
 };
@@ -52,7 +52,7 @@ subtest 'TestCompatPhoneNumbersGet' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'GET', 'GET recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers/PN_GET',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/IncomingPhoneNumbers/PN_GET",
            'GET path includes sid');
     };
 };
@@ -78,7 +78,7 @@ subtest 'TestCompatPhoneNumbersUpdate' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'POST', 'POST recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers/PN_UU',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/IncomingPhoneNumbers/PN_UU",
            'path includes sid');
         is(ref $j->{body}, 'HASH', 'body is a hashref');
         is($j->{body}{FriendlyName}, 'updated',          'FriendlyName forwarded');
@@ -99,7 +99,7 @@ subtest 'TestCompatPhoneNumbersDelete' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'DELETE', 'DELETE recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers/PN_DEL',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/IncomingPhoneNumbers/PN_DEL",
            'DELETE path includes sid');
     };
 };
@@ -124,7 +124,7 @@ subtest 'TestCompatPhoneNumbersPurchase' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'POST', 'POST recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/IncomingPhoneNumbers",
            'POST goes to /IncomingPhoneNumbers');
         is(ref $j->{body}, 'HASH', 'body is a hashref');
         is($j->{body}{PhoneNumber},  '+15555550100', 'PhoneNumber forwarded');
@@ -152,7 +152,7 @@ subtest 'TestCompatPhoneNumbersImportNumber' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'POST', 'POST recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/ImportedPhoneNumbers',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/ImportedPhoneNumbers",
            'POST goes to /ImportedPhoneNumbers (not /IncomingPhoneNumbers)');
         is(ref $j->{body}, 'HASH', 'body is a hashref');
         is($j->{body}{PhoneNumber}, '+15555550111', 'PhoneNumber forwarded');
@@ -175,7 +175,7 @@ subtest 'TestCompatPhoneNumbersListAvailableCountries' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'GET', 'GET recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/AvailablePhoneNumbers',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/AvailablePhoneNumbers",
            'GET goes to /AvailablePhoneNumbers');
     };
 };
@@ -199,7 +199,7 @@ subtest 'TestCompatPhoneNumbersSearchTollFree' => sub {
         my $j = MockTest::journal_last();
         is($j->{method}, 'GET', 'GET recorded');
         is($j->{path},
-           '/api/laml/2010-04-01/Accounts/test_proj/AvailablePhoneNumbers/US/TollFree',
+           "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/AvailablePhoneNumbers/US/TollFree",
            'GET path includes country');
         ok(exists $j->{query_params}{AreaCode},
             'AreaCode appears on the query string');

--- a/t/rest/07_compat_conferences.t
+++ b/t/rest/07_compat_conferences.t
@@ -15,7 +15,7 @@ use Test::More;
 
 use MockTest;
 
-my $BASE = '/api/laml/2010-04-01/Accounts/test_proj/Conferences';
+my $BASE = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Conferences";
 
 # ---- Conference itself ---------------------------------------------------
 

--- a/t/rest/08_compat_misc.t
+++ b/t/rest/08_compat_misc.t
@@ -14,7 +14,7 @@ use Test::More;
 
 use MockTest;
 
-my $BASE = '/api/laml/2010-04-01/Accounts/test_proj';
+my $BASE = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT";
 
 # ---- Applications --------------------------------------------------------
 

--- a/t/rest/09_compat_queues.t
+++ b/t/rest/09_compat_queues.t
@@ -12,7 +12,7 @@ use Test::More;
 
 use MockTest;
 
-my $BASE = '/api/laml/2010-04-01/Accounts/test_proj/Queues';
+my $BASE = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Queues";
 
 subtest 'TestCompatQueuesUpdate' => sub {
     subtest 'test_returns_queue_resource' => sub {

--- a/t/rest/10_compat_tokens.t
+++ b/t/rest/10_compat_tokens.t
@@ -13,7 +13,7 @@ use Test::More;
 
 use MockTest;
 
-my $BASE = '/api/laml/2010-04-01/Accounts/test_proj/tokens';
+my $BASE = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/tokens";
 
 subtest 'TestCompatTokensCreate' => sub {
     subtest 'test_returns_token_resource' => sub {

--- a/t/rest/11_compat_recordings_transcriptions.t
+++ b/t/rest/11_compat_recordings_transcriptions.t
@@ -15,7 +15,7 @@ use Test::More;
 
 use MockTest;
 
-my $BASE = '/api/laml/2010-04-01/Accounts/test_proj';
+my $BASE = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT";
 
 # ---- Recordings ----------------------------------------------------------
 


### PR DESCRIPTION
## What

Makes the shared `mock_signalwire` (REST) and `mock_relay` (RELAY) test harnesses safe under `prove -j` file parallelism, so the mock suites parallelize across test files with zero cross-test interference.

## RELAY (isolation key = handshake `sessionid`)

- **`Client.pm` `authenticate()`**: capture the server-assigned session id from the ConnectResult under its real wire key `sessionid` (no underscore). At HEAD it keyed on the nonexistent `session_id`, so `$client->session_id` was never populated and *all* relay scoping was a silent no-op. Verified against `mock_relay` `auth.connect_result_payload` (returns `sessionid`; the journal records each connection's frames under that same id).
- **`RelayMockTest.pm`**: thread `?session_id=<id>` onto `journal_all`/`journal_reset`/`scenario_reset`/`arm_method`/`arm_dial`/`push_frame`/`inbound_call`, plus per-op stamping in `scenario_play` (mirrors the TS `scopeOp`). Calls default to the active client's session. Per test = fresh client + per-session view, **no global reset** (a global wipe would race a concurrent file).
- Relay test files capture `$client->session_id` before disconnect and scope journal reads to it; hand-built clients register via `scope()`.

## REST (isolation key = Authorization header, no SDK change)

- **`MockTest.pm`**: mint a unique per-process random project (`test_proj_<12 hex>`) at module load → unique Basic-Auth header. `journal_all`/`journal_last` filter the shared global journal client-side on the lowercase `authorization` key (Starlette lowercases header names); `scenario_set`/`scenario_reset` scope via `?session_id=<urlencoded auth>`; `journal_reset` is a no-op while scoped.
- Fixed the 11 `t/rest` LAML-path assertions (+ the `MockTest` SYNOPSIS pod) to read `$MockTest::PROJECT` instead of a hard-coded `test_proj`.

## Parallel lifecycle fix (both harnesses)

The mock is a per-PORT singleton shared across test-file processes (first file spawns, others probe + reuse). The spawner no longer kills it at `END` — doing so yanked the socket out from under sibling files still mid-session, surfacing as exit-255 (WS drop) or a hung `expect_recv` under `-j`. The detached mock is now left for the prove run's lifetime and reaped by the suite's stale-mock cleanup; mirrors the TS `child.unref()` lifecycle.

## `session_id` surface decision

`session_id` is a **pre-existing** public Moo accessor on `RelayClient` (present at HEAD). The surface enumerator tracks only `sub` declarations, not Moo `has` accessors, so this change adds **no new surface symbol** — no `PORT_ADDITIONS.md` entry is required and the drift gate stays at 0 (verified).

## Verification

- `run-ci.sh`: **DRIFT / SURFACE-FRESH / NO-CHEAT / EMISSION all PASS** (drift = 0).
- REST suite (16 files) and RELAY suite (8 files): **PASS under `prove -j6`/`-j8` + CPU load (≥6× concurrency), deterministic** across repeated runs.
- The only TEST-gate failure on the dev host (`t/12_cli.t` — missing-CLI-script/exec gap, plus dependency-gated tests when run with bare system perl) is **pre-existing and identical at `origin/main`** (confirmed by stash-and-rerun); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ab1ghK8PCd2PzW79nzsAqT