### PR TITLE
fix(ci): make run-ci.sh find a local::lib so the TEST gate passes locally

### DIFF
--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -68,6 +68,21 @@ run_gate() {
 
 cd "$PORT_ROOT"
 
+# Make a local::lib visible to the gates when one is present.
+#
+# In CI the SDK's CPAN deps are installed onto the runner's perl via
+# `cpanm --installdeps .` (see .github/workflows/test.yml), so they're already
+# on @INC and this is a no-op. For LOCAL `bash scripts/run-ci.sh` runs, devs
+# install deps into a local::lib at ~/perl5 (the convention documented in
+# CLAUDE.md); that dir is NOT on the default @INC, so without this the TEST
+# gate fails with "Can't locate Plack/Request.pm" / "Protocol/WebSocket" even
+# though the code is fine. Prepend it when it exists — keyed off $HOME (never a
+# hard-coded path), and guarded so CI/containers without ~/perl5 are unaffected.
+LOCAL_LIB_DIR="${PERL_LOCAL_LIB_ROOT:-$HOME/perl5}/lib/perl5"
+if [ -d "$LOCAL_LIB_DIR" ]; then
+    export PERL5LIB="$LOCAL_LIB_DIR${PERL5LIB:+:$PERL5LIB}"
+fi
+
 echo "==> running CI gates for $PORT_NAME (porting-sdk at $PORTING_SDK_DIR)"
 
 # Gate 1: prove


### PR DESCRIPTION
## Problem
`scripts/run-ci.sh` runs `prove -Ilib -It/lib t/` without exposing the SDK's CPAN dependencies. Locally this fails the **TEST** gate with `Can't locate Plack/Request.pm` / `Protocol/WebSocket/Client.pm` even though the code is correct.

- **CI is unaffected:** GitHub Actions installs deps onto the runner's perl via `cpanm --installdeps .` (`.github/workflows/test.yml`), so they're already on `@INC`.
- **Local dev breaks:** the documented convention (CLAUDE.md) is to install deps into a `local::lib` at `~/perl5`, which is *not* on the default `@INC`. `run-ci.sh` never added it, so `bash scripts/run-ci.sh` couldn't find the deps.

This surfaced during the task #67 mock-session-isolation work: the port code + all other gates were green; only the TEST gate failed, purely on the missing dependency path.

## Fix
Prepend the local::lib's `lib/perl5` to `PERL5LIB` when it exists:
- keyed off `$HOME` (no hard-coded path), overridable via `PERL_LOCAL_LIB_ROOT`
- guarded by `[ -d ... ]` so CI/containers without `~/perl5` are a no-op
- placed before the gates so it applies to TEST (and any other perl-invoking gate)

## Verification
`env -u PERL5LIB bash scripts/run-ci.sh` (clean shell, simulating a fresh dev/CI env):

```
[TEST] prove -Ilib -It/lib t/ ... PASS          # 73 files / 2807 tests
[SIGNATURES] ... PASS
[DRIFT] ... PASS
[SURFACE-FRESH] ... PASS
[NO-CHEAT] ... PASS
[EMISSION] ... PASS
==> CI PASS
```

TEST previously failed on missing deps; now green. No test or source changes — CI-script only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)