### PR TITLE
perl: complete the gate set (FMT, LINT, DOC-AUDIT, SURFACE-DIFF, SKILL-CONTRACT)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,12 @@ jobs:
 
       - name: Install Perl dependencies
         working-directory: signalwire-perl
-        run: cpanm --notest --quiet --installdeps .
+        # --with-develop so the cpanfile's `on 'develop'` block (Perl::Tidy +
+        # Perl::Critic) installs — the FMT + LINT gates in run-ci.sh need the
+        # perltidy/perlcritic binaries on PATH. Without it the gate fails with
+        # `perltidy: command not found`. (doc-audit/surface-audit workflows don't
+        # run those gates, so they keep plain --installdeps.)
+        run: cpanm --notest --quiet --with-develop --installdeps .
 
       - name: Install Python test harnesses (mock_relay + mock_signalwire)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ local/
 # Python audit-script bytecode (scripts/enumerate_*.py invocations)
 __pycache__/
 *.pyc
+
+# Claude Code local session settings (not part of the SDK)
+.claude/

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,0 +1,38 @@
+# .perlcriticrc — canonical lint config for signalwire-perl.
+#
+# perlcritic is the Perl port's LINT gate (the analog of go vet+golangci /
+# clippy / rubocop's lint face in the sibling ports). This is the blocking
+# quality FLOOR: the configured policy set is burned to ZERO and kept there.
+#
+# SEVERITY FLOOR
+# ==============
+# severity = 5 ("gentle" — the most-severe policies only). This port had never
+# been linted; severity 5 is the honest floor we can hold at ZERO by FIXING the
+# code idiomatically rather than suppressing. (Severity 4 "stern" surfaces ~400
+# findings dominated by RequireFinalReturn / ProhibitMultiplePackages /
+# RequireArgUnpacking — policing legitimate Moo/accessor idioms — which cannot be
+# reconciled with the SDK's established style without churn that risks the wire;
+# tightening the floor is a future, separate pass.) The severity-5 burndown was
+# done by FIXING source, not by suppression:
+#   * Subroutines::ProhibitExplicitReturnUndef  — `return undef` -> `return` (24)
+#   * BuiltinFunctions::ProhibitSleepViaSelect   — select(...) -> Time::HiRes::sleep (3)
+#   * TestingAndDebugging::ProhibitNoStrict      — removed via a method call + a
+#                                                  non-stringy require (2)
+#   * BuiltinFunctions::ProhibitStringyEval      — Math safe-eval parser + path
+#                                                  require replace `eval "..."` (1)
+#   * Subroutines::ProhibitReturnSort            — `return sort ...` -> list+return (1)
+#
+# severity is set on the command line by the gate (`perlcritic --severity 5`),
+# but pinned here too so a bare `perlcritic lib/` reproduces the gate locally.
+severity = 5
+
+# Show the policy name + PBP page on each violation so a regression is
+# actionable straight from the gate output.
+verbose = %f:%l:%c %p — %m\n
+
+# NOTE: no policies are disabled and there are NO `## no critic` annotations in
+# lib/. Every severity-5 finding was fixed in source. If a future finding can
+# ONLY be resolved by changing the SWAIG wire bytes / tokens, prefer a
+# site-scoped `## no critic (Policy)` with a one-line rationale over disabling a
+# whole policy here — and never suppress a finding merely because a type-shape or
+# naming idiom is inconvenient (RULES.md: idiom is free, parity is enforced).

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -6,33 +6,72 @@
 #
 # SEVERITY FLOOR
 # ==============
-# severity = 5 ("gentle" — the most-severe policies only). This port had never
-# been linted; severity 5 is the honest floor we can hold at ZERO by FIXING the
-# code idiomatically rather than suppressing. (Severity 4 "stern" surfaces ~400
-# findings dominated by RequireFinalReturn / ProhibitMultiplePackages /
-# RequireArgUnpacking — policing legitimate Moo/accessor idioms — which cannot be
-# reconciled with the SDK's established style without churn that risks the wire;
-# tightening the floor is a future, separate pass.) The severity-5 burndown was
-# done by FIXING source, not by suppression:
-#   * Subroutines::ProhibitExplicitReturnUndef  — `return undef` -> `return` (24)
-#   * BuiltinFunctions::ProhibitSleepViaSelect   — select(...) -> Time::HiRes::sleep (3)
-#   * TestingAndDebugging::ProhibitNoStrict      — removed via a method call + a
-#                                                  non-stringy require (2)
-#   * BuiltinFunctions::ProhibitStringyEval      — Math safe-eval parser + path
-#                                                  require replace `eval "..."` (1)
-#   * Subroutines::ProhibitReturnSort            — `return sort ...` -> list+return (1)
+# severity = 4 ("stern"). The port was first linted at severity 5 ("gentle")
+# and burned to zero by FIXING source; this floor was then ratcheted to 4. The
+# severity-4 burndown was likewise done by FIXING source idiomatically, not by
+# blanket suppression:
+#   * Subroutines::RequireFinalReturn  — explicit `return` at each sub's end
+#     (behaviour-preserving: a value-returning sub gains `return $that`; a
+#     void/side-effecting sub gains a bare `return`). Catches accidental
+#     last-expression leaks.
+#   * Subroutines::RequireArgUnpacking — `@_` unpacked into named vars at the
+#     top instead of indexing `$_[0]` / passing `@_` through opaquely.
+#   * Variables::RequireLocalizedPunctuationVars — `_safe_eq`'s locals renamed
+#     off Perl's `$a`/`$b` sort globals.
+#   * Subroutines::ProhibitExplicitReturnUndef / BuiltinFunctions::ProhibitSleepViaSelect /
+#     TestingAndDebugging::ProhibitNoStrict / BuiltinFunctions::ProhibitStringyEval /
+#     Subroutines::ProhibitReturnSort — the original severity-5 fixes (see git history).
 #
-# severity is set on the command line by the gate (`perlcritic --severity 5`),
+# severity is set on the command line by the gate (`perlcritic --severity 4`),
 # but pinned here too so a bare `perlcritic lib/` reproduces the gate locally.
-severity = 5
+severity = 4
 
 # Show the policy name + PBP page on each violation so a regression is
 # actionable straight from the gate output.
 verbose = %f:%l:%c %p — %m\n
 
-# NOTE: no policies are disabled and there are NO `## no critic` annotations in
-# lib/. Every severity-5 finding was fixed in source. If a future finding can
-# ONLY be resolved by changing the SWAIG wire bytes / tokens, prefer a
-# site-scoped `## no critic (Policy)` with a one-line rationale over disabling a
-# whole policy here — and never suppress a finding merely because a type-shape or
-# naming idiom is inconvenient (RULES.md: idiom is free, parity is enforced).
+# JUSTIFIED POLICY EXEMPTIONS
+# ===========================
+# Per RULES.md, idiom is free and parity (wire + audited surface) is the
+# enforced floor; a lint policy is suppressed ONLY when obeying it would move
+# the wire/surface or fight faithful Python parity — never to hide a real
+# finding and never for a mere type/style/naming preference. Each exemption
+# below carries its one-line rationale, mirroring the justified-exemption
+# pattern the sibling ports use (e.g. ruby's disabled Style/OneClassPerFile).
+
+# Multiple packages per file: the SDK co-locates tightly-coupled classes
+# (REST namespace + its resource classes, Relay event subclasses, the
+# HttpClient + its Error) in one .pm — the audited Layer-B surface
+# (port_surface.json, enumerate_surface.pl) is keyed off these package names,
+# so SPLITTING files to satisfy this policy would MOVE the audited surface.
+# Same call ruby's port makes by disabling Style/OneClassPerFile.
+[-Modules::ProhibitMultiplePackages]
+
+# `use constant` for closed string sets: this port's DOCUMENTED idiom for a
+# knowable closed set (PORT_PHILOSOPHY_PERL.md — "use constant packages whose
+# values ARE the wire strings"). The constants ARE the canonical wire strings
+# (RecordCall/Tap/JoinConference/SkillName/LogLevel/Relay::*State); switching
+# to Readonly is pure style and the philosophy doc records the deliberate
+# choice of `constant` over `Readonly` for these sets.
+[-ValuesAndExpressions::ProhibitConstantPragma]
+
+# Subs named like Perl builtins (get/delete/connect/say/wait/reset/values/
+# warn): these are PUBLIC API method names that mirror the Python reference /
+# wire surface (REST `delete`, Relay `connect`/`wait`, `FunctionResult->say`,
+# logging `warn`). They are part of the audited surface (enumerate_surface.pl
+# even carries the delete-rename table because Perl reserves the `delete`
+# bareword); renaming them to dodge the homonym would MOVE the surface and
+# de-idiomatize the API. Always invoked as methods ($obj->delete), never as
+# the builtin, so there is no actual ambiguity.
+[-Subroutines::ProhibitBuiltinHomonyms]
+
+# NOTE: aside from the three justified, file-wide exemptions above (each tied
+# to wire/surface parity, not style), no policies are disabled. RequireBriefOpen
+# is handled with site-scoped `## no critic` + rationale where a filehandle is
+# deliberately handed off (PSGI psgi.input) and cannot be closed locally.
+# ProhibitNoWarnings likewise uses site-scoped annotations where a targeted
+# `no warnings` is load-bearing. If a future finding can ONLY be resolved by
+# changing the SWAIG wire bytes / tokens, prefer a site-scoped `## no critic
+# (Policy)` with a one-line rationale over disabling a whole policy here — and
+# never suppress a finding merely because a type-shape or naming idiom is
+# inconvenient (RULES.md: idiom is free, parity is enforced).

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -55,6 +55,17 @@ verbose = %f:%l:%c %p — %m\n
 # choice of `constant` over `Readonly` for these sets.
 [-ValuesAndExpressions::ProhibitConstantPragma]
 
+# Brief-open (close a filehandle soon after opening it): the only opens in the
+# policed scope are (a) two in-memory handles deliberately handed off as a
+# Plack `psgi.input` for downstream re-reads — the PSGI env OWNS the handle, so
+# closing it locally would break the contract and there is no "soon" close to
+# write; and (b) a whole-file line-by-line parser in enumerate_surface.pl that
+# necessarily reads across many lines before its (present) close. The policy's
+# line-distance heuristic does not fit either shape — neither is a leaked or
+# mismanaged handle — so obeying it would force non-idiomatic contortions, not
+# fix a real defect.
+[-InputOutput::RequireBriefOpen]
+
 # Subs named like Perl builtins (get/delete/connect/say/wait/reset/values/
 # warn): these are PUBLIC API method names that mirror the Python reference /
 # wire surface (REST `delete`, Relay `connect`/`wait`, `FunctionResult->say`,
@@ -65,13 +76,32 @@ verbose = %f:%l:%c %p — %m\n
 # the builtin, so there is no actual ambiguity.
 [-Subroutines::ProhibitBuiltinHomonyms]
 
-# NOTE: aside from the three justified, file-wide exemptions above (each tied
-# to wire/surface parity, not style), no policies are disabled. RequireBriefOpen
-# is handled with site-scoped `## no critic` + rationale where a filehandle is
-# deliberately handed off (PSGI psgi.input) and cannot be closed locally.
-# ProhibitNoWarnings likewise uses site-scoped annotations where a targeted
-# `no warnings` is load-bearing. If a future finding can ONLY be resolved by
-# changing the SWAIG wire bytes / tokens, prefer a site-scoped `## no critic
+# Targeted `no warnings` whitelist — NOT a disable. The policy still fires on
+# any blanket `no warnings;` (which could hide a real finding); it only permits
+# these two specific, load-bearing categories:
+#   * experimental::signatures — the documented floor-guard placed after
+#     `use feature 'signatures'` on the signatures-using files
+#     (PORT_PHILOSOPHY_PERL.md); without it the experimental sub-signature
+#     feature warns on every load.
+#   * once — silences the single-use warning on $IO::Socket::SSL::SSL_ERROR,
+#     a package global the SSL stack populates at runtime that this code reads
+#     exactly once.
+[TestingAndDebugging::ProhibitNoWarnings]
+allow = experimental::signatures once
+
+# NOTE: every disabled policy above is justified by wire/surface parity or by
+# the policy heuristic genuinely not fitting the code (never by style and never
+# to hide a real finding); the ProhibitNoWarnings whitelist is a narrowing, not
+# a disable. No other policies are disabled. The only `## no critic`
+# annotations in lib/ are three site-scoped RequireArgUnpacking suppressions
+# (RelayClient::receive/unreceive and Contexts::create_simple_context): those
+# subs MUST keep their classic ``my ($self, $contexts) = @_;`` / ``my ($name)
+# = @_;`` first line — the regex signature extractor reads it to emit the
+# audited param name, so unpacking into a slurpy ``@args`` would move the
+# surface (drift gate) — and they re-read @_ for a dual arrayref/bare-list (or
+# free-fn/class-method) calling convention. Each carries a one-line rationale at
+# the site. If a future finding can ONLY be resolved by changing the SWAIG wire
+# bytes / tokens or the audited signature, prefer a site-scoped `## no critic
 # (Policy)` with a one-line rationale over disabling a whole policy here — and
 # never suppress a finding merely because a type-shape or naming idiom is
 # inconvenient (RULES.md: idiom is free, parity is enforced).

--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,0 +1,31 @@
+# .perltidyrc — canonical source-formatting config for signalwire-perl.
+#
+# perltidy is the Perl port's FMT gate (analogous to gofmt / rustfmt /
+# google-java-format in the sibling ports). It is SOURCE-STYLE ONLY: a reformat
+# is proven surface- and emission-neutral (port_surface.json byte-identical and
+# the EMISSION differ still 81/81 after a full reformat — verified in the FMT
+# rollout). It never moves the wire or the audited surface.
+#
+# Settings are mainstream "Perl Best Practices"-flavoured with a 100-column
+# line limit (the SDK's existing code already sits comfortably under it, which
+# keeps the initial reformat churn to whitespace/alignment rather than mass
+# re-wrapping that could obscure review).
+
+--maximum-line-length=100      # -l : a touch wider than PBP's 78; matches the SDK's existing lines
+--indent-columns=4             # -i : 4-space indent (the SDK's established style)
+--continuation-indentation=4   # -ci: continuation lines indent one level
+--no-tabs                      # -nt: spaces only, never hard tabs
+
+# Bracing / blocks
+--cuddled-else                 # -ce: } else { / } elsif { on one line
+
+# Whitespace
+--paren-tightness=1            # -pt=1: moderate tightness inside ( )
+--brace-tightness=1            # -bt=1
+--square-bracket-tightness=1   # -sbt=1
+--block-brace-tightness=0      # -bbt=0: space inside sub/block { ... }
+--trim-qw                      # -tqw: tidy qw( ) contents
+
+# Comments: leave existing indentation of full-line comments alone so the
+# heavily-commented wire/contract notes are not reflowed away from their code.
+--nooutdent-long-comments

--- a/bin/emit-corpus.pl
+++ b/bin/emit-corpus.pl
@@ -54,7 +54,7 @@ use JSON ();
 
 # Make the SDK importable when run from the repo root (bin/.. = repo root; lib/
 # is a sibling of bin/). Mirrors how the other bin/ tools resolve lib/.
-use lib File::Spec->catdir($RealBin, File::Spec->updir, 'lib');
+use lib File::Spec->catdir( $RealBin, File::Spec->updir, 'lib' );
 
 use SignalWire::SWAIG::FunctionResult;
 
@@ -66,34 +66,38 @@ use SignalWire::SWAIG::FunctionResult;
 # from this file to find porting-sdk/scripts/emission_corpus.py (the adjacency
 # convention — porting-sdk cloned beside the port repo).
 sub find_corpus_script {
+
     # 1. Explicit override.
-    if (my $p = $ENV{EMISSION_CORPUS}) {
+    if ( my $p = $ENV{EMISSION_CORPUS} ) {
         return $p if -f $p;
         die "emit-corpus: EMISSION_CORPUS=$p does not exist\n";
     }
+
     # 2. Walk up from this script looking for ../porting-sdk/scripts/...
     my $dir = $RealBin;
-    for (1 .. 8) {
-        my $cand = File::Spec->catfile(
-            $dir, File::Spec->updir, 'porting-sdk', 'scripts', 'emission_corpus.py');
+    for ( 1 .. 8 ) {
+        my $cand = File::Spec->catfile( $dir, File::Spec->updir, 'porting-sdk', 'scripts',
+            'emission_corpus.py' );
         return $cand if -f $cand;
-        my $parent = File::Spec->catdir($dir, File::Spec->updir);
+        my $parent = File::Spec->catdir( $dir, File::Spec->updir );
         last if File::Spec->rel2abs($parent) eq File::Spec->rel2abs($dir);
         $dir = $parent;
     }
+
     # 3. Home-relative fallback (CLAUDE.md §7 adjacency).
     my $home = $ENV{HOME} // '';
     if ($home) {
-        my $cand = File::Spec->catfile(
-            $home, 'src', 'porting-sdk', 'scripts', 'emission_corpus.py');
+        my $cand =
+            File::Spec->catfile( $home, 'src', 'porting-sdk', 'scripts', 'emission_corpus.py' );
         return $cand if -f $cand;
     }
     die "emit-corpus: cannot locate porting-sdk/scripts/emission_corpus.py "
-      . "(clone porting-sdk adjacent to this repo, or set EMISSION_CORPUS).\n";
+        . "(clone porting-sdk adjacent to this repo, or set EMISSION_CORPUS).\n";
 }
 
 sub load_corpus {
     my $script = find_corpus_script();
+
     # Read the corpus JSON the spec prints on stdout.
     my $json = qx{python3 "$script"};
     die "emit-corpus: failed to run python3 on $script (exit $?)\n" if $? != 0;
@@ -126,20 +130,23 @@ sub kw_list ($kwargs) {
 my %DISPATCH;
 
 # ---- pure single-positional verbs (Python positional -> Perl positional) ----
-for my $m (qw(
+for my $m (
+    qw(
     say hold update_global_data remove_global_data set_metadata remove_metadata
     swml_user_event swml_change_step swml_change_context add_dynamic_hints
     set_end_of_speech_timeout set_speech_event_timeout toggle_functions
     update_settings simulate_user_input join_room sip_refer
-)) {
-    $DISPATCH{$m} = sub ($fr, $args, $kwargs) {
+    )
+    )
+{
+    $DISPATCH{$m} = sub ( $fr, $args, $kwargs ) {
         return $fr->$m(@$args);
     };
 }
 
 # ---- zero-arg verbs ---------------------------------------------------------
 for my $m (qw(hangup stop stop_background_file clear_dynamic_hints)) {
-    $DISPATCH{$m} = sub ($fr, $args, $kwargs) {
+    $DISPATCH{$m} = sub ( $fr, $args, $kwargs ) {
         return $fr->$m();
     };
 }
@@ -149,7 +156,7 @@ for my $m (qw(hangup stop stop_background_file clear_dynamic_hints)) {
 # enable_extensive_data($enabled?). The corpus passes the arg positionally when
 # present (e.g. extensive_data.false => [false]); absent => Perl default.
 for my $m (qw(replace_in_history enable_functions_on_timeout enable_extensive_data)) {
-    $DISPATCH{$m} = sub ($fr, $args, $kwargs) {
+    $DISPATCH{$m} = sub ( $fr, $args, $kwargs ) {
         return @$args ? $fr->$m(@$args) : $fr->$m();
     };
 }
@@ -158,64 +165,67 @@ for my $m (qw(replace_in_history enable_functions_on_timeout enable_extensive_da
 # play_background_file(filename, wait=>...), wait_for_user(enabled/timeout/
 # answer_first=>...), record_call(...), stop_record_call(...), tap(uri, ...),
 # stop_tap(...), execute_swml(content, transfer=>...).
-$DISPATCH{play_background_file} = sub ($fr, $args, $kwargs) {
-    return $fr->play_background_file($args->[0], kw_list($kwargs));
+$DISPATCH{play_background_file} = sub ( $fr, $args, $kwargs ) {
+    return $fr->play_background_file( $args->[0], kw_list($kwargs) );
 };
-$DISPATCH{wait_for_user} = sub ($fr, $args, $kwargs) {
-    return $fr->wait_for_user(kw_list($kwargs));
+$DISPATCH{wait_for_user} = sub ( $fr, $args, $kwargs ) {
+    return $fr->wait_for_user( kw_list($kwargs) );
 };
-$DISPATCH{record_call} = sub ($fr, $args, $kwargs) {
-    return $fr->record_call(kw_list($kwargs));
+$DISPATCH{record_call} = sub ( $fr, $args, $kwargs ) {
+    return $fr->record_call( kw_list($kwargs) );
 };
-$DISPATCH{stop_record_call} = sub ($fr, $args, $kwargs) {
-    return $fr->stop_record_call(kw_list($kwargs));
+$DISPATCH{stop_record_call} = sub ( $fr, $args, $kwargs ) {
+    return $fr->stop_record_call( kw_list($kwargs) );
 };
-$DISPATCH{tap} = sub ($fr, $args, $kwargs) {
-    return $fr->tap($args->[0], kw_list($kwargs));
+$DISPATCH{tap} = sub ( $fr, $args, $kwargs ) {
+    return $fr->tap( $args->[0], kw_list($kwargs) );
 };
-$DISPATCH{stop_tap} = sub ($fr, $args, $kwargs) {
-    return $fr->stop_tap(kw_list($kwargs));
+$DISPATCH{stop_tap} = sub ( $fr, $args, $kwargs ) {
+    return $fr->stop_tap( kw_list($kwargs) );
 };
-$DISPATCH{execute_swml} = sub ($fr, $args, $kwargs) {
-    return $fr->execute_swml($args->[0], kw_list($kwargs));
+$DISPATCH{execute_swml} = sub ( $fr, $args, $kwargs ) {
+    return $fr->execute_swml( $args->[0], kw_list($kwargs) );
 };
-$DISPATCH{join_conference} = sub ($fr, $args, $kwargs) {
+$DISPATCH{join_conference} = sub ( $fr, $args, $kwargs ) {
+
     # name is positional; everything else keyword (Perl signature matches).
-    return $fr->join_conference($args->[0], kw_list($kwargs));
+    return $fr->join_conference( $args->[0], kw_list($kwargs) );
 };
 
 # ---- connect: positional dest; final=>... ; Python from_addr -> Perl from ----
-$DISPATCH{connect} = sub ($fr, $args, $kwargs) {
+$DISPATCH{connect} = sub ( $fr, $args, $kwargs ) {
     my %opts = %{ $kwargs // {} };
+
     # Python's kwarg is `from_addr`; the Perl verb names it `from`.
-    if (exists $opts{from_addr}) {
+    if ( exists $opts{from_addr} ) {
         $opts{from} = delete $opts{from_addr};
     }
-    return $fr->connect($args->[0], %opts);
+    return $fr->connect( $args->[0], %opts );
 };
 
 # ---- swml_transfer: (dest, ai_response) positional; final=>... ---------------
-$DISPATCH{swml_transfer} = sub ($fr, $args, $kwargs) {
-    return $fr->swml_transfer($args->[0], $args->[1], kw_list($kwargs));
+$DISPATCH{swml_transfer} = sub ( $fr, $args, $kwargs ) {
+    return $fr->swml_transfer( $args->[0], $args->[1], kw_list($kwargs) );
 };
 
 # ---- switch_context: 4 Python positionals -> Perl %opts named ----------------
 # Python: switch_context(system_prompt, user_prompt, consolidate, full_reset).
-$DISPATCH{switch_context} = sub ($fr, $args, $kwargs) {
+$DISPATCH{switch_context} = sub ( $fr, $args, $kwargs ) {
     my @names = qw(system_prompt user_prompt consolidate full_reset);
     my %opts;
-    for my $i (0 .. $#$args) {
+    for my $i ( 0 .. $#$args ) {
         my $v = $args->[$i];
-        next unless defined $v;          # Python None -> omit (Perl default)
+        next unless defined $v;    # Python None -> omit (Perl default)
         $opts{ $names[$i] } = $v;
     }
+
     # Any keyword overrides (none in the corpus today, but be faithful).
-    %opts = (%opts, %{ $kwargs // {} });
+    %opts = ( %opts, %{ $kwargs // {} } );
     return $fr->switch_context(%opts);
 };
 
 # ---- send_sms: Python (to_number, from_number) positional -> Perl named ------
-$DISPATCH{send_sms} = sub ($fr, $args, $kwargs) {
+$DISPATCH{send_sms} = sub ( $fr, $args, $kwargs ) {
     return $fr->send_sms(
         to_number   => $args->[0],
         from_number => $args->[1],
@@ -224,7 +234,7 @@ $DISPATCH{send_sms} = sub ($fr, $args, $kwargs) {
 };
 
 # ---- pay: Python payment_connector_url positional -> Perl named --------------
-$DISPATCH{pay} = sub ($fr, $args, $kwargs) {
+$DISPATCH{pay} = sub ( $fr, $args, $kwargs ) {
     return $fr->pay(
         payment_connector_url => $args->[0],
         kw_list($kwargs),
@@ -232,7 +242,7 @@ $DISPATCH{pay} = sub ($fr, $args, $kwargs) {
 };
 
 # ---- execute_rpc: Python method positional -> Perl named --------------------
-$DISPATCH{execute_rpc} = sub ($fr, $args, $kwargs) {
+$DISPATCH{execute_rpc} = sub ( $fr, $args, $kwargs ) {
     return $fr->execute_rpc(
         method => $args->[0],
         kw_list($kwargs),
@@ -240,7 +250,7 @@ $DISPATCH{execute_rpc} = sub ($fr, $args, $kwargs) {
 };
 
 # ---- rpc_dial: Python (to_number, from_number, dest_swml) positional ---------
-$DISPATCH{rpc_dial} = sub ($fr, $args, $kwargs) {
+$DISPATCH{rpc_dial} = sub ( $fr, $args, $kwargs ) {
     return $fr->rpc_dial(
         to_number   => $args->[0],
         from_number => $args->[1],
@@ -250,7 +260,7 @@ $DISPATCH{rpc_dial} = sub ($fr, $args, $kwargs) {
 };
 
 # ---- rpc_ai_message: Python (call_id, message_text) positional ---------------
-$DISPATCH{rpc_ai_message} = sub ($fr, $args, $kwargs) {
+$DISPATCH{rpc_ai_message} = sub ( $fr, $args, $kwargs ) {
     return $fr->rpc_ai_message(
         call_id      => $args->[0],
         message_text => $args->[1],
@@ -259,36 +269,37 @@ $DISPATCH{rpc_ai_message} = sub ($fr, $args, $kwargs) {
 };
 
 # ---- rpc_ai_unhold: Python (call_id) positional ------------------------------
-$DISPATCH{rpc_ai_unhold} = sub ($fr, $args, $kwargs) {
-    return $fr->rpc_ai_unhold(call_id => $args->[0], kw_list($kwargs));
+$DISPATCH{rpc_ai_unhold} = sub ( $fr, $args, $kwargs ) {
+    return $fr->rpc_ai_unhold( call_id => $args->[0], kw_list($kwargs) );
 };
 
 # --------------------------------------------------------------------------- #
 # Build the emission for one corpus entry: construct FunctionResult with the
 # entry's ctor args, apply the method (+ any chain), return its to_hash.
 # --------------------------------------------------------------------------- #
-sub apply_one ($fr, $spec) {
+sub apply_one ( $fr, $spec ) {
     my $method = $spec->{method};
-    return $fr unless defined $method;   # envelope-only entry: ctor did the work
+    return $fr unless defined $method;    # envelope-only entry: ctor did the work
     my $code = $DISPATCH{$method}
         or die "emit-corpus: no dispatch for corpus method '$method' "
-             . "(corpus id may reference a verb this port lacks)\n";
-    return $code->($fr, $spec->{args} // [], $spec->{kwargs} // {});
+        . "(corpus id may reference a verb this port lacks)\n";
+    return $code->( $fr, $spec->{args} // [], $spec->{kwargs} // {} );
 }
 
 sub build_emission ($entry) {
     my $ctor = $entry->{ctor} // {};
     my %args;
+
     # ctor: { response => "...", post_process => true }. JSON true/false decode
     # to JSON::PP::Boolean; set_post_process / the post_process attr read them
     # in boolean context.
     $args{response} = $ctor->{response} if exists $ctor->{response};
     my $fr = SignalWire::SWAIG::FunctionResult->new(%args);
-    $fr->set_post_process($ctor->{post_process} ? 1 : 0) if exists $ctor->{post_process};
+    $fr->set_post_process( $ctor->{post_process} ? 1 : 0 ) if exists $ctor->{post_process};
 
-    $fr = apply_one($fr, $entry);
-    for my $chained (@{ $entry->{chain} // [] }) {
-        $fr = apply_one($fr, $chained);
+    $fr = apply_one( $fr, $entry );
+    for my $chained ( @{ $entry->{chain} // [] } ) {
+        $fr = apply_one( $fr, $chained );
     }
     return $fr->to_hash;
 }
@@ -309,7 +320,7 @@ sub main {
 
     # Canonical so the bytes are stable; the empty hashref {} renders as the
     # JSON object {} (NOT []), which is the contract for clear_dynamic_hints.
-    print JSON->new->canonical->encode(\%out), "\n";
+    print JSON->new->canonical->encode( \%out ), "\n";
     return 0;
 }
 

--- a/bin/emit-skills.pl
+++ b/bin/emit-skills.pl
@@ -1,0 +1,194 @@
+#!/usr/bin/env perl
+# Copyright (c) 2025 SignalWire
+# Licensed under the MIT License.
+#
+# emit-skills.pl — the Perl port's SKILL-DUMP program for the cross-port
+# SKILL-CONTRACT differ (porting-sdk/scripts/diff_skill_contracts.py).
+#
+# The sibling of bin/emit-corpus.pl, for built-in SKILLS rather than
+# FunctionResult. The drift/surface gates see signatures + symbol names and
+# EMISSION sees FunctionResult->to_hash; NONE sees a skill's SWAIG tool contract
+# — the {name, parameters, required, enum} each skill registers. This program
+# builds that contract for every covered skill so the differ can compare it
+# against the Python reference.
+#
+# HOW IT WORKS
+#   1. Read the shared corpus (porting-sdk/scripts/skill_contract_corpus.py —
+#      the single source of truth) as JSON: { corpus: [ {id, skill, config} ] }.
+#   2. For each entry: look up the skill class via SkillRegistry->get_factory,
+#      construct it with a tiny CAPTURING fake agent + the corpus config as
+#      params, run setup(), then register_tools(). SkillBase REQUIRES a blessed
+#      `agent` (a weak_ref isa-checked to be an object), so the fake agent is a
+#      real blessed object. It records BOTH registration paths a skill can use:
+#        * handler tools  — $self->define_tool(...)  -> agent->define_tool(%opts)
+#        * DataMap tools  — $self->agent->register_swaig_function({...})
+#   3. Print ONE JSON object { id -> [ {name, parameters, required?} ] } to
+#      stdout. Logs/diagnostics go to stderr. The id set equals corpus_ids() by
+#      construction (the differ rejects a mismatch as a setup error).
+#
+# THE CONTRACT (what the differ compares — DESCRIPTIONS are NOT compared)
+#   Each tool reduces to {name, parameters:{p:{type,enum?}}, required:[...]}.
+#   Both registration shapes carry the WRAPPED parameter schema
+#   ({type:'object', properties:{...}, required:[...]}); the differ reads the
+#   `required` from inside that wrapper, so we forward each tool's parameters
+#   verbatim and let the differ normalise.
+#
+# Run from the signalwire-perl repo root:
+#
+#     perl bin/emit-skills.pl
+#
+# (the differ invokes exactly this; see --dump-cmd in run-ci.sh.)
+
+use strict;
+use warnings;
+use feature 'signatures';
+no warnings 'experimental::signatures';
+
+use FindBin qw($RealBin);
+use File::Spec;
+use JSON ();
+
+# Make the SDK importable when run from the repo root (bin/.. = repo root;
+# lib/ is a sibling of bin/). Mirrors bin/emit-corpus.pl.
+use lib File::Spec->catdir( $RealBin, File::Spec->updir, 'lib' );
+
+use SignalWire::Skills::SkillRegistry;
+
+# --------------------------------------------------------------------------- #
+# Capturing fake agent.
+# --------------------------------------------------------------------------- #
+# SkillBase isa-checks `agent` to be a blessed object (a weak_ref to the owning
+# AgentBase). We don't need a real agent to enumerate tool SCHEMAS — only an
+# object that records what the skill registers. A skill reaches the agent two
+# ways:
+#   * via SkillBase->define_tool, which calls $self->agent->define_tool(%opts)
+#   * directly via $self->agent->register_swaig_function($swaig_hashref)
+# Both land here and are captured as {name, parameters, required?}.
+{
+
+    package SignalWire::Skills::_CapturingAgent;
+    use strict;
+    use warnings;
+
+    sub new ($class) { return bless { captured => [] }, $class }
+
+    sub captured ($self) { return $self->{captured} }
+
+    # Handler tool: define_tool(name => ..., parameters => {wrapped}, required => [...]?, ...)
+    sub define_tool ( $self, %opts ) {
+        my $tool = { name => $opts{name}, parameters => $opts{parameters} // {} };
+
+        # A handler tool may carry `required` either inside the wrapped
+        # parameters schema OR as a sibling key; forward the sibling form so
+        # the differ can fold it in.
+        $tool->{required} = $opts{required} if defined $opts{required};
+        push @{ $self->{captured} }, $tool;
+        return $self;
+    }
+
+    # DataMap / raw SWAIG tool: register_swaig_function({ function => ...,
+    # parameters => {wrapped, required:[...]}, data_map => {...}, ... }).
+    sub register_swaig_function ( $self, $fn ) {
+        return $self unless ref $fn eq 'HASH';
+        push @{ $self->{captured} },
+            {
+            name       => $fn->{function},
+            parameters => $fn->{parameters} // {},
+            };
+        return $self;
+    }
+
+    # Tolerate any other agent method a skill may poke during setup/register
+    # (add_hint, set_global_data, prompt_add_section, ...): swallow silently.
+    our $AUTOLOAD;
+
+    sub AUTOLOAD ( $self, @ ) {
+        my $name = $AUTOLOAD;
+        $name =~ s/.*:://;
+        return if $name eq 'DESTROY';
+        return $self;
+    }
+}
+
+# --------------------------------------------------------------------------- #
+# Locate + load the shared skill corpus.
+# --------------------------------------------------------------------------- #
+# Walk upward from this file to find porting-sdk/scripts/skill_contract_corpus.py
+# (the adjacency convention), honoring $PORTING_SDK / $PORTING_SDK_PATH first.
+sub find_corpus_script {
+    for my $base ( grep {defined} $ENV{PORTING_SDK}, $ENV{PORTING_SDK_PATH} ) {
+        my $cand = File::Spec->catfile( $base, 'scripts', 'skill_contract_corpus.py' );
+        return $cand if -f $cand;
+    }
+    my $dir = $RealBin;
+    for ( 1 .. 8 ) {
+        my $cand = File::Spec->catfile( $dir, File::Spec->updir, 'porting-sdk',
+            'scripts', 'skill_contract_corpus.py' );
+        return $cand if -f $cand;
+        my $parent = File::Spec->catdir( $dir, File::Spec->updir );
+        last if File::Spec->rel2abs($parent) eq File::Spec->rel2abs($dir);
+        $dir = $parent;
+    }
+    my $home = $ENV{HOME} // '';
+    if ($home) {
+        my $cand = File::Spec->catfile( $home, 'src', 'porting-sdk', 'scripts',
+            'skill_contract_corpus.py' );
+        return $cand if -f $cand;
+    }
+    die "emit-skills: cannot locate porting-sdk/scripts/skill_contract_corpus.py "
+        . "(clone porting-sdk adjacent to this repo, or set PORTING_SDK).\n";
+}
+
+sub load_corpus {
+    my $script = find_corpus_script();
+    my $json   = qx{python3 "$script"};
+    die "emit-skills: failed to run python3 on $script (exit $?)\n" if $? != 0;
+    die "emit-skills: empty corpus from $script\n" unless length $json;
+    my $data = JSON->new->decode($json);
+    return $data->{corpus} // die "emit-skills: corpus key missing in $script output\n";
+}
+
+# --------------------------------------------------------------------------- #
+# Build the contract list for one corpus entry.
+# --------------------------------------------------------------------------- #
+sub contracts_for ($entry) {
+    my $skill_name = $entry->{skill};
+    my $config     = $entry->{config} // {};
+
+    my $class = SignalWire::Skills::SkillRegistry->get_factory($skill_name);
+    die "emit-skills: no registered factory for covered skill '$skill_name'\n"
+        unless defined $class;
+
+    my $agent = SignalWire::Skills::_CapturingAgent->new;
+
+    # Construct with the fake agent + the corpus config as params. Pass a copy
+    # of the config so a skill that mutates params (SkillBase BUILD deletes
+    # swaig_fields) can't corrupt the shared corpus structure.
+    my $skill = $class->new( agent => $agent, params => { %{$config} } );
+
+    unless ( $skill->setup ) {
+        die "emit-skills: skill '$skill_name' setup() returned false with the "
+            . "corpus config — config drift between the corpus and the port.\n";
+    }
+    $skill->register_tools;
+
+    return [ @{ $agent->captured } ];
+}
+
+# --------------------------------------------------------------------------- #
+# main: emit one JSON object { id => [ contract, ... ] }.
+# --------------------------------------------------------------------------- #
+sub main {
+    my $corpus = load_corpus();
+
+    my %out;
+    for my $entry (@$corpus) {
+        my $id = $entry->{id};
+        $out{$id} = contracts_for($entry);
+    }
+
+    print JSON->new->canonical->encode( \%out ), "\n";
+    return 0;
+}
+
+exit main();

--- a/bin/emit-skills.pl
+++ b/bin/emit-skills.pl
@@ -116,7 +116,7 @@ use SignalWire::Skills::SkillRegistry;
 # Walk upward from this file to find porting-sdk/scripts/skill_contract_corpus.py
 # (the adjacency convention), honoring $PORTING_SDK / $PORTING_SDK_PATH first.
 sub find_corpus_script {
-    for my $base ( grep {defined} $ENV{PORTING_SDK}, $ENV{PORTING_SDK_PATH} ) {
+    for my $base ( grep { defined } $ENV{PORTING_SDK}, $ENV{PORTING_SDK_PATH} ) {
         my $cand = File::Spec->catfile( $base, 'scripts', 'skill_contract_corpus.py' );
         return $cand if -f $cand;
     }

--- a/bin/swaig-test
+++ b/bin/swaig-test
@@ -27,35 +27,35 @@ use Scalar::Util qw(blessed);
 my $VERSION = '1.0.0';
 
 # --- Parse CLI options ---
-my ($url, $file, $dump_swml, $list_tools, $exec_name, @params, $raw, $verbose, $help);
+my ( $url, $file, $dump_swml, $list_tools, $exec_name, @params, $raw, $verbose, $help );
 
 GetOptions(
-    'url=s'       => \$url,
-    'file=s'      => \$file,
-    'dump-swml'   => \$dump_swml,
-    'list-tools'  => \$list_tools,
-    'exec=s'      => \$exec_name,
-    'param=s@'    => \@params,
-    'raw'         => \$raw,
-    'verbose'     => \$verbose,
-    'help|h'      => \$help,
+    'url=s'      => \$url,
+    'file=s'     => \$file,
+    'dump-swml'  => \$dump_swml,
+    'list-tools' => \$list_tools,
+    'exec=s'     => \$exec_name,
+    'param=s@'   => \@params,
+    'raw'        => \$raw,
+    'verbose'    => \$verbose,
+    'help|h'     => \$help,
 ) or usage_exit();
 
 if ($help) {
     usage_exit(0);
 }
 
-unless ($url || $file) {
+unless ( $url || $file ) {
     print STDERR "Error: --url or --file is required\n\n";
     usage_exit(1);
 }
 
-if ($url && $file) {
+if ( $url && $file ) {
     print STDERR "Error: --url and --file are mutually exclusive\n\n";
     usage_exit(1);
 }
 
-unless ($dump_swml || $list_tools || $exec_name) {
+unless ( $dump_swml || $list_tools || $exec_name ) {
     print STDERR "Error: one of --dump-swml, --list-tools, or --exec NAME is required\n\n";
     usage_exit(1);
 }
@@ -67,9 +67,9 @@ if ($file) {
 }
 
 # --- URL mode: HTTP path ---
-my $uri = URI->new($url);
+my $uri      = URI->new($url);
 my $userinfo = $uri->userinfo // '';
-my ($auth_user, $auth_pass) = split(/:/, $userinfo, 2);
+my ( $auth_user, $auth_pass ) = split( /:/, $userinfo, 2 );
 
 # Build base URL without credentials
 my $clean_uri = $uri->clone;
@@ -79,17 +79,15 @@ my $base_url = $clean_uri->as_string;
 # Remove trailing slash
 $base_url =~ s{/$}{};
 
-my $http = HTTP::Tiny->new(timeout => 30);
+my $http = HTTP::Tiny->new( timeout => 30 );
 
 # --- Execute the requested operation ---
 
 if ($dump_swml) {
     do_dump_swml();
-}
-elsif ($list_tools) {
+} elsif ($list_tools) {
     do_list_tools();
-}
-elsif ($exec_name) {
+} elsif ($exec_name) {
     do_exec($exec_name);
 }
 
@@ -105,7 +103,7 @@ sub do_dump_swml {
         print $response->{content};
         print "\n" unless $response->{content} =~ /\n$/;
     } else {
-        my $data = eval { JSON::decode_json($response->{content}) };
+        my $data = eval { JSON::decode_json( $response->{content} ) };
         if ($@) {
             die "Error: Failed to parse JSON response: $@\n";
         }
@@ -115,7 +113,7 @@ sub do_dump_swml {
 
 sub do_list_tools {
     my $response = http_get($base_url);
-    my $data = eval { JSON::decode_json($response->{content}) };
+    my $data     = eval { JSON::decode_json( $response->{content} ) };
     if ($@) {
         die "Error: Failed to parse JSON response: $@\n";
     }
@@ -124,15 +122,15 @@ sub do_list_tools {
     my @functions;
 
     # Navigate the SWML structure to find AI verb functions
-    if (my $sections = $data->{sections}) {
-        for my $section_name (keys %$sections) {
+    if ( my $sections = $data->{sections} ) {
+        for my $section_name ( keys %$sections ) {
             my $verbs = $sections->{$section_name};
             next unless ref $verbs eq 'ARRAY';
             for my $verb (@$verbs) {
-                if (ref $verb eq 'HASH' && exists $verb->{ai}) {
+                if ( ref $verb eq 'HASH' && exists $verb->{ai} ) {
                     my $ai = $verb->{ai};
-                    if (my $swaig = $ai->{SWAIG}) {
-                        if (my $funcs = $swaig->{functions}) {
+                    if ( my $swaig = $ai->{SWAIG} ) {
+                        if ( my $funcs = $swaig->{functions} ) {
                             push @functions, @$funcs;
                         }
                     }
@@ -141,12 +139,12 @@ sub do_list_tools {
         }
     }
 
-    if (!@functions) {
+    if ( !@functions ) {
         print "No SWAIG functions found.\n";
         return;
     }
 
-    print_tool_list(\@functions);
+    print_tool_list( \@functions );
 }
 
 sub do_exec {
@@ -155,7 +153,7 @@ sub do_exec {
     # Parse --param key=value pairs
     my %args;
     for my $p (@params) {
-        if ($p =~ /^([^=]+)=(.*)$/) {
+        if ( $p =~ /^([^=]+)=(.*)$/ ) {
             $args{$1} = $2;
         } else {
             die "Error: Invalid --param format '$p'. Use key=value\n";
@@ -165,8 +163,8 @@ sub do_exec {
     my $swaig_url = $base_url . '/swaig';
 
     my $payload = {
-        function  => $func_name,
-        argument  => {
+        function => $func_name,
+        argument => {
             parsed => [ \%args ],
         },
     };
@@ -178,7 +176,7 @@ sub do_exec {
         print STDERR ">>> Body: $json_body\n";
     }
 
-    my $response = http_post($swaig_url, $json_body);
+    my $response = http_post( $swaig_url, $json_body );
 
     if ($verbose) {
         print STDERR "<<< Status: $response->{status}\n";
@@ -189,7 +187,7 @@ sub do_exec {
         print $response->{content};
         print "\n" unless $response->{content} =~ /\n$/;
     } else {
-        my $data = eval { JSON::decode_json($response->{content}) };
+        my $data = eval { JSON::decode_json( $response->{content} ) };
         if ($@) {
             print $response->{content};
             print "\n" unless $response->{content} =~ /\n$/;
@@ -204,7 +202,7 @@ sub do_exec {
 # ============================================================
 
 sub do_file_mode {
-    unless (-f $file) {
+    unless ( -f $file ) {
         die "Error: --file '$file' does not exist or is not a regular file\n";
     }
 
@@ -218,28 +216,26 @@ sub do_file_mode {
     # Run the file. The example scripts guard their server-start with
     # `unless caller`, so loading via `do` does NOT spin a server.
     my $rv = do $abs;
-    if (my $e = $@) {
+    if ( my $e = $@ ) {
         die "Error: failed to compile '$file': $e\n";
     }
-    if (!defined $rv && $!) {
+    if ( !defined $rv && $! ) {
         die "Error: failed to read '$file': $!\n";
     }
 
     my $svc = _resolve_service_instance($rv);
     unless ($svc) {
         die "Error: could not locate a SignalWire::SWML::Service instance in '$file'.\n"
-          . "Hint: define a build_service() sub that returns an instance, return one as\n"
-          . "the file's last value, or declare a package that ISA SignalWire::SWML::Service.\n";
+            . "Hint: define a build_service() sub that returns an instance, return one as\n"
+            . "the file's last value, or declare a package that ISA SignalWire::SWML::Service.\n";
     }
 
     if ($dump_swml) {
         do_file_dump_swml($svc);
-    }
-    elsif ($list_tools) {
+    } elsif ($list_tools) {
         do_file_list_tools($svc);
-    }
-    elsif ($exec_name) {
-        do_file_exec($svc, $exec_name);
+    } elsif ($exec_name) {
+        do_file_exec( $svc, $exec_name );
     }
 }
 
@@ -252,19 +248,19 @@ sub do_file_mode {
 sub _resolve_service_instance {
     my ($do_rv) = @_;
 
-    if (blessed($do_rv) && $do_rv->isa('SignalWire::SWML::Service')) {
+    if ( blessed($do_rv) && $do_rv->isa('SignalWire::SWML::Service') ) {
         if ($verbose) {
             print STDERR ">>> using service instance returned by file (" . ref($do_rv) . ")\n";
         }
         return $do_rv;
     }
 
-    if (my $builder = main->can('build_service')) {
+    if ( my $builder = main->can('build_service') ) {
         if ($verbose) {
             print STDERR ">>> calling main::build_service\n";
         }
         my $svc = $builder->();
-        if (blessed($svc) && $svc->isa('SignalWire::SWML::Service')) {
+        if ( blessed($svc) && $svc->isa('SignalWire::SWML::Service') ) {
             return $svc;
         }
     }
@@ -276,7 +272,7 @@ sub _resolve_service_instance {
             print STDERR ">>> attempting parameterless construction of $pkg\n";
         }
         my $svc = eval { $pkg->new };
-        if (!$@ && blessed($svc) && $svc->isa('SignalWire::SWML::Service')) {
+        if ( !$@ && blessed($svc) && $svc->isa('SignalWire::SWML::Service') ) {
             return $svc;
         }
     }
@@ -291,8 +287,8 @@ sub _find_service_subclasses {
     # Recursive walk of %:: → all loaded packages.
     my $walk;
     $walk = sub {
-        my ($stash, $prefix) = @_;
-        for my $entry (keys %$stash) {
+        my ( $stash, $prefix ) = @_;
+        for my $entry ( keys %$stash ) {
             next unless $entry =~ /::$/;
             my $name = $entry;
             $name =~ s/::$//;
@@ -302,27 +298,28 @@ sub _find_service_subclasses {
 
             # Only treat as a class if it has any symbols at all.
             no strict 'refs';
-            my $sub_stash = \%{ "${pkg}::" };
+            my $sub_stash = \%{"${pkg}::"};
             use strict 'refs';
 
-            if (eval { $pkg->isa('SignalWire::SWML::Service') }
+            if (   eval { $pkg->isa('SignalWire::SWML::Service') }
                 && $pkg ne 'SignalWire::SWML::Service'
-                && $pkg ne 'SignalWire::Agent::AgentBase')
+                && $pkg ne 'SignalWire::Agent::AgentBase' )
             {
                 push @found, $pkg;
             }
-            $walk->($sub_stash, $pkg);
+            $walk->( $sub_stash, $pkg );
         }
     };
-    $walk->(\%::, '');
+    $walk->( \%::, '' );
     return @found;
 }
 
 sub do_file_dump_swml {
     my ($svc) = @_;
+
     # Render the SWML document the same way the PSGI handler does. We
     # pass a minimal env hash so dynamic renderers don't blow up.
-    my $doc = $svc->render_main_swml({});
+    my $doc = $svc->render_main_swml( {} );
     if ($raw) {
         print JSON::encode_json($doc), "\n";
     } else {
@@ -331,25 +328,25 @@ sub do_file_dump_swml {
 }
 
 sub do_file_list_tools {
-    my ($svc) = @_;
-    my @names = $svc->list_tool_names;
+    my ($svc)    = @_;
+    my @names    = $svc->list_tool_names;
     my $registry = $svc->tools // {};
 
-    if (!@names) {
+    if ( !@names ) {
         print "No SWAIG functions found.\n";
         return;
     }
 
     my @functions = map { $registry->{$_} } @names;
-    print_tool_list(\@functions);
+    print_tool_list( \@functions );
 }
 
 sub do_file_exec {
-    my ($svc, $func_name) = @_;
+    my ( $svc, $func_name ) = @_;
 
     my %args;
     for my $p (@params) {
-        if ($p =~ /^([^=]+)=(.*)$/) {
+        if ( $p =~ /^([^=]+)=(.*)$/ ) {
             $args{$1} = $2;
         } else {
             die "Error: Invalid --param format '$p'. Use key=value\n";
@@ -361,15 +358,15 @@ sub do_file_exec {
         argument => { parsed => [ \%args ] },
     };
 
-    my $result = $svc->on_function_call($func_name, \%args, $payload);
-    unless (defined $result) {
+    my $result = $svc->on_function_call( $func_name, \%args, $payload );
+    unless ( defined $result ) {
         die "Error: function '$func_name' is not registered or returned undef.\n";
     }
 
     my $hash;
-    if (ref $result eq 'HASH') {
+    if ( ref $result eq 'HASH' ) {
         $hash = $result;
-    } elsif (blessed($result) && $result->can('to_hash')) {
+    } elsif ( blessed($result) && $result->can('to_hash') ) {
         $hash = $result->to_hash;
     } else {
         $hash = { response => "$result" };
@@ -395,18 +392,18 @@ sub print_tool_list {
     } else {
         printf "Found %d SWAIG function(s):\n\n", scalar @$functions;
         for my $f (@$functions) {
-            my $name = $f->{function} // 'unnamed';
+            my $name = $f->{function}    // 'unnamed';
             my $desc = $f->{description} // '(no description)';
             printf "  %-30s %s\n", $name, $desc;
 
             # Show parameters if any
-            if (my $params_schema = $f->{parameters}) {
-                if (my $props = $params_schema->{properties}) {
-                    my $required = $params_schema->{required} // [];
+            if ( my $params_schema = $f->{parameters} ) {
+                if ( my $props = $params_schema->{properties} ) {
+                    my $required     = $params_schema->{required} // [];
                     my %required_map = map { $_ => 1 } @$required;
-                    for my $pname (sort keys %$props) {
-                        my $ptype = $props->{$pname}{type} // 'any';
-                        my $pdesc = $props->{$pname}{description} // '';
+                    for my $pname ( sort keys %$props ) {
+                        my $ptype      = $props->{$pname}{type}        // 'any';
+                        my $pdesc      = $props->{$pname}{description} // '';
                         my $req_marker = $required_map{$pname} ? '*' : ' ';
                         printf "    %s %-20s %-10s %s\n", $req_marker, $pname, "($ptype)", $pdesc;
                     }
@@ -423,8 +420,8 @@ sub print_tool_list {
 
 sub _auth_headers {
     my %headers;
-    if (defined $auth_user && defined $auth_pass) {
-        my $encoded = encode_base64("$auth_user:$auth_pass", '');
+    if ( defined $auth_user && defined $auth_pass ) {
+        my $encoded = encode_base64( "$auth_user:$auth_pass", '' );
         $headers{Authorization} = "Basic $encoded";
     }
     return %headers;
@@ -438,33 +435,36 @@ sub http_get {
         print STDERR ">>> GET $target_url\n";
     }
 
-    my $response = $http->get($target_url, { headers => \%headers });
+    my $response = $http->get( $target_url, { headers => \%headers } );
 
     if ($verbose) {
         print STDERR "<<< Status: $response->{status}\n";
     }
 
-    unless ($response->{success}) {
-        die sprintf("Error: HTTP %s %s\n%s\n",
-            $response->{status}, $response->{reason}, $response->{content} // '');
+    unless ( $response->{success} ) {
+        die sprintf( "Error: HTTP %s %s\n%s\n",
+            $response->{status}, $response->{reason}, $response->{content} // '' );
     }
 
     return $response;
 }
 
 sub http_post {
-    my ($target_url, $body) = @_;
+    my ( $target_url, $body ) = @_;
     my %headers = _auth_headers();
     $headers{'Content-Type'} = 'application/json';
 
-    my $response = $http->post($target_url, {
-        headers => \%headers,
-        content => $body,
-    });
+    my $response = $http->post(
+        $target_url,
+        {
+            headers => \%headers,
+            content => $body,
+        }
+    );
 
-    unless ($response->{success}) {
-        die sprintf("Error: HTTP %s %s\n%s\n",
-            $response->{status}, $response->{reason}, $response->{content} // '');
+    unless ( $response->{success} ) {
+        die sprintf( "Error: HTTP %s %s\n%s\n",
+            $response->{status}, $response->{reason}, $response->{content} // '' );
     }
 
     return $response;

--- a/bin/swaig-test
+++ b/bin/swaig-test
@@ -109,6 +109,7 @@ sub do_dump_swml {
         }
         print JSON->new->utf8->pretty->canonical->encode($data);
     }
+    return;
 }
 
 sub do_list_tools {
@@ -145,6 +146,7 @@ sub do_list_tools {
     }
 
     print_tool_list( \@functions );
+    return;
 }
 
 sub do_exec {
@@ -195,6 +197,7 @@ sub do_exec {
             print JSON->new->utf8->pretty->canonical->encode($data);
         }
     }
+    return;
 }
 
 # ============================================================
@@ -237,6 +240,7 @@ sub do_file_mode {
     } elsif ($exec_name) {
         do_file_exec( $svc, $exec_name );
     }
+    return;
 }
 
 # Resolve a Service instance from the loaded script. Strategy, in order:
@@ -327,6 +331,7 @@ sub do_file_dump_swml {
     } else {
         print JSON->new->utf8->pretty->canonical->encode($doc);
     }
+    return;
 }
 
 sub do_file_list_tools {
@@ -341,6 +346,7 @@ sub do_file_list_tools {
 
     my @functions = map { $registry->{$_} } @names;
     print_tool_list( \@functions );
+    return;
 }
 
 sub do_file_exec {
@@ -379,6 +385,7 @@ sub do_file_exec {
     } else {
         print JSON->new->utf8->pretty->canonical->encode($hash);
     }
+    return;
 }
 
 # ============================================================
@@ -414,6 +421,7 @@ sub print_tool_list {
             print "\n";
         }
     }
+    return;
 }
 
 # ============================================================

--- a/bin/swaig-test
+++ b/bin/swaig-test
@@ -277,7 +277,7 @@ sub _resolve_service_instance {
         }
     }
 
-    return undef;
+    return;
 }
 
 sub _find_service_subclasses {
@@ -296,10 +296,12 @@ sub _find_service_subclasses {
             my $pkg = $prefix ? "${prefix}::${name}" : $name;
             next if $seen{$pkg}++;
 
-            # Only treat as a class if it has any symbols at all.
-            no strict 'refs';
-            my $sub_stash = \%{"${pkg}::"};
-            use strict 'refs';
+            # Only treat as a class if it has any symbols at all. Reach the
+            # child namespace's symbol table through the parent stash glob
+            # (*glob{HASH}) rather than a symbolic ref by name, so no `no strict
+            # 'refs'` is needed (matches the lint-clean idiom used in lib/).
+            my $sub_stash = *{ $stash->{$entry} }{HASH};
+            next unless $sub_stash;
 
             if (   eval { $pkg->isa('SignalWire::SWML::Service') }
                 && $pkg ne 'SignalWire::SWML::Service'

--- a/cpanfile
+++ b/cpanfile
@@ -31,4 +31,5 @@ on 'test' => sub {
 # (CI installs them so the FMT gate's `perltidy` resolves).
 on 'develop' => sub {
     requires 'Perl::Tidy';
+    requires 'Perl::Critic';
 };

--- a/cpanfile
+++ b/cpanfile
@@ -23,3 +23,12 @@ on 'test' => sub {
     requires 'Plack::Test';
     requires 'HTTP::Request::Common';
 };
+
+# Developer tooling for the CI quality gates (scripts/run-ci.sh):
+#   * Perl::Tidy  — the FMT gate's formatter (.perltidyrc).
+# These are author/develop-phase deps, not needed to RUN the SDK. Install with
+#   cpanm --installdeps --with-develop .
+# (CI installs them so the FMT gate's `perltidy` resolves).
+on 'develop' => sub {
+    requires 'Perl::Tidy';
+};

--- a/lib/SignalWire.pm
+++ b/lib/SignalWire.pm
@@ -57,8 +57,9 @@ sub RestClient {
     require SignalWire::REST::RestClient;
 
     # Three bare strings -> positional (project, token, host); anything
-    # else is a hash-style keyword args list passed via @_.
-    my @raw = @_;
+    # else is a hash-style keyword args list. @args slurped all of @_
+    # (Perl's slurpy-array semantics), so it is the full argument list.
+    my @raw = @args;
     if ( @raw == 3 && !ref( $raw[0] ) && $raw[0] !~ /^(?:project|token|host)$/ ) {
         return SignalWire::REST::RestClient->new(
             project => $raw[0],

--- a/lib/SignalWire.pm
+++ b/lib/SignalWire.pm
@@ -47,17 +47,19 @@ sub _singleton_registry {
 # the array; keyword-style callers pass an even number of args (no
 # leading positional) so @args becomes the kwargs pairlist instead.
 sub RestClient {
+
     # Audit-shape declaration: declare both slurpy positional and slurpy
     # hash so the surface enumerator sees the canonical ``*args, **kwargs``
     # shape Python uses. We don't actually rely on %kwargs at runtime —
     # Perl's slurpy-array semantics consume everything into @args, so
     # %kwargs always ends up empty. Real argument splitting happens below.
-    my (@args, %kwargs) = @_;
+    my ( @args, %kwargs ) = @_;
     require SignalWire::REST::RestClient;
+
     # Three bare strings -> positional (project, token, host); anything
     # else is a hash-style keyword args list passed via @_.
     my @raw = @_;
-    if (@raw == 3 && !ref($raw[0]) && $raw[0] !~ /^(?:project|token|host)$/) {
+    if ( @raw == 3 && !ref( $raw[0] ) && $raw[0] !~ /^(?:project|token|host)$/ ) {
         return SignalWire::REST::RestClient->new(
             project => $raw[0],
             token   => $raw[1],
@@ -76,15 +78,15 @@ sub register_skill {
     my ($skill_class) = @_;
     require SignalWire::Skills::SkillRegistry;
     my $name;
-    if ($skill_class->can('skill_name')) {
+    if ( $skill_class->can('skill_name') ) {
         $name = $skill_class->skill_name;
-    } elsif (defined &{"${skill_class}::SKILL_NAME"}) {
+    } elsif ( defined &{"${skill_class}::SKILL_NAME"} ) {
         no strict 'refs';
         $name = ${"${skill_class}::SKILL_NAME"};
     } else {
         die "skill class $skill_class must define ::skill_name or SKILL_NAME\n";
     }
-    SignalWire::Skills::SkillRegistry->register_skill($name, $skill_class);
+    SignalWire::Skills::SkillRegistry->register_skill( $name, $skill_class );
     return;
 }
 
@@ -107,9 +109,10 @@ sub add_skill_directory {
 # programmatic skill discovery.
 sub list_skills_with_params {
     require SignalWire::Skills::SkillRegistry;
-    if (SignalWire::Skills::SkillRegistry->can('get_all_skills_schema')) {
+    if ( SignalWire::Skills::SkillRegistry->can('get_all_skills_schema') ) {
         return SignalWire::Skills::SkillRegistry->get_all_skills_schema;
     }
+
     # Fallback: list_skills returns names; pair them with empty params.
     my $names = SignalWire::Skills::SkillRegistry->list_skills;
     return { map { $_ => { name => $_, parameters => {} } } @$names };

--- a/lib/SignalWire.pm
+++ b/lib/SignalWire.pm
@@ -80,9 +80,11 @@ sub register_skill {
     my $name;
     if ( $skill_class->can('skill_name') ) {
         $name = $skill_class->skill_name;
-    } elsif ( defined &{"${skill_class}::SKILL_NAME"} ) {
-        no strict 'refs';
-        $name = ${"${skill_class}::SKILL_NAME"};
+    } elsif ( $skill_class->can('SKILL_NAME') ) {
+
+        # SKILL_NAME is exposed as a constant sub; call it as a method so we
+        # never need a symbolic ref (which would force `no strict 'refs'`).
+        $name = $skill_class->SKILL_NAME;
     } else {
         die "skill class $skill_class must define ::skill_name or SKILL_NAME\n";
     }

--- a/lib/SignalWire/Agent/AgentBase.pm
+++ b/lib/SignalWire/Agent/AgentBase.pm
@@ -1,4 +1,5 @@
 package SignalWire::Agent::AgentBase;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 
@@ -7,68 +8,68 @@ use warnings;
 use Moo;
 use SignalWire::SWML::Service;
 extends 'SignalWire::SWML::Service';
-use JSON qw(encode_json decode_json);
+use JSON         qw(encode_json decode_json);
 use MIME::Base64 qw(encode_base64 decode_base64);
-use Digest::SHA qw(hmac_sha256_hex);
-use POSIX qw(strftime);
+use Digest::SHA  qw(hmac_sha256_hex);
+use POSIX        qw(strftime);
 use Scalar::Util qw(blessed reftype);
-use Storable qw(dclone);
-use Carp qw(croak carp);
+use Storable     qw(dclone);
+use Carp         qw(croak carp);
 
 # ---------- attributes ----------
 
 # name, route, host, port, basic_auth_user, basic_auth_password, document,
 # tools, tool_order, routing_callbacks are inherited from Service.
 # Override AgentBase's defaults where they diverge from Service's:
-has '+name' => (default => sub { 'agent' });
-has '+port' => (default => sub { $ENV{PORT} || 3000 });
+has '+name' => ( default => sub { 'agent' } );
+has '+port' => ( default => sub { $ENV{PORT} || 3000 } );
 has '+basic_auth_user' => (
-    lazy => 1,
+    lazy    => 1,
     builder => '_build_basic_auth_user',
 );
 has '+basic_auth_password' => (
-    lazy => 1,
+    lazy    => 1,
     builder => '_build_basic_auth_password',
 );
 
 # Call settings
-has auto_answer   => (is => 'rw', default => sub { 1 });
-has record_call   => (is => 'rw', default => sub { 0 });
-has record_format => (is => 'rw', default => sub { 'mp4' });
-has record_stereo => (is => 'rw', default => sub { 1 });
+has auto_answer   => ( is => 'rw', default => sub { 1 } );
+has record_call   => ( is => 'rw', default => sub { 0 } );
+has record_format => ( is => 'rw', default => sub { 'mp4' } );
+has record_stereo => ( is => 'rw', default => sub { 1 } );
 
 # Prompt system
-has prompt_text         => (is => 'rw', default => sub { '' });
-has post_prompt         => (is => 'rw', default => sub { '' });
-has use_pom             => (is => 'rw', default => sub { 1 });
-has pom_sections        => (is => 'rw', default => sub { [] });
+has prompt_text  => ( is => 'rw', default => sub { '' } );
+has post_prompt  => ( is => 'rw', default => sub { '' } );
+has use_pom      => ( is => 'rw', default => sub { 1 } );
+has pom_sections => ( is => 'rw', default => sub { [] } );
 
 # Tool registry — `tools` and `tool_order` are now declared on Service
 # (lifted so non-agent SWML services can host SWAIG functions). Inherited.
 
 # AI config
-has hints              => (is => 'rw', default => sub { [] });
-has pattern_hints      => (is => 'rw', default => sub { [] });
-has languages          => (is => 'rw', default => sub { [] });
-has pronunciations     => (is => 'rw', default => sub { [] });
-has params             => (is => 'rw', default => sub { {} });
-has global_data        => (is => 'rw', default => sub { {} });
-has native_functions   => (is => 'rw', default => sub { [] });
+has hints            => ( is => 'rw', default => sub { [] } );
+has pattern_hints    => ( is => 'rw', default => sub { [] } );
+has languages        => ( is => 'rw', default => sub { [] } );
+has pronunciations   => ( is => 'rw', default => sub { [] } );
+has params           => ( is => 'rw', default => sub { {} } );
+has global_data      => ( is => 'rw', default => sub { {} } );
+has native_functions => ( is => 'rw', default => sub { [] } );
 
 # Internal settings
-has internal_fillers     => (is => 'rw', default => sub { undef });
-has debug_events_level   => (is => 'rw', default => sub { 0 });
+has internal_fillers   => ( is => 'rw', default => sub { undef } );
+has debug_events_level => ( is => 'rw', default => sub { 0 } );
 
 # Includes and LLM params
-has function_includes       => (is => 'rw', default => sub { [] });
-has prompt_llm_params       => (is => 'rw', default => sub { {} });
-has post_prompt_llm_params  => (is => 'rw', default => sub { {} });
+has function_includes      => ( is => 'rw', default => sub { [] } );
+has prompt_llm_params      => ( is => 'rw', default => sub { {} } );
+has post_prompt_llm_params => ( is => 'rw', default => sub { {} } );
 
 # Verb insertion points
-has pre_answer_verbs   => (is => 'rw', default => sub { [] });
-has post_answer_verbs  => (is => 'rw', default => sub { [] });
-has post_ai_verbs      => (is => 'rw', default => sub { [] });
-has answer_config      => (is => 'rw', default => sub { {} });
+has pre_answer_verbs  => ( is => 'rw', default => sub { [] } );
+has post_answer_verbs => ( is => 'rw', default => sub { [] } );
+has post_ai_verbs     => ( is => 'rw', default => sub { [] } );
+has answer_config     => ( is => 'rw', default => sub { {} } );
 
 # Context system (lazy)
 has context_builder => (
@@ -78,18 +79,18 @@ has context_builder => (
 );
 
 # Callbacks
-has dynamic_config_callback => (is => 'rw', default => sub { undef });
-has summary_callback        => (is => 'rw', default => sub { undef });
-has debug_event_handler     => (is => 'rw', default => sub { undef });
+has dynamic_config_callback => ( is => 'rw', default => sub { undef } );
+has summary_callback        => ( is => 'rw', default => sub { undef } );
+has debug_event_handler     => ( is => 'rw', default => sub { undef } );
 
 # URLs
-has webhook_url       => (is => 'rw', default => sub { undef });
-has post_prompt_url   => (is => 'rw', default => sub { undef });
-has proxy_url_base    => (is => 'rw', lazy => 1, builder => '_build_proxy_url_base');
-has swaig_query_params => (is => 'rw', default => sub { {} });
+has webhook_url        => ( is => 'rw', default => sub { undef } );
+has post_prompt_url    => ( is => 'rw', default => sub { undef } );
+has proxy_url_base     => ( is => 'rw', lazy    => 1, builder => '_build_proxy_url_base' );
+has swaig_query_params => ( is => 'rw', default => sub { {} } );
 
 # Session manager (built in BUILD)
-has session_manager => (is => 'rw');
+has session_manager => ( is => 'rw' );
 
 # Webhook signature validation. When set (or SIGNALWIRE_SIGNING_KEY env
 # is non-empty), the PSGI app auto-mounts SignalWire::Security::WebhookMiddleware
@@ -108,11 +109,11 @@ sub _build_signing_key {
 }
 
 # Skill manager
-has skill_manager => (is => 'rw', lazy => 1, builder => '_build_skill_manager');
+has skill_manager => ( is => 'rw', lazy => 1, builder => '_build_skill_manager' );
 
 # MCP integration
-has mcp_servers        => (is => 'rw', default => sub { [] });
-has mcp_server_enabled => (is => 'rw', default => sub { 0 });
+has mcp_servers        => ( is => 'rw', default => sub { [] } );
+has mcp_server_enabled => ( is => 'rw', default => sub { 0 } );
 
 # ---------- builders ----------
 
@@ -126,12 +127,13 @@ sub _build_basic_auth_password {
     return $ENV{SWML_BASIC_AUTH_PASSWORD} if $ENV{SWML_BASIC_AUTH_PASSWORD};
 
     my $password = _generate_random_password();
+
     # Warn loudly so external callers (tests, RPC clients, MCP) know why
     # they are getting HTTP 401. This is the silent cause of every
     # external caller failing when .env wasn't loaded — the password
     # lives only in this process and changes on every restart.
     carp "basic_auth_password_autogenerated: username=\""
-        . ($self->basic_auth_user || $self->name) . "\". "
+        . ( $self->basic_auth_user || $self->name ) . "\". "
         . "No SWML_BASIC_AUTH_PASSWORD found in environment and no "
         . "basic_auth_password passed to the agent constructor. The SDK "
         . "generated a random password that exists only in this process; "
@@ -155,7 +157,7 @@ sub _build_context_builder {
 sub _build_skill_manager {
     my ($self) = @_;
     require SignalWire::Skills::SkillManager;
-    return SignalWire::Skills::SkillManager->new(agent => $self);
+    return SignalWire::Skills::SkillManager->new( agent => $self );
 }
 
 sub BUILD {
@@ -169,26 +171,25 @@ sub BUILD {
     # Initialize session manager
     require SignalWire::Security::SessionManager;
     $self->session_manager(
-        SignalWire::Security::SessionManager->new(token_expiry_secs => 3600)
-    );
+        SignalWire::Security::SessionManager->new( token_expiry_secs => 3600 ) );
 }
 
 # ---------- Prompt methods ----------
 
 sub set_prompt_text {
-    my ($self, $text) = @_;
+    my ( $self, $text ) = @_;
     $self->prompt_text($text);
     return $self;
 }
 
 sub set_post_prompt {
-    my ($self, $text) = @_;
+    my ( $self, $text ) = @_;
     $self->post_prompt($text);
     return $self;
 }
 
 sub prompt_add_section {
-    my ($self, $title, $body, %opts) = @_;
+    my ( $self, $title, $body, %opts ) = @_;
     my $section = {
         title => $title,
         body  => $body // '',
@@ -199,9 +200,9 @@ sub prompt_add_section {
 }
 
 sub prompt_add_subsection {
-    my ($self, $parent_title, $title, $body, %opts) = @_;
-    for my $sec (@{ $self->pom_sections }) {
-        if ($sec->{title} eq $parent_title) {
+    my ( $self, $parent_title, $title, $body, %opts ) = @_;
+    for my $sec ( @{ $self->pom_sections } ) {
+        if ( $sec->{title} eq $parent_title ) {
             $sec->{subsections} //= [];
             my $sub = { title => $title, body => $body // '' };
             $sub->{bullets} = $opts{bullets} if $opts{bullets};
@@ -213,13 +214,13 @@ sub prompt_add_subsection {
 }
 
 sub prompt_add_to_section {
-    my ($self, $title, %opts) = @_;
-    for my $sec (@{ $self->pom_sections }) {
-        if ($sec->{title} eq $title) {
-            if ($opts{body}) {
+    my ( $self, $title, %opts ) = @_;
+    for my $sec ( @{ $self->pom_sections } ) {
+        if ( $sec->{title} eq $title ) {
+            if ( $opts{body} ) {
                 $sec->{body} .= "\n" . $opts{body};
             }
-            if ($opts{bullets}) {
+            if ( $opts{bullets} ) {
                 $sec->{bullets} //= [];
                 push @{ $sec->{bullets} }, @{ $opts{bullets} };
             }
@@ -230,8 +231,8 @@ sub prompt_add_to_section {
 }
 
 sub prompt_has_section {
-    my ($self, $title) = @_;
-    for my $sec (@{ $self->pom_sections }) {
+    my ( $self, $title ) = @_;
+    for my $sec ( @{ $self->pom_sections } ) {
         return 1 if $sec->{title} eq $title;
     }
     return 0;
@@ -239,7 +240,7 @@ sub prompt_has_section {
 
 sub get_prompt {
     my ($self) = @_;
-    if ($self->use_pom && @{ $self->pom_sections }) {
+    if ( $self->use_pom && @{ $self->pom_sections } ) {
         return $self->pom_sections;
     }
     return $self->prompt_text;
@@ -259,7 +260,8 @@ sub pom {
     return undef unless $self->use_pom;
     require Storable;
     require SignalWire::POM::PromptObjectModel;
-    my $cloned = Storable::dclone($self->pom_sections);
+    my $cloned = Storable::dclone( $self->pom_sections );
+
     # Empty pom_sections still returns a PromptObjectModel (Python
     # parity: ``self.pom = PromptObjectModel()`` even when no sections
     # have been added).
@@ -296,10 +298,10 @@ sub get_raw_prompt {
 # Mirrors Python's PromptManager.set_prompt_pom — accepts a list of
 # section dicts and stores them in pom_sections.
 sub set_prompt_pom {
-    my ($self, $pom) = @_;
+    my ( $self, $pom ) = @_;
     $self->use_pom(1);
     $pom //= [];
-    $self->pom_sections([ @$pom ]);
+    $self->pom_sections( [@$pom] );
     return $self;
 }
 
@@ -376,10 +378,10 @@ sub get_contexts {
 # delegates to SessionManager->create_tool_token and returns "" on any
 # raised error (Python catches all exceptions and returns "").
 sub create_tool_token {
-    my ($self, $tool_name, $call_id) = @_;
+    my ( $self, $tool_name, $call_id ) = @_;
     my $token = '';
     eval {
-        $token = $self->session_manager->create_tool_token($tool_name, $call_id);
+        $token = $self->session_manager->create_tool_token( $tool_name, $call_id );
         1;
     } or do {
         return '';
@@ -394,7 +396,7 @@ sub create_tool_token {
 # Python parity: state_mixin.StateMixin.validate_tool_token —
 # rejects unknown function names up-front and swallows errors.
 sub validate_tool_token {
-    my ($self, $function_name, $token, $call_id) = @_;
+    my ( $self, $function_name, $token, $call_id ) = @_;
     return 0 unless $self->has_function($function_name);
     my $result = 0;
     eval {
@@ -402,7 +404,7 @@ sub validate_tool_token {
         # (call_id, function_name, token), not the Python order. The
         # AgentBase facade keeps the Python order so callers can write
         # the same code across languages.
-        $result = $self->session_manager->validate_token($call_id, $function_name, $token);
+        $result = $self->session_manager->validate_token( $call_id, $function_name, $token );
         1;
     } or do {
         return 0;
@@ -413,21 +415,23 @@ sub validate_tool_token {
 # ---------- AI Config methods ----------
 
 sub add_hint {
-    my ($self, $hint) = @_;
+    my ( $self, $hint ) = @_;
     push @{ $self->hints }, $hint;
     return $self;
 }
 
 sub add_hints {
-    my ($self, $hints) = @_;
+    my ( $self, $hints ) = @_;
+
     # Python parity: add_hints(hints: List[str]). Accept an arrayref
     # as the canonical form. Backward-compat: also accept slurpy
     # (``add_hints('a', 'b', 'c')``) when the first arg is a string.
-    if (ref $hints eq 'ARRAY') {
+    if ( ref $hints eq 'ARRAY' ) {
         for my $h (@$hints) {
             push @{ $self->hints }, $h if defined $h && !ref($h) && length $h;
         }
     } else {
+
         # Slurpy form — re-grab @_ skipping $self.
         my @rest = @_;
         shift @rest;
@@ -439,21 +443,22 @@ sub add_hints {
 }
 
 sub add_pattern_hint {
-    my ($self, $pattern) = @_;
+    my ( $self, $pattern ) = @_;
     push @{ $self->pattern_hints }, $pattern;
     return $self;
 }
 
 sub add_language {
-    my ($self, %lang) = @_;
+    my ( $self, %lang ) = @_;
+
     # Per-language params (engine-specific tuning, voice settings, etc.).
     # Python parity (commit 029ca6f): only emit the ``params`` key when
     # the supplied hashref is non-empty so SWML stays byte-identical for
     # existing callers who don't pass params. Treat an explicit empty
     # hashref the same as "not passed".
-    if (exists $lang{params}) {
+    if ( exists $lang{params} ) {
         my $p = $lang{params};
-        if (!defined $p || ref($p) ne 'HASH' || !%$p) {
+        if ( !defined $p || ref($p) ne 'HASH' || !%$p ) {
             delete $lang{params};
         }
     }
@@ -462,7 +467,7 @@ sub add_language {
 }
 
 sub set_languages {
-    my ($self, $langs) = @_;
+    my ( $self, $langs ) = @_;
     $self->languages($langs);
     return $self;
 }
@@ -472,10 +477,10 @@ sub set_languages {
 # removes the key; unknown ``code`` is a no-op; always returns $self
 # for chaining.
 sub set_language_params {
-    my ($self, $code, $params) = @_;
-    for my $language (@{ $self->languages }) {
+    my ( $self, $code, $params ) = @_;
+    for my $language ( @{ $self->languages } ) {
         next unless defined $language->{code} && $language->{code} eq $code;
-        if (defined $params && ref($params) eq 'HASH' && %$params) {
+        if ( defined $params && ref($params) eq 'HASH' && %$params ) {
             $language->{params} = $params;
         } else {
             delete $language->{params};
@@ -489,8 +494,8 @@ sub set_language_params {
 # language. Returns undef when the code is unknown or when params were
 # never set — no exception path (matches Python's ``return None``).
 sub get_language_params {
-    my ($self, $code) = @_;
-    for my $language (@{ $self->languages }) {
+    my ( $self, $code ) = @_;
+    for my $language ( @{ $self->languages } ) {
         next unless defined $language->{code} && $language->{code} eq $code;
         return $language->{params};
     }
@@ -498,43 +503,43 @@ sub get_language_params {
 }
 
 sub add_pronunciation {
-    my ($self, %pron) = @_;
+    my ( $self, %pron ) = @_;
     push @{ $self->pronunciations }, \%pron;
     return $self;
 }
 
 sub set_pronunciations {
-    my ($self, $prons) = @_;
+    my ( $self, $prons ) = @_;
     $self->pronunciations($prons);
     return $self;
 }
 
 sub set_param {
-    my ($self, $key, $value) = @_;
+    my ( $self, $key, $value ) = @_;
     $self->params->{$key} = $value;
     return $self;
 }
 
 sub set_params {
-    my ($self, $p) = @_;
-    $self->params({ %{ $self->params }, %$p });
+    my ( $self, $p ) = @_;
+    $self->params( { %{ $self->params }, %$p } );
     return $self;
 }
 
 sub set_global_data {
-    my ($self, $data) = @_;
+    my ( $self, $data ) = @_;
     $self->global_data($data);
     return $self;
 }
 
 sub update_global_data {
-    my ($self, $data) = @_;
-    $self->global_data({ %{ $self->global_data }, %$data });
+    my ( $self, $data ) = @_;
+    $self->global_data( { %{ $self->global_data }, %$data } );
     return $self;
 }
 
 sub set_native_functions {
-    my ($self, $funcs) = @_;
+    my ( $self, $funcs ) = @_;
     $self->native_functions($funcs);
     return $self;
 }
@@ -549,15 +554,15 @@ sub set_native_functions {
 # SWAIG function names are NOT supported.
 #
 our %SUPPORTED_INTERNAL_FILLER_NAMES = (
-    hangup                   => 1,  # AI is hanging up the call
-    check_time               => 1,  # AI is checking the time
-    wait_for_user            => 1,  # AI is waiting for user input
-    wait_seconds             => 1,  # deliberate pause / wait period
-    adjust_response_latency  => 1,  # AI is adjusting response timing
-    next_step                => 1,  # transitioning between steps in prompt.contexts
-    change_context           => 1,  # switching between contexts in prompt.contexts
-    get_visual_input         => 1,  # processing visual input (enable_vision)
-    get_ideal_strategy       => 1,  # thinking (enable_thinking)
+    hangup                  => 1,    # AI is hanging up the call
+    check_time              => 1,    # AI is checking the time
+    wait_for_user           => 1,    # AI is waiting for user input
+    wait_seconds            => 1,    # deliberate pause / wait period
+    adjust_response_latency => 1,    # AI is adjusting response timing
+    next_step               => 1,    # transitioning between steps in prompt.contexts
+    change_context          => 1,    # switching between contexts in prompt.contexts
+    get_visual_input        => 1,    # processing visual input (enable_vision)
+    get_ideal_strategy      => 1,    # thinking (enable_thinking)
 );
 
 #
@@ -582,18 +587,18 @@ our %SUPPORTED_INTERNAL_FILLER_NAMES = (
 #   { function_name => { language_code => [ phrase1, phrase2, ... ] } }
 #
 sub set_internal_fillers {
-    my ($self, $fillers) = @_;
-    if (ref $fillers eq 'HASH') {
+    my ( $self, $fillers ) = @_;
+    if ( ref $fillers eq 'HASH' ) {
         my @unknown = sort grep { !exists $SUPPORTED_INTERNAL_FILLER_NAMES{$_} }
-                           keys %$fillers;
+            keys %$fillers;
         if (@unknown) {
             my @supported = sort keys %SUPPORTED_INTERNAL_FILLER_NAMES;
             carp "unknown_internal_filler_names: ["
-                . join(', ', map { "'$_'" } @unknown)
+                . join( ', ', map { "'$_'" } @unknown )
                 . "]. set_internal_fillers received names that the SWML "
                 . "schema does not recognize. Those entries will be "
                 . "ignored by the runtime. Supported names: ["
-                . join(', ', map { "'$_'" } @supported) . "].";
+                . join( ', ', map { "'$_'" } @supported ) . "].";
         }
     }
     $self->internal_fillers($fillers);
@@ -614,14 +619,14 @@ sub set_internal_fillers {
 #   $agent->add_internal_filler($function_name, $lang_code, \@phrases)
 #
 sub add_internal_filler {
-    my ($self, @args) = @_;
+    my ( $self, @args ) = @_;
 
     # Legacy forms: single scalar or single hashref — preserve existing
     # behavior (push onto the flat arrayref).
-    if (@args == 1) {
+    if ( @args == 1 ) {
         my $filler = $args[0];
-        if (!defined $self->internal_fillers) {
-            $self->internal_fillers([]);
+        if ( !defined $self->internal_fillers ) {
+            $self->internal_fillers( [] );
         }
         my $store = $self->internal_fillers;
         push @$store, $filler if ref $store eq 'ARRAY';
@@ -629,18 +634,20 @@ sub add_internal_filler {
     }
 
     # New form: (function_name, language_code, fillers_arrayref)
-    my ($function_name, $language_code, $fillers) = @args;
-    if (!exists $SUPPORTED_INTERNAL_FILLER_NAMES{$function_name}) {
+    my ( $function_name, $language_code, $fillers ) = @args;
+    if ( !exists $SUPPORTED_INTERNAL_FILLER_NAMES{$function_name} ) {
         my @supported = sort keys %SUPPORTED_INTERNAL_FILLER_NAMES;
         carp "unknown_internal_filler_name: '$function_name'. "
             . "add_internal_filler received a function name the SWML "
             . "schema does not recognize. The entry will be stored but "
             . "the runtime will not play these fillers. Supported "
-            . "names: [" . join(', ', map { "'$_'" } @supported) . "].";
+            . "names: ["
+            . join( ', ', map { "'$_'" } @supported ) . "].";
     }
+
     # Initialise as a hashref if empty or legacy list.
     my $store = $self->internal_fillers;
-    if (!defined $store || ref $store ne 'HASH') {
+    if ( !defined $store || ref $store ne 'HASH' ) {
         $store = {};
         $self->internal_fillers($store);
     }
@@ -650,76 +657,76 @@ sub add_internal_filler {
 }
 
 sub enable_debug_events {
-    my ($self, $level) = @_;
+    my ( $self, $level ) = @_;
     $level //= 1;
     $self->debug_events_level($level);
     return $self;
 }
 
 sub add_function_include {
-    my ($self, $include) = @_;
+    my ( $self, $include ) = @_;
     push @{ $self->function_includes }, $include;
     return $self;
 }
 
 sub set_function_includes {
-    my ($self, $includes) = @_;
+    my ( $self, $includes ) = @_;
     $self->function_includes($includes);
     return $self;
 }
 
 sub set_prompt_llm_params {
-    my ($self, %p) = @_;
-    $self->prompt_llm_params({ %{ $self->prompt_llm_params }, %p });
+    my ( $self, %p ) = @_;
+    $self->prompt_llm_params( { %{ $self->prompt_llm_params }, %p } );
     return $self;
 }
 
 sub set_post_prompt_llm_params {
-    my ($self, %p) = @_;
-    $self->post_prompt_llm_params({ %{ $self->post_prompt_llm_params }, %p });
+    my ( $self, %p ) = @_;
+    $self->post_prompt_llm_params( { %{ $self->post_prompt_llm_params }, %p } );
     return $self;
 }
 
 # ---------- Verb management ----------
 
 sub add_pre_answer_verb {
-    my ($self, $verb_name, $verb_config) = @_;
+    my ( $self, $verb_name, $verb_config ) = @_;
     push @{ $self->pre_answer_verbs }, { $verb_name => $verb_config };
     return $self;
 }
 
 sub add_post_answer_verb {
-    my ($self, $verb_name, $verb_config) = @_;
+    my ( $self, $verb_name, $verb_config ) = @_;
     push @{ $self->post_answer_verbs }, { $verb_name => $verb_config };
     return $self;
 }
 
 sub add_post_ai_verb {
-    my ($self, $verb_name, $verb_config) = @_;
+    my ( $self, $verb_name, $verb_config ) = @_;
     push @{ $self->post_ai_verbs }, { $verb_name => $verb_config };
     return $self;
 }
 
 sub clear_pre_answer_verbs {
     my ($self) = @_;
-    $self->pre_answer_verbs([]);
+    $self->pre_answer_verbs( [] );
     return $self;
 }
 
 sub clear_post_answer_verbs {
     my ($self) = @_;
-    $self->post_answer_verbs([]);
+    $self->post_answer_verbs( [] );
     return $self;
 }
 
 sub clear_post_ai_verbs {
     my ($self) = @_;
-    $self->post_ai_verbs([]);
+    $self->post_ai_verbs( [] );
     return $self;
 }
 
 sub set_answer_config {
-    my ($self, $config) = @_;
+    my ( $self, $config ) = @_;
     $self->answer_config($config);
     return $self;
 }
@@ -733,40 +740,45 @@ sub set_answer_config {
 # gather_submit). See SignalWire::Contexts::ContextBuilder.
 #
 sub define_contexts {
-    my ($self, $contexts) = @_;
+    my ( $self, $contexts ) = @_;
+
     # Python parity: PromptMixin.define_contexts(contexts=None).
     #   - When called with no arg (legacy / Perl idiom), returns the
     #     ContextBuilder for fluent chaining (``$agent->define_contexts->add_context(...)``).
     #   - When called with a hashref or ContextBuilder, applies that
     #     configuration via context_builder and returns $self for chaining.
-    if (defined $contexts) {
-        if (ref $contexts eq 'HASH') {
+    if ( defined $contexts ) {
+        if ( ref $contexts eq 'HASH' ) {
+
             # Apply each top-level context name -> config pair.
             my $cb = $self->context_builder;
             $cb->attach_agent($self) if $cb->can('attach_agent');
-            for my $name (keys %$contexts) {
+            for my $name ( keys %$contexts ) {
                 my $cfg = $contexts->{$name};
                 my $ctx = $cb->add_context($name);
+
                 # Best-effort: if config is a hashref, apply known keys.
-                if (ref $cfg eq 'HASH') {
-                    if (defined $cfg->{steps} && ref $cfg->{steps} eq 'HASH') {
-                        for my $sname (keys %{ $cfg->{steps} }) {
-                            $ctx->add_step($sname, %{ $cfg->{steps}{$sname} });
+                if ( ref $cfg eq 'HASH' ) {
+                    if ( defined $cfg->{steps} && ref $cfg->{steps} eq 'HASH' ) {
+                        for my $sname ( keys %{ $cfg->{steps} } ) {
+                            $ctx->add_step( $sname, %{ $cfg->{steps}{$sname} } );
                         }
                     }
                 }
             }
             return $self;
         }
+
         # ContextBuilder-like object: assume $contexts->to_hash is the
         # canonical projection; replace this agent's builder with it.
-        if (ref $contexts && $contexts->can('to_hash')) {
+        if ( ref $contexts && $contexts->can('to_hash') ) {
             $self->{_external_context_builder} = $contexts;
             $contexts->attach_agent($self) if $contexts->can('attach_agent');
             return $self;
         }
         die "define_contexts: contexts must be a hashref or a ContextBuilder";
     }
+
     # No-arg form: return the (memoized) ContextBuilder.
     my $cb = $self->context_builder;
     $cb->attach_agent($self) if $cb->can('attach_agent');
@@ -781,7 +793,7 @@ sub define_contexts {
 #
 sub reset_contexts {
     my ($self) = @_;
-    if ($self->context_builder->can('reset')) {
+    if ( $self->context_builder->can('reset') ) {
         $self->context_builder->reset;
     }
     return $self;
@@ -805,13 +817,13 @@ sub contexts {
 # ---------- Skills ----------
 
 sub add_skill {
-    my ($self, $skill_name, $params) = @_;
+    my ( $self, $skill_name, $params ) = @_;
     $params //= {};
-    return $self->skill_manager->load_skill($skill_name, undef, $params);
+    return $self->skill_manager->load_skill( $skill_name, undef, $params );
 }
 
 sub remove_skill {
-    my ($self, $skill_name) = @_;
+    my ( $self, $skill_name ) = @_;
     return $self->skill_manager->unload_skill($skill_name);
 }
 
@@ -821,50 +833,51 @@ sub list_skills {
 }
 
 sub has_skill {
-    my ($self, $skill_name) = @_;
+    my ( $self, $skill_name ) = @_;
     return $self->skill_manager->has_skill($skill_name);
 }
 
 # ---------- Web / callback setters ----------
 
 sub set_dynamic_config_callback {
-    my ($self, $cb) = @_;
+    my ( $self, $cb ) = @_;
     $self->dynamic_config_callback($cb);
     return $self;
 }
 
 sub set_web_hook_url {
-    my ($self, $url) = @_;
+    my ( $self, $url ) = @_;
     $self->webhook_url($url);
     return $self;
 }
 
 sub set_post_prompt_url {
-    my ($self, $url) = @_;
+    my ( $self, $url ) = @_;
     $self->post_prompt_url($url);
     return $self;
 }
 
 sub manual_set_proxy_url {
-    my ($self, $url) = @_;
+    my ( $self, $url ) = @_;
     $self->proxy_url_base($url);
     return $self;
 }
 
 sub add_swaig_query_params {
-    my ($self, %params) = @_;
-    $self->swaig_query_params({ %{ $self->swaig_query_params }, %params });
+    my ( $self, %params ) = @_;
+    $self->swaig_query_params( { %{ $self->swaig_query_params }, %params } );
     return $self;
 }
 
 sub clear_swaig_query_params {
     my ($self) = @_;
-    $self->swaig_query_params({});
+    $self->swaig_query_params( {} );
     return $self;
 }
 
 sub on_summary {
-    my ($self, $summary, $raw_data) = @_;
+    my ( $self, $summary, $raw_data ) = @_;
+
     # Python parity: AgentBase.on_summary(summary, raw_data=None).
     #
     # Two invocation forms:
@@ -877,19 +890,19 @@ sub on_summary {
     #      Anything else is treated as the summary payload itself
     #      and dispatches to the registered callback. Default
     #      implementation is a no-op (matches Python's pass).
-    if (ref $summary eq 'CODE') {
+    if ( ref $summary eq 'CODE' ) {
         $self->summary_callback($summary);
         return $self;
     }
     my $cb = $self->summary_callback;
     if ($cb) {
-        return $cb->($summary, $raw_data);
+        return $cb->( $summary, $raw_data );
     }
     return undef;
 }
 
 sub on_debug_event {
-    my ($self, $cb) = @_;
+    my ( $self, $cb ) = @_;
     $self->debug_event_handler($cb);
     return $self;
 }
@@ -897,11 +910,11 @@ sub on_debug_event {
 # ---------- MCP integration ----------
 
 sub add_mcp_server {
-    my ($self, $url, %opts) = @_;
+    my ( $self, $url, %opts ) = @_;
     my $server = { url => $url };
     $server->{headers}       = $opts{headers}       if $opts{headers};
-    $server->{resources}     = JSON::true            if $opts{resources};
-    $server->{resource_vars} = $opts{resource_vars}  if $opts{resource_vars};
+    $server->{resources}     = JSON::true           if $opts{resources};
+    $server->{resource_vars} = $opts{resource_vars} if $opts{resource_vars};
     push @{ $self->mcp_servers }, $server;
     return $self;
 }
@@ -915,16 +928,16 @@ sub enable_mcp_server {
 sub _build_mcp_tool_list {
     my ($self) = @_;
     my @tools;
-    for my $fname (@{ $self->tool_order }) {
+    for my $fname ( @{ $self->tool_order } ) {
         my $tool = $self->tools->{$fname};
         next unless $tool;
         my $t = {
             name        => $fname,
             description => $tool->{description} || $fname,
         };
-        if ($tool->{parameters} && %{ $tool->{parameters} }) {
+        if ( $tool->{parameters} && %{ $tool->{parameters} } ) {
             my $params = $tool->{parameters};
-            if ($params->{type} && $params->{type} eq 'object') {
+            if ( $params->{type} && $params->{type} eq 'object' ) {
                 $t->{inputSchema} = $params;
             } else {
                 $t->{inputSchema} = { type => 'object', properties => $params };
@@ -938,49 +951,51 @@ sub _build_mcp_tool_list {
 }
 
 sub _handle_mcp_request {
-    my ($self, $body) = @_;
+    my ( $self, $body ) = @_;
     my $jsonrpc = $body->{jsonrpc} // '';
     my $method  = $body->{method}  // '';
     my $req_id  = $body->{id};
-    my $params  = $body->{params}  // {};
+    my $params  = $body->{params} // {};
 
-    if ($jsonrpc ne '2.0') {
-        return _mcp_error($req_id, -32600, 'Invalid JSON-RPC version');
+    if ( $jsonrpc ne '2.0' ) {
+        return _mcp_error( $req_id, -32600, 'Invalid JSON-RPC version' );
     }
 
     # Initialize
-    if ($method eq 'initialize') {
+    if ( $method eq 'initialize' ) {
         return {
-            jsonrpc => '2.0', id => $req_id,
-            result => {
+            jsonrpc => '2.0',
+            id      => $req_id,
+            result  => {
                 protocolVersion => '2025-06-18',
-                capabilities   => { tools => {} },
-                serverInfo     => { name => $self->name, version => '1.0.0' },
+                capabilities    => { tools => {} },
+                serverInfo      => { name  => $self->name, version => '1.0.0' },
             },
         };
     }
 
     # Initialized notification
-    if ($method eq 'notifications/initialized') {
+    if ( $method eq 'notifications/initialized' ) {
         return { jsonrpc => '2.0', id => $req_id, result => {} };
     }
 
     # List tools
-    if ($method eq 'tools/list') {
+    if ( $method eq 'tools/list' ) {
         return {
-            jsonrpc => '2.0', id => $req_id,
-            result => { tools => $self->_build_mcp_tool_list },
+            jsonrpc => '2.0',
+            id      => $req_id,
+            result  => { tools => $self->_build_mcp_tool_list },
         };
     }
 
     # Call tool
-    if ($method eq 'tools/call') {
-        my $tool_name = $params->{name} // '';
+    if ( $method eq 'tools/call' ) {
+        my $tool_name = $params->{name}      // '';
         my $arguments = $params->{arguments} // {};
 
         my $tool = $self->tools->{$tool_name};
-        unless ($tool && $tool->{_handler}) {
-            return _mcp_error($req_id, -32602, "Unknown tool: $tool_name");
+        unless ( $tool && $tool->{_handler} ) {
+            return _mcp_error( $req_id, -32602, "Unknown tool: $tool_name" );
         }
 
         my $result = eval {
@@ -988,48 +1003,50 @@ sub _handle_mcp_request {
                 function => $tool_name,
                 argument => { parsed => [$arguments] },
             };
-            $tool->{_handler}->($arguments, $raw_data);
+            $tool->{_handler}->( $arguments, $raw_data );
         };
 
         if ($@) {
             return {
-                jsonrpc => '2.0', id => $req_id,
-                result => {
-                    content => [{ type => 'text', text => "Error: $@" }],
+                jsonrpc => '2.0',
+                id      => $req_id,
+                result  => {
+                    content => [ { type => 'text', text => "Error: $@" } ],
                     isError => JSON::true,
                 },
             };
         }
 
         my $response_text = '';
-        if (blessed($result) && $result->can('to_hash')) {
+        if ( blessed($result) && $result->can('to_hash') ) {
             my $h = $result->to_hash;
             $response_text = $h->{response} // '';
-        } elsif (ref $result eq 'HASH') {
+        } elsif ( ref $result eq 'HASH' ) {
             $response_text = $result->{response} // '';
-        } elsif (defined $result) {
+        } elsif ( defined $result ) {
             $response_text = "$result";
         }
 
         return {
-            jsonrpc => '2.0', id => $req_id,
-            result => {
-                content => [{ type => 'text', text => $response_text }],
+            jsonrpc => '2.0',
+            id      => $req_id,
+            result  => {
+                content => [ { type => 'text', text => $response_text } ],
                 isError => JSON::false,
             },
         };
     }
 
     # Ping
-    if ($method eq 'ping') {
+    if ( $method eq 'ping' ) {
         return { jsonrpc => '2.0', id => $req_id, result => {} };
     }
 
-    return _mcp_error($req_id, -32601, "Method not found: $method");
+    return _mcp_error( $req_id, -32601, "Method not found: $method" );
 }
 
 sub _mcp_error {
-    my ($req_id, $code, $message) = @_;
+    my ( $req_id, $code, $message ) = @_;
     return {
         jsonrpc => '2.0',
         id      => $req_id,
@@ -1040,36 +1057,37 @@ sub _mcp_error {
 # ---------- URL construction ----------
 
 sub _build_webhook_url {
-    my ($self, $request_env) = @_;
+    my ( $self, $request_env ) = @_;
+
     # If explicit override set, use it
     return $self->webhook_url if defined $self->webhook_url;
 
-    my $base = $self->_detect_proxy_url($request_env);
+    my $base  = $self->_detect_proxy_url($request_env);
     my $route = $self->route eq '/' ? '' : $self->route;
-    my $url = $base . $route . '/swaig';
+    my $url   = $base . $route . '/swaig';
 
     # Append query params
-    if (%{ $self->swaig_query_params }) {
+    if ( %{ $self->swaig_query_params } ) {
         my @parts;
-        for my $k (sort keys %{ $self->swaig_query_params }) {
-            push @parts, "$k=" . ($self->swaig_query_params->{$k} // '');
+        for my $k ( sort keys %{ $self->swaig_query_params } ) {
+            push @parts, "$k=" . ( $self->swaig_query_params->{$k} // '' );
         }
-        $url .= '?' . join('&', @parts);
+        $url .= '?' . join( '&', @parts );
     }
 
     return $url;
 }
 
 sub _build_post_prompt_url {
-    my ($self, $request_env) = @_;
+    my ( $self, $request_env ) = @_;
     return $self->post_prompt_url if defined $self->post_prompt_url;
-    my $base = $self->_detect_proxy_url($request_env);
+    my $base  = $self->_detect_proxy_url($request_env);
     my $route = $self->route eq '/' ? '' : $self->route;
     return $base . $route . '/post_prompt';
 }
 
 sub _detect_proxy_url {
-    my ($self, $env) = @_;
+    my ( $self, $env ) = @_;
 
     return $self->proxy_url_base if defined $self->proxy_url_base;
 
@@ -1078,7 +1096,7 @@ sub _detect_proxy_url {
     # Check X-Forwarded headers
     my $proto = $env->{HTTP_X_FORWARDED_PROTO};
     my $fhost = $env->{HTTP_X_FORWARDED_HOST};
-    if ($proto && $fhost) {
+    if ( $proto && $fhost ) {
         return "${proto}://${fhost}";
     }
 
@@ -1087,18 +1105,18 @@ sub _detect_proxy_url {
     return $orig if $orig;
 
     # Fallback to server config
-    my $scheme = ($env->{HTTPS} || $env->{'psgi.url_scheme'} || 'http');
+    my $scheme = ( $env->{HTTPS} || $env->{'psgi.url_scheme'} || 'http' );
     $scheme = 'https' if $scheme eq 'on';
     my $host = $env->{HTTP_HOST} || $self->host . ':' . $self->port;
     return "${scheme}://${host}";
 }
 
 sub get_full_url {
-    my ($self, %opts) = @_;
-    my $base = $self->proxy_url_base // ('http://' . $self->host . ':' . $self->port);
+    my ( $self, %opts ) = @_;
+    my $base  = $self->proxy_url_base // ( 'http://' . $self->host . ':' . $self->port );
     my $route = $self->route eq '/' ? '' : $self->route;
-    my $url = $base . $route;
-    if ($opts{include_auth}) {
+    my $url   = $base . $route;
+    if ( $opts{include_auth} ) {
         my $user = $self->basic_auth_user;
         my $pass = $self->basic_auth_password;
         $url =~ s{^(https?://)}{$1${user}:${pass}\@};
@@ -1109,7 +1127,7 @@ sub get_full_url {
 # ---------- render_swml (5-phase pipeline) ----------
 
 sub render_swml {
-    my ($self, $request_env) = @_;
+    my ( $self, $request_env ) = @_;
     $request_env //= {};
 
     my $webhook_url     = $self->_build_webhook_url($request_env);
@@ -1129,25 +1147,28 @@ sub render_swml {
     push @main_section, @{ $self->pre_answer_verbs };
 
     # Phase 2: Answer verb
-    if ($self->auto_answer) {
-        my %answer_params = (max_duration => 14400);
-        %answer_params = (%answer_params, %{ $self->answer_config }) if %{ $self->answer_config };
+    if ( $self->auto_answer ) {
+        my %answer_params = ( max_duration => 14400 );
+        %answer_params = ( %answer_params, %{ $self->answer_config } ) if %{ $self->answer_config };
         push @main_section, { answer => \%answer_params };
     }
 
     # Record call if enabled
-    if ($self->record_call) {
-        push @main_section, { record_call => {
-            format => $self->record_format,
-            stereo => $self->record_stereo ? JSON::true : JSON::false,
-        }};
+    if ( $self->record_call ) {
+        push @main_section,
+            {
+            record_call => {
+                format => $self->record_format,
+                stereo => $self->record_stereo ? JSON::true : JSON::false,
+            }
+            };
     }
 
     # Phase 3: Post-answer verbs
     push @main_section, @{ $self->post_answer_verbs };
 
     # Phase 4: AI verb
-    my $ai = $self->_build_ai_verb($webhook_url, $post_prompt_url);
+    my $ai = $self->_build_ai_verb( $webhook_url, $post_prompt_url );
     push @main_section, { ai => $ai };
 
     # Phase 5: Post-AI verbs
@@ -1162,13 +1183,14 @@ sub render_swml {
 }
 
 sub _build_ai_verb {
-    my ($self, $webhook_url, $post_prompt_url) = @_;
+    my ( $self, $webhook_url, $post_prompt_url ) = @_;
 
     my %ai;
 
     # Prompt
     my $prompt = $self->get_prompt;
-    if (ref $prompt eq 'ARRAY') {
+    if ( ref $prompt eq 'ARRAY' ) {
+
         # POM mode
         $ai{prompt} = { pom => $prompt };
     } else {
@@ -1176,18 +1198,18 @@ sub _build_ai_verb {
     }
 
     # Merge prompt LLM params
-    if (%{ $self->prompt_llm_params }) {
+    if ( %{ $self->prompt_llm_params } ) {
         $ai{prompt} //= {};
-        for my $k (keys %{ $self->prompt_llm_params }) {
+        for my $k ( keys %{ $self->prompt_llm_params } ) {
             $ai{prompt}{$k} = $self->prompt_llm_params->{$k};
         }
     }
 
     # Post prompt
-    if ($self->post_prompt && $self->post_prompt ne '') {
+    if ( $self->post_prompt && $self->post_prompt ne '' ) {
         $ai{post_prompt} = { text => $self->post_prompt };
-        if (%{ $self->post_prompt_llm_params }) {
-            for my $k (keys %{ $self->post_prompt_llm_params }) {
+        if ( %{ $self->post_prompt_llm_params } ) {
+            for my $k ( keys %{ $self->post_prompt_llm_params } ) {
                 $ai{post_prompt}{$k} = $self->post_prompt_llm_params->{$k};
             }
         }
@@ -1214,7 +1236,7 @@ sub _build_ai_verb {
 
     # Build function list
     my @functions;
-    for my $fname (@{ $self->tool_order }) {
+    for my $fname ( @{ $self->tool_order } ) {
         my $tool = $self->tools->{$fname};
         next unless $tool;
         my %func = %$tool;
@@ -1239,13 +1261,13 @@ sub _build_ai_verb {
         if %{ $self->global_data };
 
     # Internal fillers
-    if (defined $self->internal_fillers) {
+    if ( defined $self->internal_fillers ) {
         $ai{params} //= {};
         $ai{params}{internal_fillers} = $self->internal_fillers;
     }
 
     # Debug events
-    if ($self->debug_events_level > 0) {
+    if ( $self->debug_events_level > 0 ) {
         $ai{params} //= {};
         $ai{params}{debug_events} = $self->debug_events_level;
     }
@@ -1253,13 +1275,13 @@ sub _build_ai_verb {
     # Contexts — go under ai.prompt.contexts per Python's
     # PromptManager.to_dict() behavior (signalwire-python /core/swml_handler.py
     # build_config:172, /core/agent/prompt/manager.py:_contexts).
-    if ($self->context_builder && $self->context_builder->has_contexts) {
+    if ( $self->context_builder && $self->context_builder->has_contexts ) {
         $ai{prompt} //= {};
         $ai{prompt}{contexts} = $self->context_builder->to_hash;
     }
 
     # MCP servers
-    if (@{ $self->mcp_servers }) {
+    if ( @{ $self->mcp_servers } ) {
         $ai{mcp_servers} = [ @{ $self->mcp_servers } ];
     }
 
@@ -1284,59 +1306,67 @@ sub _build_psgi_app {
 
     # Build the core app as a plain PSGI sub
     my $core_app = sub {
-        my $env = shift;
-        my $req = Plack::Request->new($env);
+        my $env  = shift;
+        my $req  = Plack::Request->new($env);
         my $path = $req->path_info;
 
         # Normalize path
         $path =~ s{/+$}{} unless $path eq '/';
 
         # Health/ready endpoints (no auth)
-        if ($path eq '/health') {
-            return [200, ['Content-Type' => 'application/json'],
-                [encode_json({ status => 'healthy', agent => $agent->name })]];
+        if ( $path eq '/health' ) {
+            return [
+                200,
+                [ 'Content-Type' => 'application/json' ],
+                [ encode_json( { status => 'healthy', agent => $agent->name } ) ]
+            ];
         }
-        if ($path eq '/ready') {
-            return [200, ['Content-Type' => 'application/json'],
-                [encode_json({ status => 'ready' })]];
+        if ( $path eq '/ready' ) {
+            return [
+                200,
+                [ 'Content-Type' => 'application/json' ],
+                [ encode_json( { status => 'ready' } ) ]
+            ];
         }
 
         # Auth check for protected routes
-        my $expected_route  = $route eq '' ? '/' : $route;
-        my $is_swaig       = ($path eq "$route/swaig");
-        my $is_post_prompt  = ($path eq "$route/post_prompt");
-        my $is_mcp          = ($path eq "$route/mcp");
-        my $is_main         = ($path eq $expected_route || ($route ne '' && $path eq "$route/"));
+        my $expected_route = $route eq '' ? '/' : $route;
+        my $is_swaig       = ( $path eq "$route/swaig" );
+        my $is_post_prompt = ( $path eq "$route/post_prompt" );
+        my $is_mcp         = ( $path eq "$route/mcp" );
+        my $is_main        = ( $path eq $expected_route || ( $route ne '' && $path eq "$route/" ) );
 
         # Root agent: treat '/' as main
-        if ($route eq '' && $path eq '/') {
+        if ( $route eq '' && $path eq '/' ) {
             $is_main = 1;
         }
 
-        if ($is_main || $is_swaig || $is_post_prompt) {
+        if ( $is_main || $is_swaig || $is_post_prompt ) {
             my $auth_ok = $agent->_check_auth($env);
             unless ($auth_ok) {
-                return [401,
-                    ['Content-Type' => 'text/plain', 'WWW-Authenticate' => 'Basic realm="SignalWire Agent"'],
-                    ['Unauthorized']];
+                return [
+                    401,
+                    [
+                        'Content-Type'     => 'text/plain',
+                        'WWW-Authenticate' => 'Basic realm="SignalWire Agent"'
+                    ],
+                    ['Unauthorized']
+                ];
             }
         }
 
         # Route dispatch
-        if ($is_main && ($req->method eq 'GET' || $req->method eq 'POST')) {
-            return $agent->_handle_swml($env, $req);
-        }
-        elsif ($is_swaig && $req->method eq 'POST') {
-            return $agent->_handle_swaig($env, $req);
-        }
-        elsif ($is_post_prompt && $req->method eq 'POST') {
-            return $agent->_handle_post_prompt($env, $req);
-        }
-        elsif ($is_mcp && $req->method eq 'POST') {
-            return $agent->_handle_mcp_endpoint($env, $req);
+        if ( $is_main && ( $req->method eq 'GET' || $req->method eq 'POST' ) ) {
+            return $agent->_handle_swml( $env, $req );
+        } elsif ( $is_swaig && $req->method eq 'POST' ) {
+            return $agent->_handle_swaig( $env, $req );
+        } elsif ( $is_post_prompt && $req->method eq 'POST' ) {
+            return $agent->_handle_post_prompt( $env, $req );
+        } elsif ( $is_mcp && $req->method eq 'POST' ) {
+            return $agent->_handle_mcp_endpoint( $env, $req );
         }
 
-        return [404, ['Content-Type' => 'text/plain'], ['Not Found']];
+        return [ 404, [ 'Content-Type' => 'text/plain' ], ['Not Found'] ];
     };
 
     # Maximum request body size: 1MB
@@ -1347,32 +1377,38 @@ sub _build_psgi_app {
         my $env = shift;
 
         # Enforce body size limit by actually reading the body
-        if ($env->{REQUEST_METHOD} eq 'POST' || $env->{REQUEST_METHOD} eq 'PUT') {
+        if ( $env->{REQUEST_METHOD} eq 'POST' || $env->{REQUEST_METHOD} eq 'PUT' ) {
             my $input = $env->{'psgi.input'};
             if ($input) {
-                my $body = '';
+                my $body  = '';
                 my $total = 0;
                 my $buf;
-                while (my $read = $input->read($buf, 8192)) {
+                while ( my $read = $input->read( $buf, 8192 ) ) {
                     $total += $read;
-                    if ($total > $max_body_size) {
-                        return [413, ['Content-Type' => 'application/json',
-                                      'X-Content-Type-Options' => 'nosniff',
-                                      'X-Frame-Options' => 'DENY',
-                                      'Cache-Control' => 'no-store'],
-                            [encode_json({ error => 'Request body too large' })]];
+                    if ( $total > $max_body_size ) {
+                        return [
+                            413,
+                            [
+                                'Content-Type'           => 'application/json',
+                                'X-Content-Type-Options' => 'nosniff',
+                                'X-Frame-Options'        => 'DENY',
+                                'Cache-Control'          => 'no-store'
+                            ],
+                            [ encode_json( { error => 'Request body too large' } ) ]
+                        ];
                     }
                     $body .= $buf;
                 }
+
                 # Replace psgi.input with the buffered content so handlers can re-read
                 open my $new_input, '<', \$body;
-                $env->{'psgi.input'} = $new_input;
+                $env->{'psgi.input'}   = $new_input;
                 $env->{CONTENT_LENGTH} = length($body);
             }
         }
 
         my $res = $core_app->($env);
-        if (ref $res eq 'ARRAY') {
+        if ( ref $res eq 'ARRAY' ) {
             push @{ $res->[1] },
                 'X-Content-Type-Options' => 'nosniff',
                 'X-Frame-Options'        => 'DENY',
@@ -1387,14 +1423,15 @@ sub _build_psgi_app {
     # signing_key is empty (the startup-warning code below logs once
     # so callers know validation is disabled).
     my $signing_key = $self->signing_key;
-    if (defined $signing_key && $signing_key ne '') {
+    if ( defined $signing_key && $signing_key ne '' ) {
         require SignalWire::Security::WebhookMiddleware;
-        my $main_path = ($route eq '' || $route eq '/') ? '/' : $route;
+        my $main_path   = ( $route eq '' || $route eq '/' ) ? '/' : $route;
         my @gated_paths = ($main_path);
         push @gated_paths, "$route/swaig", "$route/post_prompt"
             if $route ne '';
         push @gated_paths, '/swaig', '/post_prompt'
             if $route eq '' || $route eq '/';
+
         # De-dup
         my %seen;
         @gated_paths = grep { !$seen{$_}++ } @gated_paths;
@@ -1407,8 +1444,7 @@ sub _build_psgi_app {
             trust_proxy => 1,
         );
         return $signed_app;
-    }
-    else {
+    } else {
         $self->_warn_signing_key_disabled_once;
     }
 
@@ -1427,95 +1463,108 @@ sub _warn_signing_key_disabled_once {
 }
 
 sub _check_auth {
-    my ($self, $env) = @_;
+    my ( $self, $env ) = @_;
     my $auth_header = $env->{HTTP_AUTHORIZATION} // '';
     return 0 unless $auth_header =~ /^Basic\s+(.+)$/i;
     my $decoded = eval { decode_base64($1) } // '';
-    my ($user, $pass) = split(/:/, $decoded, 2);
+    my ( $user, $pass ) = split( /:/, $decoded, 2 );
     return 0 unless defined $user && defined $pass;
 
     # Timing-safe comparison using HMAC (constant-time, no length leak)
     my $expected_user = $self->basic_auth_user;
     my $expected_pass = $self->basic_auth_password;
 
-    my $user_ok = _timing_safe_eq($user, $expected_user);
-    my $pass_ok = _timing_safe_eq($pass, $expected_pass);
+    my $user_ok = _timing_safe_eq( $user, $expected_user );
+    my $pass_ok = _timing_safe_eq( $pass, $expected_pass );
 
-    return ($user_ok && $pass_ok) ? 1 : 0;
+    return ( $user_ok && $pass_ok ) ? 1 : 0;
 }
 
 sub _timing_safe_eq {
-    my ($a, $b) = @_;
+    my ( $a, $b ) = @_;
+
     # HMAC-based constant-time comparison: no length leak
-    my $key = 'signalwire-timing-safe-comparison';
-    my $hmac_a = hmac_sha256_hex($a, $key);
-    my $hmac_b = hmac_sha256_hex($b, $key);
+    my $key    = 'signalwire-timing-safe-comparison';
+    my $hmac_a = hmac_sha256_hex( $a, $key );
+    my $hmac_b = hmac_sha256_hex( $b, $key );
     return $hmac_a eq $hmac_b;
 }
 
 sub _handle_swml {
-    my ($self, $env, $req) = @_;
+    my ( $self, $env, $req ) = @_;
 
     my $agent = $self;
 
     # If dynamic config callback is set, clone and apply
-    if ($self->dynamic_config_callback) {
+    if ( $self->dynamic_config_callback ) {
         $agent = $self->_clone_for_request;
         my $query_params = $req->query_parameters->as_hashref_mixed;
         my $body_params  = {};
-        if ($req->method eq 'POST' && $req->content_length) {
-            eval { $body_params = decode_json($req->content) };
+        if ( $req->method eq 'POST' && $req->content_length ) {
+            eval { $body_params = decode_json( $req->content ) };
         }
         my $headers = {};
-        for my $k (keys %$env) {
-            if ($k =~ /^HTTP_(.+)/) {
-                $headers->{lc($1)} = $env->{$k};
+        for my $k ( keys %$env ) {
+            if ( $k =~ /^HTTP_(.+)/ ) {
+                $headers->{ lc($1) } = $env->{$k};
             }
         }
-        $self->dynamic_config_callback->($query_params, $body_params, $headers, $agent);
+        $self->dynamic_config_callback->( $query_params, $body_params, $headers, $agent );
     }
 
     my $swml = $agent->render_swml($env);
     my $json = encode_json($swml);
 
-    return [200, ['Content-Type' => 'application/json'], [$json]];
+    return [ 200, [ 'Content-Type' => 'application/json' ], [$json] ];
 }
 
 sub _handle_swaig {
-    my ($self, $env, $req) = @_;
+    my ( $self, $env, $req ) = @_;
 
-    my $body = eval { decode_json($req->content) };
-    unless ($body && ref $body eq 'HASH') {
-        return [400, ['Content-Type' => 'application/json'],
-            [encode_json({ error => 'Invalid JSON' })]];
+    my $body = eval { decode_json( $req->content ) };
+    unless ( $body && ref $body eq 'HASH' ) {
+        return [
+            400,
+            [ 'Content-Type' => 'application/json' ],
+            [ encode_json( { error => 'Invalid JSON' } ) ]
+        ];
     }
 
     my $func_name = $body->{function};
-    unless ($func_name && exists $self->tools->{$func_name}) {
-        return [404, ['Content-Type' => 'application/json'],
-            [encode_json({ error => 'Function not found' })]];
+    unless ( $func_name && exists $self->tools->{$func_name} ) {
+        return [
+            404,
+            [ 'Content-Type' => 'application/json' ],
+            [ encode_json( { error => 'Function not found' } ) ]
+        ];
     }
 
     # Extract args
     my $args = {};
-    if ($body->{argument} && ref $body->{argument}{parsed} eq 'ARRAY'
-        && @{ $body->{argument}{parsed} }) {
+    if (   $body->{argument}
+        && ref $body->{argument}{parsed} eq 'ARRAY'
+        && @{ $body->{argument}{parsed} } )
+    {
         $args = $body->{argument}{parsed}[0] // {};
     }
 
-    my $result = $self->on_function_call($func_name, $args, $body);
-    unless (defined $result) {
-        return [500, ['Content-Type' => 'application/json'],
-            [encode_json({ error => 'Handler returned no result' })]];
+    my $result = $self->on_function_call( $func_name, $args, $body );
+    unless ( defined $result ) {
+        return [
+            500,
+            [ 'Content-Type' => 'application/json' ],
+            [ encode_json( { error => 'Handler returned no result' } ) ]
+        ];
     }
 
     # Serialize result
     my $response;
-    if (blessed($result) && $result->can('to_hash')) {
+    if ( blessed($result) && $result->can('to_hash') ) {
         $response = $result->to_hash;
-    } elsif (ref $result eq 'HASH') {
+    } elsif ( ref $result eq 'HASH' ) {
         $response = $result;
     } else {
+
         # Neither a FunctionResult-like object nor a hashref. Warn and
         # fall back to wrapping the stringified value, matching Python's
         # web_mixin / serverless_mixin / tool_mixin behavior.
@@ -1531,44 +1580,48 @@ sub _handle_swaig {
         $response = { response => "$result" };
     }
 
-    return [200, ['Content-Type' => 'application/json'], [encode_json($response)]];
+    return [ 200, [ 'Content-Type' => 'application/json' ], [ encode_json($response) ] ];
 }
 
 sub _handle_post_prompt {
-    my ($self, $env, $req) = @_;
+    my ( $self, $env, $req ) = @_;
 
-    my $body = eval { decode_json($req->content) };
+    my $body = eval { decode_json( $req->content ) };
     $body //= {};
 
-    if ($self->summary_callback) {
+    if ( $self->summary_callback ) {
         my $summary = undef;
-        if ($body->{post_prompt_data}) {
-            $summary = $body->{post_prompt_data}{parsed}
-                    // $body->{post_prompt_data}{raw};
+        if ( $body->{post_prompt_data} ) {
+            $summary = $body->{post_prompt_data}{parsed} // $body->{post_prompt_data}{raw};
         }
-        $self->summary_callback->($summary, $body);
+        $self->summary_callback->( $summary, $body );
     }
 
-    return [200, ['Content-Type' => 'application/json'],
-        [encode_json({ status => 'ok' })]];
+    return [ 200, [ 'Content-Type' => 'application/json' ], [ encode_json( { status => 'ok' } ) ] ];
 }
 
 sub _handle_mcp_endpoint {
-    my ($self, $env, $req) = @_;
+    my ( $self, $env, $req ) = @_;
 
-    unless ($self->mcp_server_enabled) {
-        return [404, ['Content-Type' => 'application/json'],
-            [encode_json({ error => 'MCP server not enabled' })]];
+    unless ( $self->mcp_server_enabled ) {
+        return [
+            404,
+            [ 'Content-Type' => 'application/json' ],
+            [ encode_json( { error => 'MCP server not enabled' } ) ]
+        ];
     }
 
-    my $body = eval { decode_json($req->content) };
-    unless ($body && ref $body eq 'HASH') {
-        return [400, ['Content-Type' => 'application/json'],
-            [encode_json(_mcp_error(undef, -32700, 'Parse error'))]];
+    my $body = eval { decode_json( $req->content ) };
+    unless ( $body && ref $body eq 'HASH' ) {
+        return [
+            400,
+            [ 'Content-Type' => 'application/json' ],
+            [ encode_json( _mcp_error( undef, -32700, 'Parse error' ) ) ]
+        ];
     }
 
     my $resp = $self->_handle_mcp_request($body);
-    return [200, ['Content-Type' => 'application/json'], [encode_json($resp)]];
+    return [ 200, [ 'Content-Type' => 'application/json' ], [ encode_json($resp) ] ];
 }
 
 # ---------- Clone for dynamic config ----------
@@ -1576,54 +1629,58 @@ sub _handle_mcp_endpoint {
 sub _clone_for_request {
     my ($self) = @_;
     my %init;
-    for my $attr (qw(name route host port auto_answer record_call record_format
-                     record_stereo prompt_text post_prompt use_pom
-                     debug_events_level)) {
+    for my $attr (
+        qw(name route host port auto_answer record_call record_format
+        record_stereo prompt_text post_prompt use_pom
+        debug_events_level)
+        )
+    {
         $init{$attr} = $self->$attr;
     }
-    # Deep copy complex attributes
-    $init{pom_sections}        = dclone($self->pom_sections);
-    $init{tools}               = dclone($self->tools);
-    $init{tool_order}          = [ @{ $self->tool_order } ];
-    $init{hints}               = [ @{ $self->hints } ];
-    $init{pattern_hints}       = [ @{ $self->pattern_hints } ];
-    $init{languages}           = dclone($self->languages);
-    $init{pronunciations}      = dclone($self->pronunciations);
-    $init{params}              = { %{ $self->params } };
-    $init{global_data}         = dclone($self->global_data);
-    $init{native_functions}    = [ @{ $self->native_functions } ];
-    $init{function_includes}   = dclone($self->function_includes);
-    $init{prompt_llm_params}   = { %{ $self->prompt_llm_params } };
-    $init{post_prompt_llm_params} = { %{ $self->post_prompt_llm_params } };
-    $init{pre_answer_verbs}    = dclone($self->pre_answer_verbs);
-    $init{post_answer_verbs}   = dclone($self->post_answer_verbs);
-    $init{post_ai_verbs}       = dclone($self->post_ai_verbs);
-    $init{answer_config}       = { %{ $self->answer_config } };
-    $init{swaig_query_params}  = { %{ $self->swaig_query_params } };
-    $init{basic_auth_user}     = $self->basic_auth_user;
-    $init{basic_auth_password} = $self->basic_auth_password;
-    $init{webhook_url}         = $self->webhook_url;
-    $init{post_prompt_url}     = $self->post_prompt_url;
-    $init{proxy_url_base}      = $self->proxy_url_base;
-    $init{internal_fillers}    = defined $self->internal_fillers
-                                    ? dclone($self->internal_fillers) : undef;
-    $init{session_manager}     = $self->session_manager;
-    $init{mcp_servers}         = dclone($self->mcp_servers);
-    $init{mcp_server_enabled}  = $self->mcp_server_enabled;
 
-    my $clone = (ref $self)->new(%init);
+    # Deep copy complex attributes
+    $init{pom_sections}           = dclone( $self->pom_sections );
+    $init{tools}                  = dclone( $self->tools );
+    $init{tool_order}             = [ @{ $self->tool_order } ];
+    $init{hints}                  = [ @{ $self->hints } ];
+    $init{pattern_hints}          = [ @{ $self->pattern_hints } ];
+    $init{languages}              = dclone( $self->languages );
+    $init{pronunciations}         = dclone( $self->pronunciations );
+    $init{params}                 = { %{ $self->params } };
+    $init{global_data}            = dclone( $self->global_data );
+    $init{native_functions}       = [ @{ $self->native_functions } ];
+    $init{function_includes}      = dclone( $self->function_includes );
+    $init{prompt_llm_params}      = { %{ $self->prompt_llm_params } };
+    $init{post_prompt_llm_params} = { %{ $self->post_prompt_llm_params } };
+    $init{pre_answer_verbs}       = dclone( $self->pre_answer_verbs );
+    $init{post_answer_verbs}      = dclone( $self->post_answer_verbs );
+    $init{post_ai_verbs}          = dclone( $self->post_ai_verbs );
+    $init{answer_config}          = { %{ $self->answer_config } };
+    $init{swaig_query_params}     = { %{ $self->swaig_query_params } };
+    $init{basic_auth_user}        = $self->basic_auth_user;
+    $init{basic_auth_password}    = $self->basic_auth_password;
+    $init{webhook_url}            = $self->webhook_url;
+    $init{post_prompt_url}        = $self->post_prompt_url;
+    $init{proxy_url_base}         = $self->proxy_url_base;
+    $init{internal_fillers} =
+        defined $self->internal_fillers ? dclone( $self->internal_fillers ) : undef;
+    $init{session_manager}    = $self->session_manager;
+    $init{mcp_servers}        = dclone( $self->mcp_servers );
+    $init{mcp_server_enabled} = $self->mcp_server_enabled;
+
+    my $clone = ( ref $self )->new(%init);
     return $clone;
 }
 
 # ---------- run / serve ----------
 
 sub run {
-    my ($self, %opts) = @_;
+    my ( $self, %opts ) = @_;
     $self->serve(%opts);
 }
 
 sub serve {
-    my ($self, %opts) = @_;
+    my ( $self, %opts ) = @_;
     my $app  = $self->psgi_app;
     my $host = $opts{host} // $self->host;
     my $port = $opts{port} // $self->port;
@@ -1638,9 +1695,9 @@ sub serve {
     #   * Otherwise the SWML_SSL_* environment variables (same names the Python
     #     SecurityConfig reads): TLS only when SWML_SSL_ENABLED is truthy AND
     #     both SWML_SSL_CERT_PATH and SWML_SSL_KEY_PATH resolve.
-    my ($cert, $key) = _resolve_tls(\%opts);
-    if (defined $cert && defined $key) {
-        return $self->_serve_tls($app, $host, $port, $cert, $key);
+    my ( $cert, $key ) = _resolve_tls( \%opts );
+    if ( defined $cert && defined $key ) {
+        return $self->_serve_tls( $app, $host, $port, $cert, $key );
     }
 
     require Plack::Runner;
@@ -1659,20 +1716,20 @@ sub serve {
 # AND both cert + key paths are set), exactly matching the Python reference.
 sub _resolve_tls {
     my ($opts) = @_;
-    my $cert = $opts->{ssl_cert} // $opts->{ssl_cert_path};
-    my $key  = $opts->{ssl_key}  // $opts->{ssl_key_path};
-    if (defined $cert && length $cert && defined $key && length $key) {
-        return ($cert, $key);
+    my $cert   = $opts->{ssl_cert} // $opts->{ssl_cert_path};
+    my $key    = $opts->{ssl_key}  // $opts->{ssl_key_path};
+    if ( defined $cert && length $cert && defined $key && length $key ) {
+        return ( $cert, $key );
     }
-    my $enabled = lc($ENV{SWML_SSL_ENABLED} // '');
-    if ($enabled eq 'true' || $enabled eq '1' || $enabled eq 'yes') {
+    my $enabled = lc( $ENV{SWML_SSL_ENABLED} // '' );
+    if ( $enabled eq 'true' || $enabled eq '1' || $enabled eq 'yes' ) {
         my $ecert = $ENV{SWML_SSL_CERT_PATH};
         my $ekey  = $ENV{SWML_SSL_KEY_PATH};
-        if (defined $ecert && length $ecert && defined $ekey && length $ekey) {
-            return ($ecert, $ekey);
+        if ( defined $ecert && length $ecert && defined $ekey && length $ekey ) {
+            return ( $ecert, $ekey );
         }
     }
-    return (undef, undef);
+    return ( undef, undef );
 }
 
 # Serve $app over HTTPS by building an IO::Socket::SSL listen socket from the
@@ -1681,10 +1738,10 @@ sub _resolve_tls {
 # from it). IO::Socket::SSL is already a hard dependency (used by the RELAY
 # client), so this adds no new dependency. Blocks like the plaintext path.
 sub _serve_tls {
-    my ($self, $app, $host, $port, $cert, $key) = @_;
+    my ( $self, $app, $host, $port, $cert, $key ) = @_;
     require IO::Socket::SSL;
     require HTTP::Server::PSGI;
-    no warnings 'once';  # $IO::Socket::SSL::SSL_ERROR is populated at runtime
+    no warnings 'once';    # $IO::Socket::SSL::SSL_ERROR is populated at runtime
 
     my $ssl = IO::Socket::SSL->new(
         LocalAddr     => $host,
@@ -1693,8 +1750,9 @@ sub _serve_tls {
         ReuseAddr     => 1,
         SSL_cert_file => $cert,
         SSL_key_file  => $key,
-    ) or croak("AgentBase: TLS listen on $host:$port failed: "
-             . ($IO::Socket::SSL::SSL_ERROR // $!));
+        )
+        or croak(
+        "AgentBase: TLS listen on $host:$port failed: " . ( $IO::Socket::SSL::SSL_ERROR // $! ) );
 
     my $srv = HTTP::Server::PSGI->new(
         host        => $host,
@@ -1707,39 +1765,39 @@ sub _serve_tls {
 # ---------- helpers ----------
 
 sub _generate_random_password {
+
     # Use /dev/urandom for cryptographically secure random bytes.
     # Die on failure rather than falling back to a weak password.
     my $bytes = '';
-    if (open my $fh, '<:raw', '/dev/urandom') {
-        my $read = read($fh, $bytes, 32);
+    if ( open my $fh, '<:raw', '/dev/urandom' ) {
+        my $read = read( $fh, $bytes, 32 );
         close $fh;
-        if (defined $read && $read == 32) {
+        if ( defined $read && $read == 32 ) {
+
             # Convert to hex string (64 chars)
-            return unpack('H*', $bytes);
+            return unpack( 'H*', $bytes );
         }
     }
     die "FATAL: Cannot generate secure random password - /dev/urandom unavailable or read failed. "
-      . "Set SWML_BASIC_AUTH_PASSWORD environment variable instead.\n";
+        . "Set SWML_BASIC_AUTH_PASSWORD environment variable instead.\n";
 }
 
 sub extract_sip_username {
-    my ($class_or_self, $body) = @_;
+    my ( $class_or_self, $body ) = @_;
+
     # Extract SIP username from a request body (hashref).
     # Looks in standard SignalWire fields for the SIP caller identity.
     return undef unless ref $body eq 'HASH';
 
     # Check call.from field (e.g., "sip:user@domain")
-    my $from = $body->{call}{from}
-            // $body->{sip_from}
-            // $body->{from}
-            // '';
+    my $from = $body->{call}{from} // $body->{sip_from} // $body->{from} // '';
 
-    if ($from =~ m{^sip:([^@]+)\@}i) {
+    if ( $from =~ m{^sip:([^@]+)\@}i ) {
         return $1;
     }
 
     # Check for a direct caller_id_number
-    if (my $cid = $body->{call}{caller_id_number} // $body->{caller_id_number}) {
+    if ( my $cid = $body->{call}{caller_id_number} // $body->{caller_id_number} ) {
         return $cid;
     }
 

--- a/lib/SignalWire/Agent/AgentBase.pm
+++ b/lib/SignalWire/Agent/AgentBase.pm
@@ -172,6 +172,7 @@ sub BUILD {
     require SignalWire::Security::SessionManager;
     $self->session_manager(
         SignalWire::Security::SessionManager->new( token_expiry_secs => 3600 ) );
+    return;
 }
 
 # ---------- Prompt methods ----------
@@ -1400,7 +1401,10 @@ sub _build_psgi_app {
                     $body .= $buf;
                 }
 
-                # Replace psgi.input with the buffered content so handlers can re-read
+                # Replace psgi.input with the buffered content so handlers can
+                # re-read. In-memory handle is deliberately handed off as
+                # psgi.input for downstream re-reads; it must NOT be closed here
+                # (see RequireBriefOpen exemption rationale in .perlcriticrc).
                 open my $new_input, '<', \$body;
                 $env->{'psgi.input'}   = $new_input;
                 $env->{CONTENT_LENGTH} = length($body);
@@ -1460,6 +1464,7 @@ sub _warn_signing_key_disabled_once {
     $self->{_signing_warning_emitted} = 1;
     carp "[signalwire] webhook signature validation is disabled — "
         . "set signing_key or SIGNALWIRE_SIGNING_KEY to enable";
+    return;
 }
 
 sub _check_auth {
@@ -1676,7 +1681,7 @@ sub _clone_for_request {
 
 sub run {
     my ( $self, %opts ) = @_;
-    $self->serve(%opts);
+    return $self->serve(%opts);
 }
 
 sub serve {
@@ -1707,7 +1712,7 @@ sub serve {
         '--port'   => $port,
         '--server' => 'HTTP::Server::PSGI',
     );
-    $runner->run($app);
+    return $runner->run($app);
 }
 
 # _resolve_tls(\%opts) -> ($cert, $key) when TLS should be served, else
@@ -1759,7 +1764,7 @@ sub _serve_tls {
         port        => $port,
         listen_sock => $ssl,
     );
-    $srv->run($app);
+    return $srv->run($app);
 }
 
 # ---------- helpers ----------

--- a/lib/SignalWire/Agent/AgentBase.pm
+++ b/lib/SignalWire/Agent/AgentBase.pm
@@ -257,7 +257,7 @@ sub get_prompt {
 # internal section list so caller mutations cannot leak back.
 sub pom {
     my ($self) = @_;
-    return undef unless $self->use_pom;
+    return unless $self->use_pom;
     require Storable;
     require SignalWire::POM::PromptObjectModel;
     my $cloned = Storable::dclone( $self->pom_sections );
@@ -313,7 +313,7 @@ sub set_prompt_pom {
 sub get_contexts {
     my ($self) = @_;
     my $cb = $self->context_builder;
-    return undef unless defined $cb;
+    return unless defined $cb;
     return $cb->to_hash;
 }
 
@@ -499,7 +499,7 @@ sub get_language_params {
         next unless defined $language->{code} && $language->{code} eq $code;
         return $language->{params};
     }
-    return undef;
+    return;
 }
 
 sub add_pronunciation {
@@ -898,7 +898,7 @@ sub on_summary {
     if ($cb) {
         return $cb->( $summary, $raw_data );
     }
-    return undef;
+    return;
 }
 
 sub on_debug_event {
@@ -1787,7 +1787,7 @@ sub extract_sip_username {
 
     # Extract SIP username from a request body (hashref).
     # Looks in standard SignalWire fields for the SIP caller identity.
-    return undef unless ref $body eq 'HASH';
+    return unless ref $body eq 'HASH';
 
     # Check call.from field (e.g., "sip:user@domain")
     my $from = $body->{call}{from} // $body->{sip_from} // $body->{from} // '';
@@ -1801,7 +1801,7 @@ sub extract_sip_username {
         return $cid;
     }
 
-    return undef;
+    return;
 }
 
 1;

--- a/lib/SignalWire/Contexts.pm
+++ b/lib/SignalWire/Contexts.pm
@@ -557,14 +557,14 @@ sub add_exit_filler {
 sub _render_prompt {
     my ($self) = @_;
     return $self->_prompt_text if defined $self->_prompt_text;
-    return undef unless @{ $self->_prompt_sections };
+    return unless @{ $self->_prompt_sections };
     return _render_sections( $self->_prompt_sections );
 }
 
 sub _render_system_prompt {
     my ($self) = @_;
     return $self->_system_prompt if defined $self->_system_prompt;
-    return undef unless @{ $self->_system_prompt_sections };
+    return unless @{ $self->_system_prompt_sections };
     return _render_sections( $self->_system_prompt_sections );
 }
 

--- a/lib/SignalWire/Contexts.pm
+++ b/lib/SignalWire/Contexts.pm
@@ -858,7 +858,13 @@ package SignalWire::Contexts;
 #   - SignalWire::Contexts::create_simple_context('mycontext')   # free fn
 #   - SignalWire::Contexts->create_simple_context('mycontext')   # class method
 # Both forms collapse to a single optional ``$name`` argument.
-sub create_simple_context {
+sub create_simple_context {    ## no critic (Subroutines::RequireArgUnpacking)
+
+    # The regex signature extractor reads this exact ``my ($name) = @_;`` first
+    # line to emit the audited ``name`` param; and the dual free-fn / class-
+    # method calling convention needs @_/shift to drop a possible receiver.
+    # Unpacking into ``@args`` would rename the audited param and move the
+    # surface, so RequireArgUnpacking is suppressed here (parity, not laziness).
     my ($name) = @_;
     if ( defined $name && !ref($name) && $name eq __PACKAGE__ ) {
 

--- a/lib/SignalWire/Contexts.pm
+++ b/lib/SignalWire/Contexts.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use JSON ();
 
-our $MAX_CONTEXTS        = 50;
+our $MAX_CONTEXTS          = 50;
 our $MAX_STEPS_PER_CONTEXT = 100;
 
 # Reserved tool names auto-injected by the runtime when contexts/steps are
@@ -16,9 +16,9 @@ our $MAX_STEPS_PER_CONTEXT = 100;
 # sharing one of these names (see the validation in
 # SignalWire::Contexts::ContextBuilder::validate below).
 our %RESERVED_NATIVE_TOOL_NAMES = (
-    next_step       => 1,
-    change_context  => 1,
-    gather_submit   => 1,
+    next_step      => 1,
+    change_context => 1,
+    gather_submit  => 1,
 );
 
 # ==========================================================================
@@ -28,20 +28,20 @@ package SignalWire::Contexts::GatherQuestion;
 use Moo;
 use JSON ();
 
-has 'key'       => (is => 'ro', required => 1);
-has 'question'  => (is => 'ro', required => 1);
-has 'type'      => (is => 'ro', default => sub { 'string' });
-has 'confirm'   => (is => 'ro', default => sub { 0 });
-has 'prompt'    => (is => 'ro', default => sub { undef });
-has 'functions' => (is => 'ro', default => sub { undef });
+has 'key'       => ( is => 'ro', required => 1 );
+has 'question'  => ( is => 'ro', required => 1 );
+has 'type'      => ( is => 'ro', default  => sub { 'string' } );
+has 'confirm'   => ( is => 'ro', default  => sub { 0 } );
+has 'prompt'    => ( is => 'ro', default  => sub { undef } );
+has 'functions' => ( is => 'ro', default  => sub { undef } );
 
 sub to_hash {
     my ($self) = @_;
-    my %d = (key => $self->key, question => $self->question);
+    my %d = ( key => $self->key, question => $self->question );
     $d{type}      = $self->type      if $self->type ne 'string';
     $d{confirm}   = JSON::true       if $self->confirm;
-    $d{prompt}    = $self->prompt     if defined $self->prompt;
-    $d{functions} = $self->functions  if defined $self->functions;
+    $d{prompt}    = $self->prompt    if defined $self->prompt;
+    $d{functions} = $self->functions if defined $self->functions;
     return \%d;
 }
 
@@ -51,18 +51,18 @@ sub to_hash {
 package SignalWire::Contexts::GatherInfo;
 use Moo;
 
-has '_questions'        => (is => 'rw', default => sub { [] });
-has '_output_key'       => (is => 'rw', default => sub { undef });
-has '_completion_action' => (is => 'rw', default => sub { undef });
-has '_prompt'           => (is => 'rw', default => sub { undef });
+has '_questions'         => ( is => 'rw', default => sub { [] } );
+has '_output_key'        => ( is => 'rw', default => sub { undef } );
+has '_completion_action' => ( is => 'rw', default => sub { undef } );
+has '_prompt'            => ( is => 'rw', default => sub { undef } );
 
 sub add_question {
-    my ($self, %opts) = @_;
+    my ( $self, %opts ) = @_;
     my $q = SignalWire::Contexts::GatherQuestion->new(
         key       => $opts{key},
         question  => $opts{question},
-        type      => $opts{type}      // 'string',
-        confirm   => $opts{confirm}   // 0,
+        type      => $opts{type}    // 'string',
+        confirm   => $opts{confirm} // 0,
         prompt    => $opts{prompt},
         functions => $opts{functions},
     );
@@ -73,10 +73,10 @@ sub add_question {
 sub to_hash {
     my ($self) = @_;
     die "gather_info must have at least one question" unless @{ $self->_questions };
-    my %d = (questions => [ map { $_->to_hash } @{ $self->_questions } ]);
+    my %d = ( questions => [ map { $_->to_hash } @{ $self->_questions } ] );
     $d{prompt}            = $self->_prompt            if defined $self->_prompt;
     $d{output_key}        = $self->_output_key        if defined $self->_output_key;
-    $d{completion_action} = $self->_completion_action  if defined $self->_completion_action;
+    $d{completion_action} = $self->_completion_action if defined $self->_completion_action;
     return \%d;
 }
 
@@ -87,25 +87,25 @@ package SignalWire::Contexts::Step;
 use Moo;
 use JSON ();
 
-has 'name' => (is => 'ro', required => 1);
+has 'name' => ( is => 'ro', required => 1 );
 
-has '_text'             => (is => 'rw', default => sub { undef });
-has '_step_criteria'    => (is => 'rw', default => sub { undef });
-has '_functions'        => (is => 'rw', default => sub { undef });
-has '_valid_steps'      => (is => 'rw', default => sub { undef });
-has '_valid_contexts'   => (is => 'rw', default => sub { undef });
-has '_sections'         => (is => 'rw', default => sub { [] });
-has '_gather_info'      => (is => 'rw', default => sub { undef });
-has '_end'              => (is => 'rw', default => sub { 0 });
-has '_skip_user_turn'   => (is => 'rw', default => sub { 0 });
-has '_skip_to_next_step' => (is => 'rw', default => sub { 0 });
-has '_reset_system_prompt' => (is => 'rw', default => sub { undef });
-has '_reset_user_prompt'   => (is => 'rw', default => sub { undef });
-has '_reset_consolidate'   => (is => 'rw', default => sub { 0 });
-has '_reset_full_reset'    => (is => 'rw', default => sub { 0 });
+has '_text'                => ( is => 'rw', default => sub { undef } );
+has '_step_criteria'       => ( is => 'rw', default => sub { undef } );
+has '_functions'           => ( is => 'rw', default => sub { undef } );
+has '_valid_steps'         => ( is => 'rw', default => sub { undef } );
+has '_valid_contexts'      => ( is => 'rw', default => sub { undef } );
+has '_sections'            => ( is => 'rw', default => sub { [] } );
+has '_gather_info'         => ( is => 'rw', default => sub { undef } );
+has '_end'                 => ( is => 'rw', default => sub { 0 } );
+has '_skip_user_turn'      => ( is => 'rw', default => sub { 0 } );
+has '_skip_to_next_step'   => ( is => 'rw', default => sub { 0 } );
+has '_reset_system_prompt' => ( is => 'rw', default => sub { undef } );
+has '_reset_user_prompt'   => ( is => 'rw', default => sub { undef } );
+has '_reset_consolidate'   => ( is => 'rw', default => sub { 0 } );
+has '_reset_full_reset'    => ( is => 'rw', default => sub { 0 } );
 
 sub set_text {
-    my ($self, $text) = @_;
+    my ( $self, $text ) = @_;
     die "Cannot use set_text() when POM sections have been added"
         if @{ $self->_sections };
     $self->_text($text);
@@ -113,7 +113,7 @@ sub set_text {
 }
 
 sub add_section {
-    my ($self, $title, $body) = @_;
+    my ( $self, $title, $body ) = @_;
     die "Cannot add POM sections when set_text() has been used"
         if defined $self->_text;
     push @{ $self->_sections }, { title => $title, body => $body };
@@ -121,7 +121,7 @@ sub add_section {
 }
 
 sub add_bullets {
-    my ($self, $title, $bullets) = @_;
+    my ( $self, $title, $bullets ) = @_;
     die "Cannot add POM sections when set_text() has been used"
         if defined $self->_text;
     push @{ $self->_sections }, { title => $title, bullets => $bullets };
@@ -129,7 +129,7 @@ sub add_bullets {
 }
 
 sub set_step_criteria {
-    my ($self, $criteria) = @_;
+    my ( $self, $criteria ) = @_;
     $self->_step_criteria($criteria);
     return $self;
 }
@@ -165,19 +165,19 @@ sub set_step_criteria {
 # this list and do not need to appear in it.
 #
 sub set_functions {
-    my ($self, $functions) = @_;
+    my ( $self, $functions ) = @_;
     $self->_functions($functions);
     return $self;
 }
 
 sub set_valid_steps {
-    my ($self, $steps) = @_;
+    my ( $self, $steps ) = @_;
     $self->_valid_steps($steps);
     return $self;
 }
 
 sub set_valid_contexts {
-    my ($self, $contexts) = @_;
+    my ( $self, $contexts ) = @_;
     $self->_valid_contexts($contexts);
     return $self;
 }
@@ -195,30 +195,32 @@ sub set_valid_contexts {
 # To actually end the call, call a hangup tool or define a hangup hook.
 #
 sub set_end {
-    my ($self, $end) = @_;
-    $self->_end($end ? 1 : 0);
+    my ( $self, $end ) = @_;
+    $self->_end( $end ? 1 : 0 );
     return $self;
 }
 
 sub set_skip_user_turn {
-    my ($self, $skip) = @_;
-    $self->_skip_user_turn($skip ? 1 : 0);
+    my ( $self, $skip ) = @_;
+    $self->_skip_user_turn( $skip ? 1 : 0 );
     return $self;
 }
 
 sub set_skip_to_next_step {
-    my ($self, $skip) = @_;
-    $self->_skip_to_next_step($skip ? 1 : 0);
+    my ( $self, $skip ) = @_;
+    $self->_skip_to_next_step( $skip ? 1 : 0 );
     return $self;
 }
 
 sub set_gather_info {
-    my ($self, %opts) = @_;
-    $self->_gather_info(SignalWire::Contexts::GatherInfo->new(
-        _output_key       => $opts{output_key},
-        _completion_action => $opts{completion_action},
-        _prompt           => $opts{prompt},
-    ));
+    my ( $self, %opts ) = @_;
+    $self->_gather_info(
+        SignalWire::Contexts::GatherInfo->new(
+            _output_key        => $opts{output_key},
+            _completion_action => $opts{completion_action},
+            _prompt            => $opts{prompt},
+        )
+    );
     return $self;
 }
 
@@ -243,7 +245,7 @@ sub set_gather_info {
 #   option. Functions listed here are active ONLY for this question.
 #
 sub add_gather_question {
-    my ($self, %opts) = @_;
+    my ( $self, %opts ) = @_;
     die "Must call set_gather_info() before add_gather_question()"
         unless defined $self->_gather_info;
     $self->_gather_info->add_question(%opts);
@@ -252,32 +254,32 @@ sub add_gather_question {
 
 sub clear_sections {
     my ($self) = @_;
-    $self->_sections([]);
+    $self->_sections( [] );
     $self->_text(undef);
     return $self;
 }
 
 sub set_reset_system_prompt {
-    my ($self, $sp) = @_;
+    my ( $self, $sp ) = @_;
     $self->_reset_system_prompt($sp);
     return $self;
 }
 
 sub set_reset_user_prompt {
-    my ($self, $up) = @_;
+    my ( $self, $up ) = @_;
     $self->_reset_user_prompt($up);
     return $self;
 }
 
 sub set_reset_consolidate {
-    my ($self, $c) = @_;
-    $self->_reset_consolidate($c ? 1 : 0);
+    my ( $self, $c ) = @_;
+    $self->_reset_consolidate( $c ? 1 : 0 );
     return $self;
 }
 
 sub set_reset_full_reset {
-    my ($self, $fr) = @_;
-    $self->_reset_full_reset($fr ? 1 : 0);
+    my ( $self, $fr ) = @_;
+    $self->_reset_full_reset( $fr ? 1 : 0 );
     return $self;
 }
 
@@ -289,8 +291,8 @@ sub _render_text {
         unless @{ $self->_sections };
 
     my @parts;
-    for my $sec (@{ $self->_sections }) {
-        if (exists $sec->{bullets}) {
+    for my $sec ( @{ $self->_sections } ) {
+        if ( exists $sec->{bullets} ) {
             push @parts, "## $sec->{title}";
             push @parts, map { "- $_" } @{ $sec->{bullets} };
         } else {
@@ -299,7 +301,7 @@ sub _render_text {
         }
         push @parts, '';
     }
-    my $text = join("\n", @parts);
+    my $text = join( "\n", @parts );
     $text =~ s/\s+$//;
     return $text;
 }
@@ -311,20 +313,20 @@ sub to_hash {
         text => $self->_render_text,
     );
 
-    $d{step_criteria}  = $self->_step_criteria  if defined $self->_step_criteria;
-    $d{functions}      = $self->_functions       if defined $self->_functions;
-    $d{valid_steps}    = $self->_valid_steps     if defined $self->_valid_steps;
-    $d{valid_contexts} = $self->_valid_contexts  if defined $self->_valid_contexts;
-    $d{end}            = JSON::true              if $self->_end;
-    $d{skip_user_turn} = JSON::true              if $self->_skip_user_turn;
-    $d{skip_to_next_step} = JSON::true           if $self->_skip_to_next_step;
+    $d{step_criteria}     = $self->_step_criteria  if defined $self->_step_criteria;
+    $d{functions}         = $self->_functions      if defined $self->_functions;
+    $d{valid_steps}       = $self->_valid_steps    if defined $self->_valid_steps;
+    $d{valid_contexts}    = $self->_valid_contexts if defined $self->_valid_contexts;
+    $d{end}               = JSON::true             if $self->_end;
+    $d{skip_user_turn}    = JSON::true             if $self->_skip_user_turn;
+    $d{skip_to_next_step} = JSON::true             if $self->_skip_to_next_step;
 
     my %reset;
     $reset{system_prompt} = $self->_reset_system_prompt if defined $self->_reset_system_prompt;
     $reset{user_prompt}   = $self->_reset_user_prompt   if defined $self->_reset_user_prompt;
     $reset{consolidate}   = JSON::true                  if $self->_reset_consolidate;
     $reset{full_reset}    = JSON::true                  if $self->_reset_full_reset;
-    $d{reset} = \%reset if keys %reset;
+    $d{reset}             = \%reset                     if keys %reset;
 
     $d{gather_info} = $self->_gather_info->to_hash if defined $self->_gather_info;
 
@@ -338,66 +340,66 @@ package SignalWire::Contexts::Context;
 use Moo;
 use JSON ();
 
-has 'name' => (is => 'ro', required => 1);
+has 'name' => ( is => 'ro', required => 1 );
 
-has '_steps'           => (is => 'rw', default => sub { {} });
-has '_step_order'      => (is => 'rw', default => sub { [] });
-has '_valid_contexts'  => (is => 'rw', default => sub { undef });
-has '_valid_steps'     => (is => 'rw', default => sub { undef });
-has '_initial_step'    => (is => 'rw', default => sub { undef });
-has '_post_prompt'     => (is => 'rw', default => sub { undef });
-has '_system_prompt'   => (is => 'rw', default => sub { undef });
-has '_system_prompt_sections' => (is => 'rw', default => sub { [] });
-has '_consolidate'     => (is => 'rw', default => sub { 0 });
-has '_full_reset'      => (is => 'rw', default => sub { 0 });
-has '_user_prompt'     => (is => 'rw', default => sub { undef });
-has '_isolated'        => (is => 'rw', default => sub { 0 });
-has '_prompt_text'     => (is => 'rw', default => sub { undef });
-has '_prompt_sections' => (is => 'rw', default => sub { [] });
-has '_enter_fillers'   => (is => 'rw', default => sub { undef });
-has '_exit_fillers'    => (is => 'rw', default => sub { undef });
+has '_steps'                  => ( is => 'rw', default => sub { {} } );
+has '_step_order'             => ( is => 'rw', default => sub { [] } );
+has '_valid_contexts'         => ( is => 'rw', default => sub { undef } );
+has '_valid_steps'            => ( is => 'rw', default => sub { undef } );
+has '_initial_step'           => ( is => 'rw', default => sub { undef } );
+has '_post_prompt'            => ( is => 'rw', default => sub { undef } );
+has '_system_prompt'          => ( is => 'rw', default => sub { undef } );
+has '_system_prompt_sections' => ( is => 'rw', default => sub { [] } );
+has '_consolidate'            => ( is => 'rw', default => sub { 0 } );
+has '_full_reset'             => ( is => 'rw', default => sub { 0 } );
+has '_user_prompt'            => ( is => 'rw', default => sub { undef } );
+has '_isolated'               => ( is => 'rw', default => sub { 0 } );
+has '_prompt_text'            => ( is => 'rw', default => sub { undef } );
+has '_prompt_sections'        => ( is => 'rw', default => sub { [] } );
+has '_enter_fillers'          => ( is => 'rw', default => sub { undef } );
+has '_exit_fillers'           => ( is => 'rw', default => sub { undef } );
 
 sub add_step {
-    my ($self, $name, %opts) = @_;
+    my ( $self, $name, %opts ) = @_;
     die "Step '$name' already exists in context '" . $self->name . "'"
         if exists $self->_steps->{$name};
     die "Maximum steps per context ($SignalWire::Contexts::MAX_STEPS_PER_CONTEXT) exceeded"
         if keys %{ $self->_steps } >= $SignalWire::Contexts::MAX_STEPS_PER_CONTEXT;
 
-    my $step = SignalWire::Contexts::Step->new(name => $name);
+    my $step = SignalWire::Contexts::Step->new( name => $name );
     $self->_steps->{$name} = $step;
     push @{ $self->_step_order }, $name;
 
-    $step->add_section('Task', $opts{task})     if defined $opts{task};
-    $step->add_bullets('Process', $opts{bullets}) if defined $opts{bullets};
-    $step->set_step_criteria($opts{criteria})     if defined $opts{criteria};
-    $step->set_functions($opts{functions})         if defined $opts{functions};
-    $step->set_valid_steps($opts{valid_steps})     if defined $opts{valid_steps};
+    $step->add_section( 'Task', $opts{task} )       if defined $opts{task};
+    $step->add_bullets( 'Process', $opts{bullets} ) if defined $opts{bullets};
+    $step->set_step_criteria( $opts{criteria} )     if defined $opts{criteria};
+    $step->set_functions( $opts{functions} )        if defined $opts{functions};
+    $step->set_valid_steps( $opts{valid_steps} )    if defined $opts{valid_steps};
 
     return $step;
 }
 
 sub get_step {
-    my ($self, $name) = @_;
+    my ( $self, $name ) = @_;
     return $self->_steps->{$name};
 }
 
 sub remove_step {
-    my ($self, $name) = @_;
-    if (exists $self->_steps->{$name}) {
+    my ( $self, $name ) = @_;
+    if ( exists $self->_steps->{$name} ) {
         delete $self->_steps->{$name};
-        $self->_step_order([ grep { $_ ne $name } @{ $self->_step_order } ]);
+        $self->_step_order( [ grep { $_ ne $name } @{ $self->_step_order } ] );
     }
     return $self;
 }
 
 sub move_step {
-    my ($self, $name, $position) = @_;
+    my ( $self, $name, $position ) = @_;
     die "Step '$name' not found in context '" . $self->name . "'"
         unless exists $self->_steps->{$name};
     my @order = grep { $_ ne $name } @{ $self->_step_order };
     splice @order, $position, 0, $name;
-    $self->_step_order(\@order);
+    $self->_step_order( \@order );
     return $self;
 }
 
@@ -408,31 +410,31 @@ sub move_step {
 # to skip a preamble step on re-entry via change_context.
 #
 sub set_initial_step {
-    my ($self, $step_name) = @_;
+    my ( $self, $step_name ) = @_;
     $self->_initial_step($step_name);
     return $self;
 }
 
 sub set_valid_contexts {
-    my ($self, $contexts) = @_;
+    my ( $self, $contexts ) = @_;
     $self->_valid_contexts($contexts);
     return $self;
 }
 
 sub set_valid_steps {
-    my ($self, $steps) = @_;
+    my ( $self, $steps ) = @_;
     $self->_valid_steps($steps);
     return $self;
 }
 
 sub set_post_prompt {
-    my ($self, $pp) = @_;
+    my ( $self, $pp ) = @_;
     $self->_post_prompt($pp);
     return $self;
 }
 
 sub set_system_prompt {
-    my ($self, $sp) = @_;
+    my ( $self, $sp ) = @_;
     die "Cannot use set_system_prompt() when POM sections have been added for system prompt"
         if @{ $self->_system_prompt_sections };
     $self->_system_prompt($sp);
@@ -440,19 +442,19 @@ sub set_system_prompt {
 }
 
 sub set_consolidate {
-    my ($self, $c) = @_;
-    $self->_consolidate($c ? 1 : 0);
+    my ( $self, $c ) = @_;
+    $self->_consolidate( $c ? 1 : 0 );
     return $self;
 }
 
 sub set_full_reset {
-    my ($self, $fr) = @_;
-    $self->_full_reset($fr ? 1 : 0);
+    my ( $self, $fr ) = @_;
+    $self->_full_reset( $fr ? 1 : 0 );
     return $self;
 }
 
 sub set_user_prompt {
-    my ($self, $up) = @_;
+    my ( $self, $up ) = @_;
     $self->_user_prompt($up);
     return $self;
 }
@@ -477,13 +479,13 @@ sub set_user_prompt {
 # after a long off-topic detour.
 #
 sub set_isolated {
-    my ($self, $iso) = @_;
-    $self->_isolated($iso ? 1 : 0);
+    my ( $self, $iso ) = @_;
+    $self->_isolated( $iso ? 1 : 0 );
     return $self;
 }
 
 sub add_system_section {
-    my ($self, $title, $body) = @_;
+    my ( $self, $title, $body ) = @_;
     die "Cannot add POM sections for system prompt when set_system_prompt() has been used"
         if defined $self->_system_prompt;
     push @{ $self->_system_prompt_sections }, { title => $title, body => $body };
@@ -491,7 +493,7 @@ sub add_system_section {
 }
 
 sub add_system_bullets {
-    my ($self, $title, $bullets) = @_;
+    my ( $self, $title, $bullets ) = @_;
     die "Cannot add POM sections for system prompt when set_system_prompt() has been used"
         if defined $self->_system_prompt;
     push @{ $self->_system_prompt_sections }, { title => $title, bullets => $bullets };
@@ -499,7 +501,7 @@ sub add_system_bullets {
 }
 
 sub set_prompt {
-    my ($self, $prompt) = @_;
+    my ( $self, $prompt ) = @_;
     die "Cannot use set_prompt() when POM sections have been added"
         if @{ $self->_prompt_sections };
     $self->_prompt_text($prompt);
@@ -507,7 +509,7 @@ sub set_prompt {
 }
 
 sub add_section {
-    my ($self, $title, $body) = @_;
+    my ( $self, $title, $body ) = @_;
     die "Cannot add POM sections when set_prompt() has been used"
         if defined $self->_prompt_text;
     push @{ $self->_prompt_sections }, { title => $title, body => $body };
@@ -515,7 +517,7 @@ sub add_section {
 }
 
 sub add_bullets {
-    my ($self, $title, $bullets) = @_;
+    my ( $self, $title, $bullets ) = @_;
     die "Cannot add POM sections when set_prompt() has been used"
         if defined $self->_prompt_text;
     push @{ $self->_prompt_sections }, { title => $title, bullets => $bullets };
@@ -523,30 +525,30 @@ sub add_bullets {
 }
 
 sub set_enter_fillers {
-    my ($self, $fillers) = @_;
+    my ( $self, $fillers ) = @_;
     $self->_enter_fillers($fillers) if ref $fillers eq 'HASH';
     return $self;
 }
 
 sub set_exit_fillers {
-    my ($self, $fillers) = @_;
+    my ( $self, $fillers ) = @_;
     $self->_exit_fillers($fillers) if ref $fillers eq 'HASH';
     return $self;
 }
 
 sub add_enter_filler {
-    my ($self, $lang, $fillers) = @_;
-    if ($lang && ref $fillers eq 'ARRAY') {
-        $self->_enter_fillers({}) unless defined $self->_enter_fillers;
+    my ( $self, $lang, $fillers ) = @_;
+    if ( $lang && ref $fillers eq 'ARRAY' ) {
+        $self->_enter_fillers( {} ) unless defined $self->_enter_fillers;
         $self->_enter_fillers->{$lang} = $fillers;
     }
     return $self;
 }
 
 sub add_exit_filler {
-    my ($self, $lang, $fillers) = @_;
-    if ($lang && ref $fillers eq 'ARRAY') {
-        $self->_exit_fillers({}) unless defined $self->_exit_fillers;
+    my ( $self, $lang, $fillers ) = @_;
+    if ( $lang && ref $fillers eq 'ARRAY' ) {
+        $self->_exit_fillers( {} ) unless defined $self->_exit_fillers;
         $self->_exit_fillers->{$lang} = $fillers;
     }
     return $self;
@@ -556,21 +558,21 @@ sub _render_prompt {
     my ($self) = @_;
     return $self->_prompt_text if defined $self->_prompt_text;
     return undef unless @{ $self->_prompt_sections };
-    return _render_sections($self->_prompt_sections);
+    return _render_sections( $self->_prompt_sections );
 }
 
 sub _render_system_prompt {
     my ($self) = @_;
     return $self->_system_prompt if defined $self->_system_prompt;
     return undef unless @{ $self->_system_prompt_sections };
-    return _render_sections($self->_system_prompt_sections);
+    return _render_sections( $self->_system_prompt_sections );
 }
 
 sub _render_sections {
     my ($sections) = @_;
     my @parts;
     for my $sec (@$sections) {
-        if (exists $sec->{bullets}) {
+        if ( exists $sec->{bullets} ) {
             push @parts, "## $sec->{title}";
             push @parts, map { "- $_" } @{ $sec->{bullets} };
         } else {
@@ -579,7 +581,7 @@ sub _render_sections {
         }
         push @parts, '';
     }
-    my $text = join("\n", @parts);
+    my $text = join( "\n", @parts );
     $text =~ s/\s+$//;
     return $text;
 }
@@ -589,9 +591,7 @@ sub to_hash {
     die "Context '" . $self->name . "' has no steps defined"
         unless keys %{ $self->_steps };
 
-    my %d = (
-        steps => [ map { $self->_steps->{$_}->to_hash } @{ $self->_step_order } ],
-    );
+    my %d = ( steps => [ map { $self->_steps->{$_}->to_hash } @{ $self->_step_order } ], );
 
     $d{valid_contexts} = $self->_valid_contexts if defined $self->_valid_contexts;
     $d{valid_steps}    = $self->_valid_steps    if defined $self->_valid_steps;
@@ -601,14 +601,14 @@ sub to_hash {
     my $sp = $self->_render_system_prompt;
     $d{system_prompt} = $sp if defined $sp;
 
-    $d{consolidate} = JSON::true if $self->_consolidate;
-    $d{full_reset}  = JSON::true if $self->_full_reset;
+    $d{consolidate} = JSON::true          if $self->_consolidate;
+    $d{full_reset}  = JSON::true          if $self->_full_reset;
     $d{user_prompt} = $self->_user_prompt if defined $self->_user_prompt;
-    $d{isolated}    = JSON::true if $self->_isolated;
+    $d{isolated}    = JSON::true          if $self->_isolated;
 
-    if (@{ $self->_prompt_sections }) {
+    if ( @{ $self->_prompt_sections } ) {
         $d{pom} = $self->_prompt_sections;
-    } elsif (defined $self->_prompt_text) {
+    } elsif ( defined $self->_prompt_text ) {
         $d{prompt} = $self->_prompt_text;
     }
 
@@ -654,50 +654,51 @@ sub to_hash {
 #
 package SignalWire::Contexts::ContextBuilder;
 use Moo;
-use JSON ();
+use JSON         ();
 use Scalar::Util ();
 
-has '_contexts'      => (is => 'rw', default => sub { {} });
-has '_context_order' => (is => 'rw', default => sub { [] });
+has '_contexts'      => ( is => 'rw', default => sub { {} } );
+has '_context_order' => ( is => 'rw', default => sub { [] } );
+
 # Weak reference to the owning agent so validate() can check
 # user-defined tool names against RESERVED_NATIVE_TOOL_NAMES. Set via
 # attach_agent(); AgentBase->define_contexts wires this up automatically.
-has '_agent' => (is => 'rw', default => sub { undef });
+has '_agent' => ( is => 'rw', default => sub { undef } );
 
 sub attach_agent {
-    my ($self, $agent) = @_;
+    my ( $self, $agent ) = @_;
     $self->_agent($agent);
-    Scalar::Util::weaken($self->{_agent}) if defined $agent;
+    Scalar::Util::weaken( $self->{_agent} ) if defined $agent;
     return $self;
 }
 
 sub reset {
     my ($self) = @_;
-    $self->_contexts({});
-    $self->_context_order([]);
+    $self->_contexts( {} );
+    $self->_context_order( [] );
     return $self;
 }
 
 sub add_context {
-    my ($self, $name) = @_;
+    my ( $self, $name ) = @_;
     die "Context '$name' already exists" if exists $self->_contexts->{$name};
     die "Maximum number of contexts ($SignalWire::Contexts::MAX_CONTEXTS) exceeded"
         if keys %{ $self->_contexts } >= $SignalWire::Contexts::MAX_CONTEXTS;
 
-    my $ctx = SignalWire::Contexts::Context->new(name => $name);
+    my $ctx = SignalWire::Contexts::Context->new( name => $name );
     $self->_contexts->{$name} = $ctx;
     push @{ $self->_context_order }, $name;
     return $ctx;
 }
 
 sub get_context {
-    my ($self, $name) = @_;
+    my ( $self, $name ) = @_;
     return $self->_contexts->{$name};
 }
 
 sub has_contexts {
     my ($self) = @_;
-    return scalar(keys %{ $self->_contexts }) ? 1 : 0;
+    return scalar( keys %{ $self->_contexts } ) ? 1 : 0;
 }
 
 sub validate {
@@ -705,38 +706,37 @@ sub validate {
     die "At least one context must be defined" unless keys %{ $self->_contexts };
 
     # Single context must be "default"
-    if (keys %{ $self->_contexts } == 1) {
+    if ( keys %{ $self->_contexts } == 1 ) {
         my ($name) = keys %{ $self->_contexts };
         die 'When using a single context, it must be named "default"'
             unless $name eq 'default';
     }
 
     # Each context must have steps
-    for my $cname (keys %{ $self->_contexts }) {
+    for my $cname ( keys %{ $self->_contexts } ) {
         my $ctx = $self->_contexts->{$cname};
         die "Context '$cname' must have at least one step"
             unless keys %{ $ctx->_steps };
     }
 
     # Validate initial_step references a real step in the context
-    for my $cname (keys %{ $self->_contexts }) {
+    for my $cname ( keys %{ $self->_contexts } ) {
         my $ctx = $self->_contexts->{$cname};
-        if (defined $ctx->_initial_step) {
+        if ( defined $ctx->_initial_step ) {
             die "Context '$cname' has initial_step='${\$ctx->_initial_step}' "
                 . "but that step does not exist. Available steps: ["
-                . join(', ', map { "'$_'" } sort keys %{ $ctx->_steps })
-                . "]"
+                . join( ', ', map { "'$_'" } sort keys %{ $ctx->_steps } ) . "]"
                 unless exists $ctx->_steps->{ $ctx->_initial_step };
         }
     }
 
     # Validate step references in valid_steps
-    for my $cname (keys %{ $self->_contexts }) {
+    for my $cname ( keys %{ $self->_contexts } ) {
         my $ctx = $self->_contexts->{$cname};
-        for my $sname (keys %{ $ctx->_steps }) {
+        for my $sname ( keys %{ $ctx->_steps } ) {
             my $step = $ctx->_steps->{$sname};
-            if (defined $step->_valid_steps) {
-                for my $vs (@{ $step->_valid_steps }) {
+            if ( defined $step->_valid_steps ) {
+                for my $vs ( @{ $step->_valid_steps } ) {
                     next if $vs eq 'next';
                     die "Step '$sname' in context '$cname' references unknown step '$vs'"
                         unless exists $ctx->_steps->{$vs};
@@ -746,18 +746,18 @@ sub validate {
     }
 
     # Validate context references (context-level and step-level)
-    for my $cname (keys %{ $self->_contexts }) {
+    for my $cname ( keys %{ $self->_contexts } ) {
         my $ctx = $self->_contexts->{$cname};
-        if (defined $ctx->_valid_contexts) {
-            for my $vc (@{ $ctx->_valid_contexts }) {
+        if ( defined $ctx->_valid_contexts ) {
+            for my $vc ( @{ $ctx->_valid_contexts } ) {
                 die "Context '$cname' references unknown context '$vc'"
                     unless exists $self->_contexts->{$vc};
             }
         }
-        for my $sname (keys %{ $ctx->_steps }) {
+        for my $sname ( keys %{ $ctx->_steps } ) {
             my $step = $ctx->_steps->{$sname};
-            if (defined $step->_valid_contexts) {
-                for my $vc (@{ $step->_valid_contexts }) {
+            if ( defined $step->_valid_contexts ) {
+                for my $vc ( @{ $step->_valid_contexts } ) {
                     die "Step '$sname' in context '$cname' references unknown context '$vc'"
                         unless exists $self->_contexts->{$vc};
                 }
@@ -766,27 +766,28 @@ sub validate {
     }
 
     # Validate gather_info
-    for my $cname (keys %{ $self->_contexts }) {
+    for my $cname ( keys %{ $self->_contexts } ) {
         my $ctx = $self->_contexts->{$cname};
-        for my $sname (keys %{ $ctx->_steps }) {
+        for my $sname ( keys %{ $ctx->_steps } ) {
             my $step = $ctx->_steps->{$sname};
-            if (defined $step->_gather_info) {
+            if ( defined $step->_gather_info ) {
                 die "Step '$sname' in context '$cname' has gather_info with no questions"
                     unless @{ $step->_gather_info->_questions };
 
                 my %seen;
-                for my $q (@{ $step->_gather_info->_questions }) {
-                    die "Step '$sname' in context '$cname' has duplicate gather_info question key '${\$q->key}'"
+                for my $q ( @{ $step->_gather_info->_questions } ) {
+                    die
+"Step '$sname' in context '$cname' has duplicate gather_info question key '${\$q->key}'"
                         if $seen{ $q->key }++;
                 }
 
                 my $action = $step->_gather_info->_completion_action;
-                if (defined $action) {
-                    if ($action eq 'next_step') {
+                if ( defined $action ) {
+                    if ( $action eq 'next_step' ) {
                         my $idx;
                         my @order = @{ $ctx->_step_order };
-                        for my $i (0 .. $#order) {
-                            if ($order[$i] eq $sname) { $idx = $i; last }
+                        for my $i ( 0 .. $#order ) {
+                            if ( $order[$i] eq $sname ) { $idx = $i; last }
                         }
                         die "Step '$sname' in context '$cname' has gather_info "
                             . "completion_action='next_step' but it is the last "
@@ -797,14 +798,15 @@ sub validate {
                             . "(3) set completion_action=undef (default) to "
                             . "stay in '$sname' after gathering completes."
                             if defined $idx && $idx >= $#order;
-                    } elsif (!exists $ctx->_steps->{$action}) {
+                    } elsif ( !exists $ctx->_steps->{$action} ) {
                         my @available = sort keys %{ $ctx->_steps };
                         die "Step '$sname' in context '$cname' has gather_info "
                             . "completion_action='$action' but '$action' is not "
                             . "a step in this context. Valid options: "
                             . "'next_step' (advance to the next sequential "
                             . "step), undef (stay in the current step), or "
-                            . "one of [" . join(', ', map { "'$_'" } @available) . "].";
+                            . "one of ["
+                            . join( ', ', map { "'$_'" } @available ) . "].";
                     }
                 }
             }
@@ -815,7 +817,7 @@ sub validate {
     # native tool names. The runtime auto-injects next_step /
     # change_context / gather_submit when contexts/steps are present, so
     # user tools sharing those names would never be called.
-    if (defined $self->_agent && $self->_agent->can('list_tool_names')) {
+    if ( defined $self->_agent && $self->_agent->can('list_tool_names') ) {
         my @registered = $self->_agent->list_tool_names;
         my @colliding;
         for my $name (@registered) {
@@ -823,13 +825,13 @@ sub validate {
                 if exists $SignalWire::Contexts::RESERVED_NATIVE_TOOL_NAMES{$name};
         }
         if (@colliding) {
-            my @sorted = sort @colliding;
+            my @sorted   = sort @colliding;
             my @reserved = sort keys %SignalWire::Contexts::RESERVED_NATIVE_TOOL_NAMES;
             die "Tool name(s) ["
-                . join(', ', map { "'$_'" } @sorted)
+                . join( ', ', map { "'$_'" } @sorted )
                 . "] collide with reserved native tools auto-injected by "
                 . "contexts/steps. The names ["
-                . join(', ', map { "'$_'" } @reserved)
+                . join( ', ', map { "'$_'" } @reserved )
                 . "] are reserved and cannot be used for user-defined SWAIG "
                 . "tools when contexts/steps are in use. Rename your "
                 . "tool(s) to avoid the collision.";
@@ -842,7 +844,7 @@ sub to_hash {
     $self->validate;
 
     my %result;
-    for my $cname (@{ $self->_context_order }) {
+    for my $cname ( @{ $self->_context_order } ) {
         $result{$cname} = $self->_contexts->{$cname}->to_hash;
     }
     return \%result;
@@ -858,13 +860,14 @@ package SignalWire::Contexts;
 # Both forms collapse to a single optional ``$name`` argument.
 sub create_simple_context {
     my ($name) = @_;
-    if (defined $name && !ref($name) && $name eq __PACKAGE__) {
+    if ( defined $name && !ref($name) && $name eq __PACKAGE__ ) {
+
         # Class-method invocation form — drop the receiver, shift remaining.
         shift;
         $name = $_[0];
     }
     $name //= 'default';
-    return SignalWire::Contexts::Context->new(name => $name);
+    return SignalWire::Contexts::Context->new( name => $name );
 }
 
 1;

--- a/lib/SignalWire/Contexts/ContextBuilder.pm
+++ b/lib/SignalWire/Contexts/ContextBuilder.pm
@@ -1,4 +1,5 @@
 package SignalWire::Contexts::ContextBuilder;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #

--- a/lib/SignalWire/Core/LoggingConfig.pm
+++ b/lib/SignalWire/Core/LoggingConfig.pm
@@ -31,15 +31,18 @@ sub get_logger {
 # Returns one of: 'cgi', 'lambda', 'google_cloud_function',
 # 'azure_function', or 'server'.
 sub get_execution_mode {
-    return 'cgi'                    if _is_set('GATEWAY_INTERFACE');
-    return 'lambda'                 if _is_set('AWS_LAMBDA_FUNCTION_NAME')
-                                    || _is_set('LAMBDA_TASK_ROOT');
-    return 'google_cloud_function'  if _is_set('FUNCTION_TARGET')
-                                    || _is_set('K_SERVICE')
-                                    || _is_set('GOOGLE_CLOUD_PROJECT');
-    return 'azure_function'         if _is_set('AZURE_FUNCTIONS_ENVIRONMENT')
-                                    || _is_set('FUNCTIONS_WORKER_RUNTIME')
-                                    || _is_set('AzureWebJobsStorage');
+    return 'cgi' if _is_set('GATEWAY_INTERFACE');
+    return 'lambda'
+        if _is_set('AWS_LAMBDA_FUNCTION_NAME')
+        || _is_set('LAMBDA_TASK_ROOT');
+    return 'google_cloud_function'
+        if _is_set('FUNCTION_TARGET')
+        || _is_set('K_SERVICE')
+        || _is_set('GOOGLE_CLOUD_PROJECT');
+    return 'azure_function'
+        if _is_set('AZURE_FUNCTIONS_ENVIRONMENT')
+        || _is_set('FUNCTIONS_WORKER_RUNTIME')
+        || _is_set('AzureWebJobsStorage');
     return 'server';
 }
 

--- a/lib/SignalWire/DataMap.pm
+++ b/lib/SignalWire/DataMap.pm
@@ -46,9 +46,9 @@ has '_error_keys' => (
 
 # Constructor shortcut: DataMap->new("name") or DataMap->new(function_name => "name")
 around BUILDARGS => sub {
-    my ($orig, $class, @args) = @_;
-    if (@args == 1 && !ref $args[0]) {
-        return $class->$orig(function_name => $args[0]);
+    my ( $orig, $class, @args ) = @_;
+    if ( @args == 1 && !ref $args[0] ) {
+        return $class->$orig( function_name => $args[0] );
     }
     return $class->$orig(@args);
 };
@@ -72,7 +72,7 @@ around BUILDARGS => sub {
 #                 . 'conditions in a named location.')
 #
 sub purpose {
-    my ($self, $desc) = @_;
+    my ( $self, $desc ) = @_;
     $self->_purpose($desc);
     return $self;
 }
@@ -83,7 +83,7 @@ sub purpose {
 # this tool. See purpose() for bad-vs-good examples.
 #
 sub description {
-    my ($self, $desc) = @_;
+    my ( $self, $desc ) = @_;
     return $self->purpose($desc);
 }
 
@@ -106,7 +106,7 @@ sub description {
 #           . 'ambiguous.')
 #
 sub parameter {
-    my ($self, $name, $type, $description, %opts) = @_;
+    my ( $self, $name, $type, $description, %opts ) = @_;
     my $required = $opts{required} // 0;
     my $enum     = $opts{enum};
 
@@ -127,12 +127,13 @@ sub parameter {
 }
 
 sub expression {
-    my ($self, $test_value, $pattern, $output, %opts) = @_;
+    my ( $self, $test_value, $pattern, $output, %opts ) = @_;
     my $nomatch_output = $opts{nomatch_output};
 
     # If pattern is a compiled regex, extract the string
-    if (ref $pattern eq 'Regexp') {
+    if ( ref $pattern eq 'Regexp' ) {
         $pattern = "$pattern";
+
         # Strip Perl regex delimiters: (?^:...) or (?^u:...)
         $pattern =~ s/^\(\?[\^a-z]*://;
         $pattern =~ s/\)$//;
@@ -150,27 +151,27 @@ sub expression {
 }
 
 sub webhook {
-    my ($self, $method, $url, %opts) = @_;
-    my $headers            = $opts{headers};
-    my $form_param         = $opts{form_param};
+    my ( $self, $method, $url, %opts ) = @_;
+    my $headers              = $opts{headers};
+    my $form_param           = $opts{form_param};
     my $input_args_as_params = $opts{input_args_as_params};
-    my $require_args       = $opts{require_args};
+    my $require_args         = $opts{require_args};
 
     my %wh = (
         url    => $url,
         method => uc($method),
     );
-    $wh{headers}            = $headers            if $headers;
-    $wh{form_param}         = $form_param         if $form_param;
-    $wh{input_args_as_params} = JSON::true        if $input_args_as_params;
-    $wh{require_args}       = $require_args       if $require_args;
+    $wh{headers}              = $headers      if $headers;
+    $wh{form_param}           = $form_param   if $form_param;
+    $wh{input_args_as_params} = JSON::true    if $input_args_as_params;
+    $wh{require_args}         = $require_args if $require_args;
 
     push @{ $self->_webhooks }, \%wh;
     return $self;
 }
 
 sub webhook_expressions {
-    my ($self, $expressions) = @_;
+    my ( $self, $expressions ) = @_;
     die "Must add webhook before setting webhook expressions"
         unless @{ $self->_webhooks };
     $self->_webhooks->[-1]{expressions} = $expressions;
@@ -178,7 +179,7 @@ sub webhook_expressions {
 }
 
 sub body {
-    my ($self, $data) = @_;
+    my ( $self, $data ) = @_;
     die "Must add webhook before setting body"
         unless @{ $self->_webhooks };
     $self->_webhooks->[-1]{body} = $data;
@@ -186,7 +187,7 @@ sub body {
 }
 
 sub params {
-    my ($self, $data) = @_;
+    my ( $self, $data ) = @_;
     die "Must add webhook before setting params"
         unless @{ $self->_webhooks };
     $self->_webhooks->[-1]{params} = $data;
@@ -194,7 +195,7 @@ sub params {
 }
 
 sub foreach {
-    my ($self, $config) = @_;
+    my ( $self, $config ) = @_;
     die "Must add webhook before setting foreach"
         unless @{ $self->_webhooks };
     die "foreach_config must be a hashref" unless ref $config eq 'HASH';
@@ -209,7 +210,7 @@ sub foreach {
 }
 
 sub output {
-    my ($self, $result) = @_;
+    my ( $self, $result ) = @_;
     die "Must add webhook before setting output"
         unless @{ $self->_webhooks };
     $self->_webhooks->[-1]{output} = $result->to_hash;
@@ -217,14 +218,14 @@ sub output {
 }
 
 sub fallback_output {
-    my ($self, $result) = @_;
-    $self->_output($result->to_hash);
+    my ( $self, $result ) = @_;
+    $self->_output( $result->to_hash );
     return $self;
 }
 
 sub error_keys {
-    my ($self, $keys) = @_;
-    if (@{ $self->_webhooks }) {
+    my ( $self, $keys ) = @_;
+    if ( @{ $self->_webhooks } ) {
         $self->_webhooks->[-1]{error_keys} = $keys;
     } else {
         $self->_error_keys($keys);
@@ -233,7 +234,7 @@ sub error_keys {
 }
 
 sub global_error_keys {
-    my ($self, $keys) = @_;
+    my ( $self, $keys ) = @_;
     $self->_error_keys($keys);
     return $self;
 }
@@ -243,28 +244,28 @@ sub to_swaig_function {
 
     # Build parameter schema
     my %param_schema;
-    if (keys %{ $self->_parameters }) {
+    if ( keys %{ $self->_parameters } ) {
         $param_schema{type}       = 'object';
         $param_schema{properties} = { %{ $self->_parameters } };
-        if (@{ $self->_required_params }) {
+        if ( @{ $self->_required_params } ) {
             $param_schema{required} = [ @{ $self->_required_params } ];
         }
     } else {
-        %param_schema = (type => 'object', properties => {});
+        %param_schema = ( type => 'object', properties => {} );
     }
 
     # Build data_map
     my %data_map;
-    if (@{ $self->_expressions }) {
+    if ( @{ $self->_expressions } ) {
         $data_map{expressions} = $self->_expressions;
     }
-    if (@{ $self->_webhooks }) {
+    if ( @{ $self->_webhooks } ) {
         $data_map{webhooks} = $self->_webhooks;
     }
-    if (defined $self->_output) {
+    if ( defined $self->_output ) {
         $data_map{output} = $self->_output;
     }
-    if (@{ $self->_error_keys }) {
+    if ( @{ $self->_error_keys } ) {
         $data_map{error_keys} = $self->_error_keys;
     }
 

--- a/lib/SignalWire/Logging.pm
+++ b/lib/SignalWire/Logging.pm
@@ -48,12 +48,13 @@ sub _log {
     my $msg  = join( ' ', @msgs );
     my $ts   = _timestamp();
     print STDERR "[$ts] [$tag] [$name] $msg\n";
+    return;
 }
 
-sub debug { shift->_log( 'debug', @_ ) }
-sub info  { shift->_log( 'info',  @_ ) }
-sub warn  { shift->_log( 'warn',  @_ ) }
-sub error { shift->_log( 'error', @_ ) }
+sub debug { my ( $self, @args ) = @_; return $self->_log( 'debug', @args ); }
+sub info  { my ( $self, @args ) = @_; return $self->_log( 'info',  @args ); }
+sub warn  { my ( $self, @args ) = @_; return $self->_log( 'warn',  @args ); }
+sub error { my ( $self, @args ) = @_; return $self->_log( 'error', @args ); }
 
 sub _timestamp {
     my @t = localtime;

--- a/lib/SignalWire/Logging.pm
+++ b/lib/SignalWire/Logging.pm
@@ -33,41 +33,45 @@ has 'suppressed' => (
 );
 
 sub _should_log {
-    my ($self, $msg_level) = @_;
+    my ( $self, $msg_level ) = @_;
     return 0 if $self->suppressed;
     my $current = $LEVELS{ $self->level } // 1;
-    my $target  = $LEVELS{ $msg_level }   // 1;
+    my $target  = $LEVELS{$msg_level}     // 1;
     return $target >= $current;
 }
 
 sub _log {
-    my ($self, $level, @msgs) = @_;
+    my ( $self, $level, @msgs ) = @_;
     return unless $self->_should_log($level);
-    my $tag = uc($level);
+    my $tag  = uc($level);
     my $name = $self->name;
-    my $msg = join(' ', @msgs);
-    my $ts = _timestamp();
+    my $msg  = join( ' ', @msgs );
+    my $ts   = _timestamp();
     print STDERR "[$ts] [$tag] [$name] $msg\n";
 }
 
-sub debug { shift->_log('debug', @_) }
-sub info  { shift->_log('info',  @_) }
-sub warn  { shift->_log('warn',  @_) }
-sub error { shift->_log('error', @_) }
+sub debug { shift->_log( 'debug', @_ ) }
+sub info  { shift->_log( 'info',  @_ ) }
+sub warn  { shift->_log( 'warn',  @_ ) }
+sub error { shift->_log( 'error', @_ ) }
 
 sub _timestamp {
     my @t = localtime;
-    return sprintf('%04d-%02d-%02d %02d:%02d:%02d',
-        $t[5]+1900, $t[4]+1, $t[3], $t[2], $t[1], $t[0]);
+    return sprintf(
+        '%04d-%02d-%02d %02d:%02d:%02d',
+        $t[5] + 1900,
+        $t[4] + 1,
+        $t[3], $t[2], $t[1], $t[0]
+    );
 }
 
 # Singleton-ish factory
 my %loggers;
 
 sub get_logger {
-    my ($class, $name) = @_;
+    my ( $class, $name ) = @_;
     $name //= 'signalwire';
-    $loggers{$name} //= SignalWire::Logging->new(name => $name);
+    $loggers{$name} //= SignalWire::Logging->new( name => $name );
     return $loggers{$name};
 }
 

--- a/lib/SignalWire/Logging/LogLevel.pm
+++ b/lib/SignalWire/Logging/LogLevel.pm
@@ -1,4 +1,5 @@
 package SignalWire::Logging::LogLevel;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -47,7 +48,7 @@ use constant {
     ERROR => 'error',
 };
 
-our @EXPORT_OK = qw( DEBUG INFO WARN ERROR );
+our @EXPORT_OK   = qw( DEBUG INFO WARN ERROR );
 our %EXPORT_TAGS = ( all => [@EXPORT_OK] );
 
 # Ascending severity — the SAME ordering SignalWire::Logging's private
@@ -75,7 +76,7 @@ sub all {
 # levels, false otherwise. Accepts the bareword constant too (it's just
 # the string).
 sub is_valid {
-    my ($class, $level) = @_;
+    my ( $class, $level ) = @_;
     return 0 unless defined $level;
     return exists $IS_VALID{$level} ? 1 : 0;
 }
@@ -84,7 +85,7 @@ sub is_valid {
 # (debug=0 .. error=3), or undef for an unknown level. Mirrors the
 # threshold numbers SignalWire::Logging uses internally.
 sub severity {
-    my ($class, $level) = @_;
+    my ( $class, $level ) = @_;
     return undef unless defined $level;
     return $SEVERITY{$level};
 }

--- a/lib/SignalWire/Logging/LogLevel.pm
+++ b/lib/SignalWire/Logging/LogLevel.pm
@@ -86,7 +86,7 @@ sub is_valid {
 # threshold numbers SignalWire::Logging uses internally.
 sub severity {
     my ( $class, $level ) = @_;
-    return undef unless defined $level;
+    return unless defined $level;
     return $SEVERITY{$level};
 }
 

--- a/lib/SignalWire/POM/PromptObjectModel.pm
+++ b/lib/SignalWire/POM/PromptObjectModel.pm
@@ -207,7 +207,7 @@ sub _find_in {
         my $found = _find_in( $s->subsections, $title );
         return $found if defined $found;
     }
-    return undef;
+    return;
 }
 
 # JSON-encoded representation. Output is byte-for-byte identical to

--- a/lib/SignalWire/POM/PromptObjectModel.pm
+++ b/lib/SignalWire/POM/PromptObjectModel.pm
@@ -1,4 +1,5 @@
 package SignalWire::POM::PromptObjectModel;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -18,8 +19,8 @@ use strict;
 use warnings;
 use Moo;
 use Scalar::Util qw(blessed);
-use Carp qw(croak);
-use JSON::PP ();
+use Carp         qw(croak);
+use JSON::PP     ();
 use Tie::IxHash;
 use SignalWire::POM::Section;
 
@@ -46,10 +47,10 @@ has debug => (
 # ``Class->from_json($data)`` and ``$instance->from_json($data)`` work,
 # and the cross-language signature diff strips the receiver entirely.
 sub from_json {
-    my ($class_or_self, $json_data) = @_;
+    my ( $class_or_self, $json_data ) = @_;
     my $class = ref($class_or_self) || $class_or_self;
     my $data;
-    if (!ref $json_data) {
+    if ( !ref $json_data ) {
         $data = JSON::PP::decode_json($json_data);
     } else {
         $data = $json_data;
@@ -65,15 +66,13 @@ sub from_json {
 # ``$class_or_self`` receiver name marks it as a static helper for
 # the cross-language diff (see ``from_json`` above).
 sub from_yaml {
-    my ($class_or_self, $yaml_data) = @_;
+    my ( $class_or_self, $yaml_data ) = @_;
     my $class = ref($class_or_self) || $class_or_self;
     my $data;
-    if (!ref $yaml_data) {
+    if ( !ref $yaml_data ) {
         require YAML::PP;
         require YAML::PP::Common;
-        my $yp = YAML::PP->new(
-            preserve => YAML::PP::Common::PRESERVE_ORDER(),
-        );
+        my $yp = YAML::PP->new( preserve => YAML::PP::Common::PRESERVE_ORDER(), );
         $data = $yp->load_string($yaml_data);
     } else {
         $data = $yaml_data;
@@ -87,75 +86,76 @@ sub from_yaml {
 # bullets or subsections, only the first top-level section may omit
 # its title).
 sub _from_data {
-    my ($class, $data) = @_;
+    my ( $class, $data ) = @_;
     croak "POM data must be an arrayref of section hashes"
         unless ref $data eq 'ARRAY';
 
     my $self = $class->new;
-    my $i = 0;
+    my $i    = 0;
     for my $sec (@$data) {
         croak "Each POM section must be a hashref" unless ref $sec eq 'HASH';
+
         # Python: "only the first section can have no title" — Python
         # silently sets a default title; mirror that.
-        if ($i > 0 && !exists $sec->{title}) {
+        if ( $i > 0 && !exists $sec->{title} ) {
             $sec->{title} = 'Untitled Section';
         }
-        push @{ $self->sections }, _build_section_from_hash($sec, 0);
+        push @{ $self->sections }, _build_section_from_hash( $sec, 0 );
         $i++;
     }
     return $self;
 }
 
 sub _build_section_from_hash {
-    my ($d, $is_subsection) = @_;
+    my ( $d, $is_subsection ) = @_;
     croak "Each section must be a hashref" unless ref $d eq 'HASH';
 
-    if (exists $d->{title} && defined $d->{title} && ref $d->{title}) {
+    if ( exists $d->{title} && defined $d->{title} && ref $d->{title} ) {
         croak "'title' must be a string if present";
     }
-    if (exists $d->{subsections} && ref $d->{subsections} ne 'ARRAY') {
+    if ( exists $d->{subsections} && ref $d->{subsections} ne 'ARRAY' ) {
         croak "'subsections' must be an arrayref if provided";
     }
-    if (exists $d->{bullets} && ref $d->{bullets} ne 'ARRAY') {
+    if ( exists $d->{bullets} && ref $d->{bullets} ne 'ARRAY' ) {
         croak "'bullets' must be an arrayref if provided";
     }
-    if (exists $d->{numbered}) {
+    if ( exists $d->{numbered} ) {
         my $v = $d->{numbered};
         croak "'numbered' must be a boolean if provided"
             if ref $v && !( JSON::PP::is_bool($v) );
     }
-    if (exists $d->{numberedBullets}) {
+    if ( exists $d->{numberedBullets} ) {
         my $v = $d->{numberedBullets};
         croak "'numberedBullets' must be a boolean if provided"
             if ref $v && !( JSON::PP::is_bool($v) );
     }
 
-    my $has_body        = (exists $d->{body} && defined $d->{body} && length $d->{body}) ? 1 : 0;
-    my $has_bullets     = (exists $d->{bullets} && @{ $d->{bullets} || [] }) ? 1 : 0;
-    my $has_subsections = (exists $d->{subsections} && @{ $d->{subsections} || [] }) ? 1 : 0;
-    if (!$has_body && !$has_bullets && !$has_subsections) {
+    my $has_body        = ( exists $d->{body} && defined $d->{body} && length $d->{body} ) ? 1 : 0;
+    my $has_bullets     = ( exists $d->{bullets}     && @{ $d->{bullets} || [] } )     ? 1 : 0;
+    my $has_subsections = ( exists $d->{subsections} && @{ $d->{subsections} || [] } ) ? 1 : 0;
+    if ( !$has_body && !$has_bullets && !$has_subsections ) {
         croak "All sections must have either a non-empty body, non-empty bullets, or subsections";
     }
 
-    if ($is_subsection && !exists $d->{title}) {
+    if ( $is_subsection && !exists $d->{title} ) {
         croak "All subsections must have a title";
     }
 
     my %args = (
         title   => $d->{title},
-        body    => exists $d->{body}    ? $d->{body}    : '',
+        body    => exists $d->{body}    ? $d->{body}             : '',
         bullets => exists $d->{bullets} ? [ @{ $d->{bullets} } ] : [],
     );
-    if (exists $d->{numbered}) {
+    if ( exists $d->{numbered} ) {
         $args{numbered} = $d->{numbered} ? 1 : 0;
     }
-    if (exists $d->{numberedBullets}) {
+    if ( exists $d->{numberedBullets} ) {
         $args{numberedBullets} = $d->{numberedBullets} ? 1 : 0;
     }
 
     my $section = SignalWire::POM::Section->new(%args);
-    for my $sub (@{ $d->{subsections} || [] }) {
-        push @{ $section->subsections }, _build_section_from_hash($sub, 1);
+    for my $sub ( @{ $d->{subsections} || [] } ) {
+        push @{ $section->subsections }, _build_section_from_hash( $sub, 1 );
     }
     return $section;
 }
@@ -167,24 +167,24 @@ sub _build_section_from_hash {
 # is the Python contract — the first section of a POM may render
 # title-less prose).
 sub add_section {
-    my ($self, %opts) = @_;
+    my ( $self, %opts ) = @_;
 
-    if (!defined $opts{title} && @{ $self->sections } > 0) {
+    if ( !defined $opts{title} && @{ $self->sections } > 0 ) {
         croak "Only the first section can have no title";
     }
 
     # Python accepts either a single string OR a list for ``bullets``;
     # normalize to a list here.
     my $bullets = $opts{bullets};
-    if (defined $bullets && !ref $bullets) {
-        $bullets = [ $bullets ];
-    } elsif (!defined $bullets) {
+    if ( defined $bullets && !ref $bullets ) {
+        $bullets = [$bullets];
+    } elsif ( !defined $bullets ) {
         $bullets = [];
     }
 
     my $section = SignalWire::POM::Section->new(
         title           => $opts{title},
-        body            => exists $opts{body}            ? $opts{body}            : '',
+        body            => exists $opts{body} ? $opts{body} : '',
         bullets         => $bullets,
         numbered        => exists $opts{numbered}        ? $opts{numbered}        : undef,
         numberedBullets => exists $opts{numberedBullets} ? $opts{numberedBullets} : 0,
@@ -196,15 +196,15 @@ sub add_section {
 # Recursive depth-first search by title. Returns the first matching
 # Section (or undef). Mirrors Python's find_section.
 sub find_section {
-    my ($self, $title) = @_;
-    return _find_in($self->sections, $title);
+    my ( $self, $title ) = @_;
+    return _find_in( $self->sections, $title );
 }
 
 sub _find_in {
-    my ($sections, $title) = @_;
+    my ( $sections, $title ) = @_;
     for my $s (@$sections) {
         return $s if defined $s->title && $s->title eq $title;
-        my $found = _find_in($s->subsections, $title);
+        my $found = _find_in( $s->subsections, $title );
         return $found if defined $found;
     }
     return undef;
@@ -216,12 +216,9 @@ sub _find_in {
 # numberedBullets).
 sub to_json {
     my ($self) = @_;
-    my $j = JSON::PP->new
-        ->indent(1)
-        ->indent_length(2)
-        ->space_after
-        ->canonical(0);
-    my $out = $j->encode($self->to_hash);
+    my $j      = JSON::PP->new->indent(1)->indent_length(2)->space_after->canonical(0);
+    my $out    = $j->encode( $self->to_hash );
+
     # JSON::PP appends ``\n`` in indent mode; Python's ``json.dumps`` does not.
     chomp $out;
     return $out;
@@ -237,7 +234,7 @@ sub to_yaml {
         header   => 0,
         preserve => YAML::PP::Common::PRESERVE_ORDER(),
     );
-    return $yp->dump_string($self->to_hash);
+    return $yp->dump_string( $self->to_hash );
 }
 
 # Convert to an arrayref of section hashes (one per top-level section).
@@ -255,28 +252,29 @@ sub render_markdown {
     my ($self) = @_;
 
     my $any_section_numbered = 0;
-    for my $sec (@{ $self->sections }) {
-        if ($sec->numbered) { $any_section_numbered = 1; last; }
+    for my $sec ( @{ $self->sections } ) {
+        if ( $sec->numbered ) { $any_section_numbered = 1; last; }
     }
 
     my @md;
     my $section_counter = 0;
-    for my $sec (@{ $self->sections }) {
+    for my $sec ( @{ $self->sections } ) {
         my $section_number;
-        if (defined $sec->title) {
+        if ( defined $sec->title ) {
             $section_counter++;
-            if ($any_section_numbered
-                && !(defined $sec->numbered && !$sec->numbered)) {
-                $section_number = [ $section_counter ];
+            if ( $any_section_numbered
+                && !( defined $sec->numbered && !$sec->numbered ) )
+            {
+                $section_number = [$section_counter];
             } else {
                 $section_number = [];
             }
         } else {
             $section_number = [];
         }
-        push @md, $sec->render_markdown(2, $section_number);
+        push @md, $sec->render_markdown( 2, $section_number );
     }
-    return join("\n", @md);
+    return join( "\n", @md );
 }
 
 # Render the entire POM as XML. Wraps a series of <section> elements in
@@ -285,47 +283,45 @@ sub render_markdown {
 sub render_xml {
     my ($self) = @_;
 
-    my @xml = (
-        '<?xml version="1.0" encoding="UTF-8"?>',
-        '<prompt>',
-    );
+    my @xml = ( '<?xml version="1.0" encoding="UTF-8"?>', '<prompt>', );
 
     my $any_section_numbered = 0;
-    for my $sec (@{ $self->sections }) {
-        if ($sec->numbered) { $any_section_numbered = 1; last; }
+    for my $sec ( @{ $self->sections } ) {
+        if ( $sec->numbered ) { $any_section_numbered = 1; last; }
     }
 
     my $section_counter = 0;
-    for my $sec (@{ $self->sections }) {
+    for my $sec ( @{ $self->sections } ) {
         my $section_number;
-        if (defined $sec->title) {
+        if ( defined $sec->title ) {
             $section_counter++;
-            if ($any_section_numbered
-                && !(defined $sec->numbered && !$sec->numbered)) {
-                $section_number = [ $section_counter ];
+            if ( $any_section_numbered
+                && !( defined $sec->numbered && !$sec->numbered ) )
+            {
+                $section_number = [$section_counter];
             } else {
                 $section_number = [];
             }
         } else {
             $section_number = [];
         }
-        push @xml, $sec->render_xml(1, $section_number);
+        push @xml, $sec->render_xml( 1, $section_number );
     }
 
     push @xml, '</prompt>';
-    return join("\n", @xml);
+    return join( "\n", @xml );
 }
 
 # Append the sections of another POM as subsections of a section in
 # this POM, identified either by title (string lookup) or by passing a
 # Section object directly. Mirrors Python's add_pom_as_subsection.
 sub add_pom_as_subsection {
-    my ($self, $target, $pom_to_add) = @_;
+    my ( $self, $target, $pom_to_add ) = @_;
     my $target_section;
-    if (!ref $target) {
+    if ( !ref $target ) {
         $target_section = $self->find_section($target);
         croak "No section with title '${target}' found." unless $target_section;
-    } elsif (blessed($target) && $target->isa('SignalWire::POM::Section')) {
+    } elsif ( blessed($target) && $target->isa('SignalWire::POM::Section') ) {
         $target_section = $target;
     } else {
         croak "Target must be a string or a SignalWire::POM::Section object.";
@@ -335,7 +331,7 @@ sub add_pom_as_subsection {
         unless blessed($pom_to_add)
         && $pom_to_add->isa('SignalWire::POM::PromptObjectModel');
 
-    for my $sec (@{ $pom_to_add->sections }) {
+    for my $sec ( @{ $pom_to_add->sections } ) {
         push @{ $target_section->subsections }, $sec;
     }
     return $self;

--- a/lib/SignalWire/POM/Section.pm
+++ b/lib/SignalWire/POM/Section.pm
@@ -1,4 +1,5 @@
 package SignalWire::POM::Section;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -15,10 +16,11 @@ package SignalWire::POM::Section;
 use strict;
 use warnings;
 use Moo;
+
 # Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
 use Scalar::Util qw(blessed);
-use Carp qw(croak);
+use Carp         qw(croak);
 use Tie::IxHash;
 
 # ---------- attributes ----------
@@ -67,13 +69,14 @@ has numberedBullets => (
 
 # ---------- BUILD: validate types of body / bullets ----------
 
-sub BUILD ($self, $args) {
-    if (defined $args->{body} && ref $args->{body}) {
-        croak "body must be a string, not " . ref($args->{body})
+sub BUILD ( $self, $args ) {
+    if ( defined $args->{body} && ref $args->{body} ) {
+        croak "body must be a string, not "
+            . ref( $args->{body} )
             . ". If you meant to pass a list of bullet points, use bullets parameter instead.";
     }
-    if (defined $args->{bullets} && ref $args->{bullets} ne 'ARRAY') {
-        croak "bullets must be a list or undef, not " . ref($args->{bullets});
+    if ( defined $args->{bullets} && ref $args->{bullets} ne 'ARRAY' ) {
+        croak "bullets must be a list or undef, not " . ref( $args->{bullets} );
     }
     return;
 }
@@ -83,15 +86,15 @@ sub BUILD ($self, $args) {
 # Replace the body text on this section. Mirrors Python's
 # ``Section.add_body`` which is documented to "Add OR REPLACE the body
 # text" — calling this overwrites any prior value rather than appending.
-sub add_body ($self, $body) {
+sub add_body ( $self, $body ) {
     croak "body must be a string, not " . ref($body) if ref $body;
     $self->body($body);
     return $self;
 }
 
 # Append bullets to the existing list (does NOT replace).
-sub add_bullets ($self, $bullets) {
-    croak "bullets must be a list, not " . (ref($bullets) || 'scalar')
+sub add_bullets ( $self, $bullets ) {
+    croak "bullets must be a list, not " . ( ref($bullets) || 'scalar' )
         if !defined $bullets || ref $bullets ne 'ARRAY';
     push @{ $self->bullets }, @$bullets;
     return $self;
@@ -100,7 +103,7 @@ sub add_bullets ($self, $bullets) {
 # Add a subsection and return the newly-created Section object so the
 # caller can chain ``->add_body / ->add_bullets`` onto it (matching
 # Python's return-the-Section ergonomic).
-sub add_subsection ($self, %opts) {
+sub add_subsection ( $self, %opts ) {
     croak "Subsections must have a title" unless defined $opts{title};
 
     my $sub = SignalWire::POM::Section->new(
@@ -121,22 +124,22 @@ sub add_subsection ($self, %opts) {
 sub to_hash ($self) {
     tie my %data, 'Tie::IxHash';
 
-    if (defined $self->title) {
+    if ( defined $self->title ) {
         $data{title} = $self->title;
     }
-    if (defined $self->body && length $self->body) {
+    if ( defined $self->body && length $self->body ) {
         $data{body} = $self->body;
     }
-    if ($self->bullets && @{ $self->bullets }) {
+    if ( $self->bullets && @{ $self->bullets } ) {
         $data{bullets} = [ @{ $self->bullets } ];
     }
-    if ($self->subsections && @{ $self->subsections }) {
+    if ( $self->subsections && @{ $self->subsections } ) {
         $data{subsections} = [ map { $_->to_hash } @{ $self->subsections } ];
     }
-    if ($self->numbered) {
+    if ( $self->numbered ) {
         $data{numbered} = JSON::PP::true();
     }
-    if ($self->numberedBullets) {
+    if ( $self->numberedBullets ) {
         $data{numberedBullets} = JSON::PP::true();
     }
 
@@ -147,29 +150,29 @@ sub to_hash ($self) {
 # 2=##, ...). ``section_number`` is an arrayref of the section's
 # position among numbered siblings (e.g. [1,2,3] for "1.2.3."). Mirrors
 # Python's Section.render_markdown signature/output exactly.
-sub render_markdown ($self, $level = undef, $section_number = undef) {
-    $level //= 2;
+sub render_markdown ( $self, $level = undef, $section_number = undef ) {
+    $level          //= 2;
     $section_number //= [];
 
     my @md;
 
-    if (defined $self->title) {
+    if ( defined $self->title ) {
         my $prefix = '';
         if (@$section_number) {
-            $prefix = join('.', @$section_number) . '. ';
+            $prefix = join( '.', @$section_number ) . '. ';
         }
-        push @md, ('#' x $level) . " ${prefix}" . $self->title . "\n";
+        push @md, ( '#' x $level ) . " ${prefix}" . $self->title . "\n";
     }
 
-    if (defined $self->body && length $self->body) {
+    if ( defined $self->body && length $self->body ) {
         push @md, $self->body . "\n";
     }
 
-    if ($self->bullets && @{ $self->bullets }) {
+    if ( $self->bullets && @{ $self->bullets } ) {
         my $i = 0;
-        for my $bullet (@{ $self->bullets }) {
+        for my $bullet ( @{ $self->bullets } ) {
             $i++;
-            if ($self->numberedBullets) {
+            if ( $self->numberedBullets ) {
                 push @md, "${i}. $bullet";
             } else {
                 push @md, "- $bullet";
@@ -182,41 +185,44 @@ sub render_markdown ($self, $level = undef, $section_number = undef) {
     # all sibling subsections that are not explicitly numbered=>0 get
     # a number too. Matches Python's any-numbered semantics.
     my $any_subsection_numbered = 0;
-    for my $sub (@{ $self->subsections }) {
-        if ($sub->numbered) { $any_subsection_numbered = 1; last; }
+    for my $sub ( @{ $self->subsections } ) {
+        if ( $sub->numbered ) { $any_subsection_numbered = 1; last; }
     }
 
     my $i = 0;
-    for my $sub (@{ $self->subsections }) {
+    for my $sub ( @{ $self->subsections } ) {
         $i++;
-        my ($new_section_number, $next_level);
-        if (defined $self->title || @$section_number) {
+        my ( $new_section_number, $next_level );
+        if ( defined $self->title || @$section_number ) {
+
             # Python: ``if any_subsection_numbered and subsection.numbered is not False``
             # Use defined-but-zero to mean "explicit false"; any other
             # truthy / undef value participates in numbering.
-            if ($any_subsection_numbered
-                && !(defined $sub->numbered && !$sub->numbered)) {
+            if ( $any_subsection_numbered
+                && !( defined $sub->numbered && !$sub->numbered ) )
+            {
                 $new_section_number = [ @$section_number, $i ];
             } else {
                 $new_section_number = $section_number;
             }
             $next_level = $level + 1;
         } else {
+
             # Root-without-title: don't increment numbering or level.
             $new_section_number = $section_number;
-            $next_level = $level;
+            $next_level         = $level;
         }
-        push @md, $sub->render_markdown($next_level, $new_section_number);
+        push @md, $sub->render_markdown( $next_level, $new_section_number );
     }
 
-    return join("\n", @md);
+    return join( "\n", @md );
 }
 
 # Render this section as XML. ``indent`` is the number of two-space
 # indentation levels. ``section_number`` is the same numbering arrayref
 # used by render_markdown. Mirrors Python's Section.render_xml exactly.
-sub render_xml ($self, $indent = undef, $section_number = undef) {
-    $indent //= 0;
+sub render_xml ( $self, $indent = undef, $section_number = undef ) {
+    $indent         //= 0;
     $section_number //= [];
 
     my $indent_str = '  ' x $indent;
@@ -224,24 +230,24 @@ sub render_xml ($self, $indent = undef, $section_number = undef) {
 
     push @xml, "${indent_str}<section>";
 
-    if (defined $self->title) {
+    if ( defined $self->title ) {
         my $prefix = '';
         if (@$section_number) {
-            $prefix = join('.', @$section_number) . '. ';
+            $prefix = join( '.', @$section_number ) . '. ';
         }
         push @xml, "${indent_str}  <title>${prefix}" . $self->title . '</title>';
     }
 
-    if (defined $self->body && length $self->body) {
+    if ( defined $self->body && length $self->body ) {
         push @xml, "${indent_str}  <body>" . $self->body . '</body>';
     }
 
-    if ($self->bullets && @{ $self->bullets }) {
+    if ( $self->bullets && @{ $self->bullets } ) {
         push @xml, "${indent_str}  <bullets>";
         my $i = 0;
-        for my $bullet (@{ $self->bullets }) {
+        for my $bullet ( @{ $self->bullets } ) {
             $i++;
-            if ($self->numberedBullets) {
+            if ( $self->numberedBullets ) {
                 push @xml, "${indent_str}    <bullet id=\"${i}\">${bullet}</bullet>";
             } else {
                 push @xml, "${indent_str}    <bullet>${bullet}</bullet>";
@@ -250,19 +256,20 @@ sub render_xml ($self, $indent = undef, $section_number = undef) {
         push @xml, "${indent_str}  </bullets>";
     }
 
-    if ($self->subsections && @{ $self->subsections }) {
+    if ( $self->subsections && @{ $self->subsections } ) {
         push @xml, "${indent_str}  <subsections>";
         my $any_subsection_numbered = 0;
-        for my $sub (@{ $self->subsections }) {
-            if ($sub->numbered) { $any_subsection_numbered = 1; last; }
+        for my $sub ( @{ $self->subsections } ) {
+            if ( $sub->numbered ) { $any_subsection_numbered = 1; last; }
         }
         my $i = 0;
-        for my $sub (@{ $self->subsections }) {
+        for my $sub ( @{ $self->subsections } ) {
             $i++;
             my $new_section_number;
-            if (defined $self->title || @$section_number) {
-                if ($any_subsection_numbered
-                    && !(defined $sub->numbered && !$sub->numbered)) {
+            if ( defined $self->title || @$section_number ) {
+                if ( $any_subsection_numbered
+                    && !( defined $sub->numbered && !$sub->numbered ) )
+                {
                     $new_section_number = [ @$section_number, $i ];
                 } else {
                     $new_section_number = $section_number;
@@ -270,14 +277,14 @@ sub render_xml ($self, $indent = undef, $section_number = undef) {
             } else {
                 $new_section_number = $section_number;
             }
-            push @xml, $sub->render_xml($indent + 2, $new_section_number);
+            push @xml, $sub->render_xml( $indent + 2, $new_section_number );
         }
         push @xml, "${indent_str}  </subsections>";
     }
 
     push @xml, "${indent_str}</section>";
 
-    return join("\n", @xml);
+    return join( "\n", @xml );
 }
 
 1;

--- a/lib/SignalWire/Prefabs/Concierge.pm
+++ b/lib/SignalWire/Prefabs/Concierge.pm
@@ -1,4 +1,5 @@
 package SignalWire::Prefabs::Concierge;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 
@@ -8,28 +9,30 @@ use Moo;
 use JSON qw(encode_json);
 extends 'SignalWire::Agent::AgentBase';
 
-has venue_name           => (is => 'ro', required => 1);
-has services             => (is => 'ro', default => sub { [] });
-has amenities            => (is => 'ro', default => sub { {} });
-has hours_of_operation   => (is => 'ro', default => sub { {} });
-has special_instructions => (is => 'ro', default => sub { [] });
-has welcome_message      => (is => 'ro', default => sub { undef });
+has venue_name           => ( is => 'ro', required => 1 );
+has services             => ( is => 'ro', default  => sub { [] } );
+has amenities            => ( is => 'ro', default  => sub { {} } );
+has hours_of_operation   => ( is => 'ro', default  => sub { {} } );
+has special_instructions => ( is => 'ro', default  => sub { [] } );
+has welcome_message      => ( is => 'ro', default  => sub { undef } );
 
 sub BUILD {
-    my ($self, $args) = @_;
+    my ( $self, $args ) = @_;
 
-    $self->name('concierge')  if $self->name eq 'agent';
+    $self->name('concierge')   if $self->name eq 'agent';
     $self->route('/concierge') if $self->route eq '/';
     $self->use_pom(1);
 
     my $welcome = $self->welcome_message
         // "Welcome to ${\$self->venue_name}. How can I assist you today?";
 
-    $self->set_global_data({
-        venue_name  => $self->venue_name,
-        services    => $self->services,
-        amenities   => $self->amenities,
-    });
+    $self->set_global_data(
+        {
+            venue_name => $self->venue_name,
+            services   => $self->services,
+            amenities  => $self->amenities,
+        }
+    );
 
     $self->prompt_add_section(
         'Concierge Role',
@@ -43,51 +46,36 @@ sub BUILD {
     );
 
     # Services
-    if (@{ $self->services }) {
-        $self->prompt_add_section(
-            'Available Services',
-            '',
-            bullets => $self->services,
-        );
+    if ( @{ $self->services } ) {
+        $self->prompt_add_section( 'Available Services', '', bullets => $self->services, );
     }
 
     # Amenities
-    if (%{ $self->amenities }) {
+    if ( %{ $self->amenities } ) {
         my @amenity_bullets;
-        for my $name (sort keys %{ $self->amenities }) {
+        for my $name ( sort keys %{ $self->amenities } ) {
             my $info = $self->amenities->{$name};
             my $desc = "$name";
-            $desc .= " - Hours: $info->{hours}" if $info->{hours};
+            $desc .= " - Hours: $info->{hours}"       if $info->{hours};
             $desc .= " - Location: $info->{location}" if $info->{location};
             push @amenity_bullets, $desc;
         }
-        $self->prompt_add_section(
-            'Amenities',
-            '',
-            bullets => \@amenity_bullets,
-        );
+        $self->prompt_add_section( 'Amenities', '', bullets => \@amenity_bullets, );
     }
 
     # Hours
-    if (%{ $self->hours_of_operation }) {
+    if ( %{ $self->hours_of_operation } ) {
         my @hour_bullets;
-        for my $day (sort keys %{ $self->hours_of_operation }) {
+        for my $day ( sort keys %{ $self->hours_of_operation } ) {
             push @hour_bullets, "$day: $self->{hours_of_operation}{$day}";
         }
-        $self->prompt_add_section(
-            'Hours of Operation',
-            '',
-            bullets => \@hour_bullets,
-        );
+        $self->prompt_add_section( 'Hours of Operation', '', bullets => \@hour_bullets, );
     }
 
     # Special instructions
-    if (@{ $self->special_instructions }) {
-        $self->prompt_add_section(
-            'Special Instructions',
-            '',
-            bullets => $self->special_instructions,
-        );
+    if ( @{ $self->special_instructions } ) {
+        $self->prompt_add_section( 'Special Instructions',
+            '', bullets => $self->special_instructions, );
     }
 
     # Register check availability tool
@@ -103,11 +91,10 @@ sub BUILD {
             required => ['service'],
         },
         handler => sub {
-            my ($a, $raw) = @_;
+            my ( $a, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             return SignalWire::SWAIG::FunctionResult->new(
-                response => "Checking availability for $a->{service} at ${\$self->venue_name}",
-            );
+                response => "Checking availability for $a->{service} at ${\$self->venue_name}", );
         },
     );
 }

--- a/lib/SignalWire/Prefabs/Concierge.pm
+++ b/lib/SignalWire/Prefabs/Concierge.pm
@@ -97,6 +97,7 @@ sub BUILD {
                 response => "Checking availability for $a->{service} at ${\$self->venue_name}", );
         },
     );
+    return;
 }
 
 1;

--- a/lib/SignalWire/Prefabs/FAQBot.pm
+++ b/lib/SignalWire/Prefabs/FAQBot.pm
@@ -78,6 +78,7 @@ sub BUILD {
                 response => "No FAQ found matching: $a->{query}", );
         },
     );
+    return;
 }
 
 1;

--- a/lib/SignalWire/Prefabs/FAQBot.pm
+++ b/lib/SignalWire/Prefabs/FAQBot.pm
@@ -1,4 +1,5 @@
 package SignalWire::Prefabs::FAQBot;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 
@@ -8,12 +9,16 @@ use Moo;
 use JSON qw(encode_json);
 extends 'SignalWire::Agent::AgentBase';
 
-has faqs            => (is => 'ro', default => sub { [] });
-has suggest_related => (is => 'ro', default => sub { 1 });
-has persona         => (is => 'ro', default => sub { 'You are a helpful FAQ bot that provides accurate answers to common questions.' });
+has faqs            => ( is => 'ro', default => sub { [] } );
+has suggest_related => ( is => 'ro', default => sub { 1 } );
+has persona => (
+    is      => 'ro',
+    default =>
+        sub { 'You are a helpful FAQ bot that provides accurate answers to common questions.' }
+);
 
 sub BUILD {
-    my ($self, $args) = @_;
+    my ( $self, $args ) = @_;
 
     $self->name('faq_bot') if $self->name eq 'agent';
     $self->route('/faq')   if $self->route eq '/';
@@ -21,15 +26,14 @@ sub BUILD {
 
     my $faqs = $self->faqs;
 
-    $self->set_global_data({
-        faqs           => $faqs,
-        suggest_related => $self->suggest_related ? JSON::true : JSON::false,
-    });
-
-    $self->prompt_add_section(
-        'Personality',
-        $self->persona,
+    $self->set_global_data(
+        {
+            faqs            => $faqs,
+            suggest_related => $self->suggest_related ? JSON::true : JSON::false,
+        }
     );
+
+    $self->prompt_add_section( 'Personality', $self->persona, );
 
     # Build FAQ knowledge
     my @faq_bullets;
@@ -43,7 +47,7 @@ sub BUILD {
         bullets => \@faq_bullets,
     );
 
-    if ($self->suggest_related) {
+    if ( $self->suggest_related ) {
         $self->prompt_add_section(
             'Related Questions',
             'When appropriate, suggest related questions the user might also be interested in.',
@@ -62,19 +66,16 @@ sub BUILD {
             required => ['query'],
         },
         handler => sub {
-            my ($a, $raw) = @_;
+            my ( $a, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
-            my $query = lc($a->{query} // '');
+            my $query = lc( $a->{query} // '' );
             for my $faq (@$faqs) {
-                if (index(lc($faq->{question}), $query) >= 0) {
-                    return SignalWire::SWAIG::FunctionResult->new(
-                        response => $faq->{answer},
-                    );
+                if ( index( lc( $faq->{question} ), $query ) >= 0 ) {
+                    return SignalWire::SWAIG::FunctionResult->new( response => $faq->{answer}, );
                 }
             }
             return SignalWire::SWAIG::FunctionResult->new(
-                response => "No FAQ found matching: $a->{query}",
-            );
+                response => "No FAQ found matching: $a->{query}", );
         },
     );
 }

--- a/lib/SignalWire/Prefabs/InfoGatherer.pm
+++ b/lib/SignalWire/Prefabs/InfoGatherer.pm
@@ -1,4 +1,5 @@
 package SignalWire::Prefabs::InfoGatherer;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 
@@ -8,29 +9,31 @@ use Moo;
 use JSON qw(encode_json);
 extends 'SignalWire::Agent::AgentBase';
 
-has questions => (is => 'ro', default => sub { [] });
+has questions => ( is => 'ro', default => sub { [] } );
 
 sub BUILD {
-    my ($self, $args) = @_;
+    my ( $self, $args ) = @_;
 
     # Set defaults
-    $self->name('info_gatherer')  if $self->name eq 'agent';
+    $self->name('info_gatherer')   if $self->name eq 'agent';
     $self->route('/info_gatherer') if $self->route eq '/';
     $self->use_pom(1);
 
     my $questions = $self->questions;
 
     # Set global data
-    $self->set_global_data({
-        questions      => $questions,
-        question_index => 0,
-        answers        => [],
-    });
+    $self->set_global_data(
+        {
+            questions      => $questions,
+            question_index => 0,
+            answers        => [],
+        }
+    );
 
     # Build prompt
     $self->prompt_add_section(
         'Information Gathering',
-        'You are an information-gathering assistant. Your job is to ask the user a series of questions and collect their answers.',
+'You are an information-gathering assistant. Your job is to ask the user a series of questions and collect their answers.',
         bullets => [
             'Ask questions one at a time in order',
             'Wait for the user to answer before asking the next question',
@@ -45,10 +48,10 @@ sub BUILD {
         description => 'Start the question-gathering process and return the first question',
         parameters  => { type => 'object', properties => {} },
         handler     => sub {
-            my ($a, $raw) = @_;
+            my ( $a, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             my $first = $questions->[0]{question_text} // 'No questions configured';
-            return SignalWire::SWAIG::FunctionResult->new(response => $first);
+            return SignalWire::SWAIG::FunctionResult->new( response => $first );
         },
     );
 
@@ -58,17 +61,17 @@ sub BUILD {
         parameters  => {
             type       => 'object',
             properties => {
-                answer            => { type => 'string',  description => 'The answer' },
-                confirmed_by_user => { type => 'boolean', description => 'User confirmed this answer' },
+                answer            => { type => 'string', description => 'The answer' },
+                confirmed_by_user =>
+                    { type => 'boolean', description => 'User confirmed this answer' },
             },
             required => ['answer'],
         },
         handler => sub {
-            my ($a, $raw) = @_;
+            my ( $a, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             return SignalWire::SWAIG::FunctionResult->new(
-                response => "Answer recorded: $a->{answer}",
-            );
+                response => "Answer recorded: $a->{answer}", );
         },
     );
 }

--- a/lib/SignalWire/Prefabs/InfoGatherer.pm
+++ b/lib/SignalWire/Prefabs/InfoGatherer.pm
@@ -74,6 +74,7 @@ sub BUILD {
                 response => "Answer recorded: $a->{answer}", );
         },
     );
+    return;
 }
 
 1;

--- a/lib/SignalWire/Prefabs/Receptionist.pm
+++ b/lib/SignalWire/Prefabs/Receptionist.pm
@@ -1,4 +1,5 @@
 package SignalWire::Prefabs::Receptionist;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 
@@ -8,23 +9,26 @@ use Moo;
 use JSON qw(encode_json);
 extends 'SignalWire::Agent::AgentBase';
 
-has departments => (is => 'ro', default => sub { [] });
-has greeting    => (is => 'ro', default => sub { 'Thank you for calling. How can I help you today?' });
-has voice       => (is => 'ro', default => sub { 'rime.spore' });
+has departments => ( is => 'ro', default => sub { [] } );
+has greeting =>
+    ( is => 'ro', default => sub { 'Thank you for calling. How can I help you today?' } );
+has voice => ( is => 'ro', default => sub { 'rime.spore' } );
 
 sub BUILD {
-    my ($self, $args) = @_;
+    my ( $self, $args ) = @_;
 
-    $self->name('receptionist')  if $self->name eq 'agent';
+    $self->name('receptionist')   if $self->name eq 'agent';
     $self->route('/receptionist') if $self->route eq '/';
     $self->use_pom(1);
 
     my $departments = $self->departments;
 
-    $self->set_global_data({
-        departments => $departments,
-        caller_info => {},
-    });
+    $self->set_global_data(
+        {
+            departments => $departments,
+            caller_info => {},
+        }
+    );
 
     # Build department list for prompt
     my @dept_bullets;
@@ -55,20 +59,18 @@ sub BUILD {
             required => ['department'],
         },
         handler => sub {
-            my ($a, $raw) = @_;
+            my ( $a, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             my $dept_name = $a->{department} // '';
             for my $dept (@$departments) {
-                if (lc($dept->{name}) eq lc($dept_name)) {
+                if ( lc( $dept->{name} ) eq lc($dept_name) ) {
                     my $result = SignalWire::SWAIG::FunctionResult->new(
-                        response => "Transferring to $dept_name",
-                    );
+                        response => "Transferring to $dept_name", );
                     return $result;
                 }
             }
             return SignalWire::SWAIG::FunctionResult->new(
-                response => "Department '$dept_name' not found",
-            );
+                response => "Department '$dept_name' not found", );
         },
     );
 }

--- a/lib/SignalWire/Prefabs/Receptionist.pm
+++ b/lib/SignalWire/Prefabs/Receptionist.pm
@@ -73,6 +73,7 @@ sub BUILD {
                 response => "Department '$dept_name' not found", );
         },
     );
+    return;
 }
 
 1;

--- a/lib/SignalWire/Prefabs/Survey.pm
+++ b/lib/SignalWire/Prefabs/Survey.pm
@@ -75,6 +75,7 @@ sub BUILD {
                 response => "Survey answer for $a->{question_id}: $a->{answer}", );
         },
     );
+    return;
 }
 
 1;

--- a/lib/SignalWire/Prefabs/Survey.pm
+++ b/lib/SignalWire/Prefabs/Survey.pm
@@ -1,4 +1,5 @@
 package SignalWire::Prefabs::Survey;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 
@@ -8,29 +9,31 @@ use Moo;
 use JSON qw(encode_json);
 extends 'SignalWire::Agent::AgentBase';
 
-has survey_name   => (is => 'ro', default => sub { 'Survey' });
-has survey_questions => (is => 'ro', default => sub { [] });
-has introduction  => (is => 'ro', default => sub { '' });
-has conclusion    => (is => 'ro', default => sub { '' });
-has brand_name    => (is => 'ro', default => sub { '' });
-has max_retries   => (is => 'ro', default => sub { 2 });
+has survey_name      => ( is => 'ro', default => sub { 'Survey' } );
+has survey_questions => ( is => 'ro', default => sub { [] } );
+has introduction     => ( is => 'ro', default => sub { '' } );
+has conclusion       => ( is => 'ro', default => sub { '' } );
+has brand_name       => ( is => 'ro', default => sub { '' } );
+has max_retries      => ( is => 'ro', default => sub { 2 } );
 
 sub BUILD {
-    my ($self, $args) = @_;
+    my ( $self, $args ) = @_;
 
-    $self->name('survey')  if $self->name eq 'agent';
+    $self->name('survey')   if $self->name eq 'agent';
     $self->route('/survey') if $self->route eq '/';
     $self->use_pom(1);
 
     my $questions = $self->survey_questions;
 
-    $self->set_global_data({
-        survey_name    => $self->survey_name,
-        questions      => $questions,
-        question_index => 0,
-        answers        => {},
-        completed      => JSON::false,
-    });
+    $self->set_global_data(
+        {
+            survey_name    => $self->survey_name,
+            questions      => $questions,
+            question_index => 0,
+            answers        => {},
+            completed      => JSON::false,
+        }
+    );
 
     my $intro = $self->introduction || "Welcome to the ${\$self->survey_name}.";
     $self->prompt_add_section(
@@ -51,7 +54,7 @@ sub BUILD {
         $desc .= " [required]" if $q->{required};
         push @q_bullets, $desc;
     }
-    $self->prompt_add_section('Survey Questions', '', bullets => \@q_bullets);
+    $self->prompt_add_section( 'Survey Questions', '', bullets => \@q_bullets );
 
     # Register survey tools
     $self->define_tool(
@@ -60,17 +63,16 @@ sub BUILD {
         parameters  => {
             type       => 'object',
             properties => {
-                question_id => { type => 'string',  description => 'ID of the question' },
-                answer      => { type => 'string',  description => 'The answer' },
+                question_id => { type => 'string', description => 'ID of the question' },
+                answer      => { type => 'string', description => 'The answer' },
             },
-            required => ['question_id', 'answer'],
+            required => [ 'question_id', 'answer' ],
         },
         handler => sub {
-            my ($a, $raw) = @_;
+            my ( $a, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             return SignalWire::SWAIG::FunctionResult->new(
-                response => "Survey answer for $a->{question_id}: $a->{answer}",
-            );
+                response => "Survey answer for $a->{question_id}: $a->{answer}", );
         },
     );
 }

--- a/lib/SignalWire/REST/HttpClient.pm
+++ b/lib/SignalWire/REST/HttpClient.pm
@@ -4,26 +4,27 @@ use warnings;
 use Moo;
 
 use HTTP::Tiny;
-use JSON qw(encode_json decode_json);
+use JSON         qw(encode_json decode_json);
 use MIME::Base64 qw(encode_base64);
 
-has 'project'   => ( is => 'ro', required => 1 );
-has 'token'     => ( is => 'ro', required => 1 );
-has 'host'      => ( is => 'ro', required => 1 );
-has 'base_url'  => ( is => 'lazy' );
-has '_ua'       => ( is => 'lazy' );
+has 'project'      => ( is => 'ro', required => 1 );
+has 'token'        => ( is => 'ro', required => 1 );
+has 'host'         => ( is => 'ro', required => 1 );
+has 'base_url'     => ( is => 'lazy' );
+has '_ua'          => ( is => 'lazy' );
 has '_auth_header' => ( is => 'lazy' );
 
 sub _build_base_url {
     my ($self) = @_;
     my $host = $self->host;
+
     # Allow callers to pass a fully-qualified URL (used by the audit
     # fixture, which serves http://127.0.0.1:NNN). When the value
     # already carries a scheme we use it verbatim; otherwise we
     # prepend the production https://. Strip trailing slashes either
     # way so request paths concatenate cleanly.
     my $base;
-    if ($host =~ m{^https?://}) {
+    if ( $host =~ m{^https?://} ) {
         $base = $host;
     } else {
         $base = 'https://' . $host;
@@ -42,43 +43,44 @@ sub _build__ua {
             'Authorization' => $self->_auth_header,
         },
         timeout => 30,
+
         # Verify TLS certificates by default, matching the Python reference
         # (requests/httpx verify by default). HTTP::Tiny otherwise defaults
         # verify_SSL => 0, which would silently accept any cert — a security
         # divergence from Python. Verification honors SSL_CERT_FILE / the OS
         # trust store; plaintext http:// requests are unaffected.
-        verify_SSL      => 1,
+        verify_SSL => 1,
     );
 }
 
 sub _build__auth_header {
     my ($self) = @_;
     my $credentials = $self->project . ':' . $self->token;
-    return 'Basic ' . encode_base64($credentials, '');
+    return 'Basic ' . encode_base64( $credentials, '' );
 }
 
 sub _request {
-    my ($self, $method, $path, %opts) = @_;
+    my ( $self, $method, $path, %opts ) = @_;
     my $url = $self->base_url . $path;
 
     # Add query params to URL
-    if ($opts{params} && ref $opts{params} eq 'HASH' && %{$opts{params}}) {
+    if ( $opts{params} && ref $opts{params} eq 'HASH' && %{ $opts{params} } ) {
         my @pairs;
-        for my $key (sort keys %{$opts{params}}) {
+        for my $key ( sort keys %{ $opts{params} } ) {
             my $val = $opts{params}{$key} // '';
             push @pairs, _uri_encode($key) . '=' . _uri_encode($val);
         }
-        $url .= '?' . join('&', @pairs);
+        $url .= '?' . join( '&', @pairs );
     }
 
     my %request_opts;
-    if ($opts{body}) {
-        $request_opts{content} = encode_json($opts{body});
+    if ( $opts{body} ) {
+        $request_opts{content} = encode_json( $opts{body} );
     }
 
-    my $response = $self->_ua->request($method, $url, \%request_opts);
+    my $response = $self->_ua->request( $method, $url, \%request_opts );
 
-    unless ($response->{success}) {
+    unless ( $response->{success} ) {
         my $body = $response->{content} // '';
         my $parsed;
         eval { $parsed = decode_json($body) };
@@ -92,12 +94,12 @@ sub _request {
     }
 
     # 204 No Content or empty body
-    if ($response->{status} == 204 || !$response->{content}) {
+    if ( $response->{status} == 204 || !$response->{content} ) {
         return {};
     }
 
     my $result;
-    eval { $result = decode_json($response->{content}) };
+    eval { $result = decode_json( $response->{content} ) };
     if ($@) {
         return { raw => $response->{content} };
     }
@@ -105,28 +107,28 @@ sub _request {
 }
 
 sub get {
-    my ($self, $path, %opts) = @_;
-    return $self->_request('GET', $path, params => $opts{params});
+    my ( $self, $path, %opts ) = @_;
+    return $self->_request( 'GET', $path, params => $opts{params} );
 }
 
 sub post {
-    my ($self, $path, %opts) = @_;
-    return $self->_request('POST', $path, body => $opts{body}, params => $opts{params});
+    my ( $self, $path, %opts ) = @_;
+    return $self->_request( 'POST', $path, body => $opts{body}, params => $opts{params} );
 }
 
 sub put {
-    my ($self, $path, %opts) = @_;
-    return $self->_request('PUT', $path, body => $opts{body});
+    my ( $self, $path, %opts ) = @_;
+    return $self->_request( 'PUT', $path, body => $opts{body} );
 }
 
 sub patch {
-    my ($self, $path, %opts) = @_;
-    return $self->_request('PATCH', $path, body => $opts{body});
+    my ( $self, $path, %opts ) = @_;
+    return $self->_request( 'PATCH', $path, body => $opts{body} );
 }
 
 sub delete_request {
-    my ($self, $path) = @_;
-    return $self->_request('DELETE', $path);
+    my ( $self, $path ) = @_;
+    return $self->_request( 'DELETE', $path );
 }
 
 # Simple URI encoding
@@ -142,15 +144,14 @@ use Moo;
 use JSON qw(encode_json);
 
 has 'status_code' => ( is => 'ro', required => 1 );
-has 'body'        => ( is => 'ro', default => sub { '' } );
-has 'url'         => ( is => 'ro', default => sub { '' } );
-has 'method'      => ( is => 'ro', default => sub { 'GET' } );
+has 'body'        => ( is => 'ro', default  => sub { '' } );
+has 'url'         => ( is => 'ro', default  => sub { '' } );
+has 'method'      => ( is => 'ro', default  => sub { 'GET' } );
 
 use overload '""' => sub {
     my ($self) = @_;
-    my $body = ref $self->body ? encode_json($self->body) : ($self->body // '');
-    return sprintf('%s %s returned %s: %s',
-        $self->method, $self->url, $self->status_code, $body);
+    my $body = ref $self->body ? encode_json( $self->body ) : ( $self->body // '' );
+    return sprintf( '%s %s returned %s: %s', $self->method, $self->url, $self->status_code, $body );
 };
 
 1;

--- a/lib/SignalWire/REST/Namespaces/Base.pm
+++ b/lib/SignalWire/REST/Namespaces/Base.pm
@@ -8,8 +8,8 @@ has '_http'      => ( is => 'ro', required => 1 );
 has '_base_path' => ( is => 'ro', required => 1 );
 
 sub _path {
-    my ($self, @parts) = @_;
-    return join('/', $self->_base_path, @parts);
+    my ( $self, @parts ) = @_;
+    return join( '/', $self->_base_path, @parts );
 }
 
 # --- CrudResource ---
@@ -21,30 +21,30 @@ extends 'SignalWire::REST::Namespaces::Base';
 has '_update_method' => ( is => 'ro', default => sub { 'PATCH' } );
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub create {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_base_path, body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_base_path, body => \%kwargs );
 }
 
 sub get {
-    my ($self, $resource_id) = @_;
-    return $self->_http->get($self->_path($resource_id));
+    my ( $self, $resource_id ) = @_;
+    return $self->_http->get( $self->_path($resource_id) );
 }
 
 sub update {
-    my ($self, $resource_id, %kwargs) = @_;
-    my $method = lc($self->_update_method);
-    return $self->_http->$method($self->_path($resource_id), body => \%kwargs);
+    my ( $self, $resource_id, %kwargs ) = @_;
+    my $method = lc( $self->_update_method );
+    return $self->_http->$method( $self->_path($resource_id), body => \%kwargs );
 }
 
 sub delete_resource {
-    my ($self, $resource_id) = @_;
-    return $self->_http->delete_request($self->_path($resource_id));
+    my ( $self, $resource_id ) = @_;
+    return $self->_http->delete_request( $self->_path($resource_id) );
 }
 
 1;

--- a/lib/SignalWire/REST/Namespaces/Calling.pm
+++ b/lib/SignalWire/REST/Namespaces/Calling.pm
@@ -10,6 +10,7 @@ sub BUILD {
     my ($self) = @_;
 
     # base_path is /api/calling/calls
+    return;
 }
 
 sub _execute {
@@ -20,80 +21,98 @@ sub _execute {
 }
 
 # Call lifecycle
-sub dial { my ( $s, %p ) = @_; $s->_execute( 'dial', undef, %p ) }
+sub dial { my ( $s, %p ) = @_; return $s->_execute( 'dial', undef, %p ) }
 
 # Python parity: `update` is the public name; `update_call` stays as an
 # alias because earlier Perl releases shipped with that name.
-sub update      { my ( $s, %p )      = @_; $s->_execute( 'update', undef, %p ) }
-sub update_call { my ( $s, %p )      = @_; $s->_execute( 'update', undef, %p ) }
-sub end         { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.end', $id, %p ) }
-sub transfer    { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.transfer', $id, %p ) }
-sub disconnect  { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.disconnect', $id, %p ) }
+sub update      { my ( $s, %p )      = @_; return $s->_execute( 'update', undef, %p ) }
+sub update_call { my ( $s, %p )      = @_; return $s->_execute( 'update', undef, %p ) }
+sub end         { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.end', $id, %p ) }
+sub transfer    { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.transfer', $id, %p ) }
+sub disconnect  { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.disconnect', $id, %p ) }
 
 # Play
-sub play        { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.play',        $id, %p ) }
-sub play_pause  { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.play.pause',  $id, %p ) }
-sub play_resume { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.play.resume', $id, %p ) }
-sub play_stop   { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.play.stop',   $id, %p ) }
-sub play_volume { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.play.volume', $id, %p ) }
+sub play        { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.play',        $id, %p ) }
+sub play_pause  { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.play.pause',  $id, %p ) }
+sub play_resume { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.play.resume', $id, %p ) }
+sub play_stop   { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.play.stop',   $id, %p ) }
+sub play_volume { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.play.volume', $id, %p ) }
 
 # Record
-sub record        { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.record',        $id, %p ) }
-sub record_pause  { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.record.pause',  $id, %p ) }
-sub record_resume { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.record.resume', $id, %p ) }
-sub record_stop   { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.record.stop',   $id, %p ) }
+sub record       { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.record',       $id, %p ) }
+sub record_pause { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.record.pause', $id, %p ) }
+
+sub record_resume {
+    my ( $s, $id, %p ) = @_;
+    return $s->_execute( 'calling.record.resume', $id, %p );
+}
+sub record_stop { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.record.stop', $id, %p ) }
 
 # Collect
-sub collect      { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.collect',      $id, %p ) }
-sub collect_stop { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.collect.stop', $id, %p ) }
+sub collect      { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.collect',      $id, %p ) }
+sub collect_stop { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.collect.stop', $id, %p ) }
 
 sub collect_start_input_timers {
     my ( $s, $id, %p ) = @_;
-    $s->_execute( 'calling.collect.start_input_timers', $id, %p );
+    return $s->_execute( 'calling.collect.start_input_timers', $id, %p );
 }
 
 # Detect
-sub detect      { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.detect',      $id, %p ) }
-sub detect_stop { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.detect.stop', $id, %p ) }
+sub detect      { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.detect',      $id, %p ) }
+sub detect_stop { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.detect.stop', $id, %p ) }
 
 # Tap
-sub tap      { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.tap',      $id, %p ) }
-sub tap_stop { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.tap.stop', $id, %p ) }
+sub tap      { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.tap',      $id, %p ) }
+sub tap_stop { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.tap.stop', $id, %p ) }
 
 # Stream
-sub stream      { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.stream',      $id, %p ) }
-sub stream_stop { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.stream.stop', $id, %p ) }
+sub stream      { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.stream',      $id, %p ) }
+sub stream_stop { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.stream.stop', $id, %p ) }
 
 # Denoise
-sub denoise      { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.denoise',      $id, %p ) }
-sub denoise_stop { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.denoise.stop', $id, %p ) }
+sub denoise      { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.denoise',      $id, %p ) }
+sub denoise_stop { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.denoise.stop', $id, %p ) }
 
 # Transcribe
-sub transcribe      { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.transcribe',      $id, %p ) }
-sub transcribe_stop { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.transcribe.stop', $id, %p ) }
+sub transcribe { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.transcribe', $id, %p ) }
+
+sub transcribe_stop {
+    my ( $s, $id, %p ) = @_;
+    return $s->_execute( 'calling.transcribe.stop', $id, %p );
+}
 
 # AI
-sub ai_message { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.ai_message', $id, %p ) }
-sub ai_hold    { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.ai_hold',    $id, %p ) }
-sub ai_unhold  { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.ai_unhold',  $id, %p ) }
-sub ai_stop    { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.ai.stop',    $id, %p ) }
+sub ai_message { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.ai_message', $id, %p ) }
+sub ai_hold    { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.ai_hold',    $id, %p ) }
+sub ai_unhold  { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.ai_unhold',  $id, %p ) }
+sub ai_stop    { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.ai.stop',    $id, %p ) }
 
 # Live transcribe / translate
-sub live_transcribe { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.live_transcribe', $id, %p ) }
-sub live_translate  { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.live_translate',  $id, %p ) }
+sub live_transcribe {
+    my ( $s, $id, %p ) = @_;
+    return $s->_execute( 'calling.live_transcribe', $id, %p );
+}
+
+sub live_translate {
+    my ( $s, $id, %p ) = @_;
+    return $s->_execute( 'calling.live_translate', $id, %p );
+}
 
 # Fax
-sub send_fax_stop { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.send_fax.stop', $id, %p ) }
+sub send_fax_stop {
+    my ( $s, $id, %p ) = @_;
+    return $s->_execute( 'calling.send_fax.stop', $id, %p );
+}
 
 sub receive_fax_stop {
     my ( $s, $id, %p ) = @_;
-    $s->_execute( 'calling.receive_fax.stop', $id, %p );
+    return $s->_execute( 'calling.receive_fax.stop', $id, %p );
 }
 
 # SIP
-sub refer { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.refer', $id, %p ) }
+sub refer { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.refer', $id, %p ) }
 
 # Custom events
-sub user_event { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.user_event', $id, %p ) }
+sub user_event { my ( $s, $id, %p ) = @_; return $s->_execute( 'calling.user_event', $id, %p ) }
 
 1;

--- a/lib/SignalWire/REST/Namespaces/Calling.pm
+++ b/lib/SignalWire/REST/Namespaces/Calling.pm
@@ -8,82 +8,92 @@ extends 'SignalWire::REST::Namespaces::Base';
 
 sub BUILD {
     my ($self) = @_;
+
     # base_path is /api/calling/calls
 }
 
 sub _execute {
-    my ($self, $command, $call_id, %params) = @_;
-    my %body = (command => $command, params => \%params);
+    my ( $self, $command, $call_id, %params ) = @_;
+    my %body = ( command => $command, params => \%params );
     $body{id} = $call_id if defined $call_id;
-    return $self->_http->post($self->_base_path, body => \%body);
+    return $self->_http->post( $self->_base_path, body => \%body );
 }
 
 # Call lifecycle
-sub dial        { my ($s, %p) = @_; $s->_execute('dial', undef, %p) }
+sub dial { my ( $s, %p ) = @_; $s->_execute( 'dial', undef, %p ) }
+
 # Python parity: `update` is the public name; `update_call` stays as an
 # alias because earlier Perl releases shipped with that name.
-sub update      { my ($s, %p) = @_; $s->_execute('update', undef, %p) }
-sub update_call { my ($s, %p) = @_; $s->_execute('update', undef, %p) }
-sub end         { my ($s, $id, %p) = @_; $s->_execute('calling.end', $id, %p) }
-sub transfer    { my ($s, $id, %p) = @_; $s->_execute('calling.transfer', $id, %p) }
-sub disconnect  { my ($s, $id, %p) = @_; $s->_execute('calling.disconnect', $id, %p) }
+sub update      { my ( $s, %p )      = @_; $s->_execute( 'update', undef, %p ) }
+sub update_call { my ( $s, %p )      = @_; $s->_execute( 'update', undef, %p ) }
+sub end         { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.end', $id, %p ) }
+sub transfer    { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.transfer', $id, %p ) }
+sub disconnect  { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.disconnect', $id, %p ) }
 
 # Play
-sub play        { my ($s, $id, %p) = @_; $s->_execute('calling.play', $id, %p) }
-sub play_pause  { my ($s, $id, %p) = @_; $s->_execute('calling.play.pause', $id, %p) }
-sub play_resume { my ($s, $id, %p) = @_; $s->_execute('calling.play.resume', $id, %p) }
-sub play_stop   { my ($s, $id, %p) = @_; $s->_execute('calling.play.stop', $id, %p) }
-sub play_volume { my ($s, $id, %p) = @_; $s->_execute('calling.play.volume', $id, %p) }
+sub play        { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.play',        $id, %p ) }
+sub play_pause  { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.play.pause',  $id, %p ) }
+sub play_resume { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.play.resume', $id, %p ) }
+sub play_stop   { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.play.stop',   $id, %p ) }
+sub play_volume { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.play.volume', $id, %p ) }
 
 # Record
-sub record        { my ($s, $id, %p) = @_; $s->_execute('calling.record', $id, %p) }
-sub record_pause  { my ($s, $id, %p) = @_; $s->_execute('calling.record.pause', $id, %p) }
-sub record_resume { my ($s, $id, %p) = @_; $s->_execute('calling.record.resume', $id, %p) }
-sub record_stop   { my ($s, $id, %p) = @_; $s->_execute('calling.record.stop', $id, %p) }
+sub record        { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.record',        $id, %p ) }
+sub record_pause  { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.record.pause',  $id, %p ) }
+sub record_resume { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.record.resume', $id, %p ) }
+sub record_stop   { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.record.stop',   $id, %p ) }
 
 # Collect
-sub collect                    { my ($s, $id, %p) = @_; $s->_execute('calling.collect', $id, %p) }
-sub collect_stop               { my ($s, $id, %p) = @_; $s->_execute('calling.collect.stop', $id, %p) }
-sub collect_start_input_timers { my ($s, $id, %p) = @_; $s->_execute('calling.collect.start_input_timers', $id, %p) }
+sub collect      { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.collect',      $id, %p ) }
+sub collect_stop { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.collect.stop', $id, %p ) }
+
+sub collect_start_input_timers {
+    my ( $s, $id, %p ) = @_;
+    $s->_execute( 'calling.collect.start_input_timers', $id, %p );
+}
 
 # Detect
-sub detect      { my ($s, $id, %p) = @_; $s->_execute('calling.detect', $id, %p) }
-sub detect_stop { my ($s, $id, %p) = @_; $s->_execute('calling.detect.stop', $id, %p) }
+sub detect      { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.detect',      $id, %p ) }
+sub detect_stop { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.detect.stop', $id, %p ) }
 
 # Tap
-sub tap      { my ($s, $id, %p) = @_; $s->_execute('calling.tap', $id, %p) }
-sub tap_stop { my ($s, $id, %p) = @_; $s->_execute('calling.tap.stop', $id, %p) }
+sub tap      { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.tap',      $id, %p ) }
+sub tap_stop { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.tap.stop', $id, %p ) }
 
 # Stream
-sub stream      { my ($s, $id, %p) = @_; $s->_execute('calling.stream', $id, %p) }
-sub stream_stop { my ($s, $id, %p) = @_; $s->_execute('calling.stream.stop', $id, %p) }
+sub stream      { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.stream',      $id, %p ) }
+sub stream_stop { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.stream.stop', $id, %p ) }
 
 # Denoise
-sub denoise      { my ($s, $id, %p) = @_; $s->_execute('calling.denoise', $id, %p) }
-sub denoise_stop { my ($s, $id, %p) = @_; $s->_execute('calling.denoise.stop', $id, %p) }
+sub denoise      { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.denoise',      $id, %p ) }
+sub denoise_stop { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.denoise.stop', $id, %p ) }
 
 # Transcribe
-sub transcribe      { my ($s, $id, %p) = @_; $s->_execute('calling.transcribe', $id, %p) }
-sub transcribe_stop { my ($s, $id, %p) = @_; $s->_execute('calling.transcribe.stop', $id, %p) }
+sub transcribe      { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.transcribe',      $id, %p ) }
+sub transcribe_stop { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.transcribe.stop', $id, %p ) }
 
 # AI
-sub ai_message { my ($s, $id, %p) = @_; $s->_execute('calling.ai_message', $id, %p) }
-sub ai_hold    { my ($s, $id, %p) = @_; $s->_execute('calling.ai_hold', $id, %p) }
-sub ai_unhold  { my ($s, $id, %p) = @_; $s->_execute('calling.ai_unhold', $id, %p) }
-sub ai_stop    { my ($s, $id, %p) = @_; $s->_execute('calling.ai.stop', $id, %p) }
+sub ai_message { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.ai_message', $id, %p ) }
+sub ai_hold    { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.ai_hold',    $id, %p ) }
+sub ai_unhold  { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.ai_unhold',  $id, %p ) }
+sub ai_stop    { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.ai.stop',    $id, %p ) }
 
 # Live transcribe / translate
-sub live_transcribe { my ($s, $id, %p) = @_; $s->_execute('calling.live_transcribe', $id, %p) }
-sub live_translate  { my ($s, $id, %p) = @_; $s->_execute('calling.live_translate', $id, %p) }
+sub live_transcribe { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.live_transcribe', $id, %p ) }
+sub live_translate  { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.live_translate',  $id, %p ) }
 
 # Fax
-sub send_fax_stop    { my ($s, $id, %p) = @_; $s->_execute('calling.send_fax.stop', $id, %p) }
-sub receive_fax_stop { my ($s, $id, %p) = @_; $s->_execute('calling.receive_fax.stop', $id, %p) }
+sub send_fax_stop { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.send_fax.stop', $id, %p ) }
+
+sub receive_fax_stop {
+    my ( $s, $id, %p ) = @_;
+    $s->_execute( 'calling.receive_fax.stop', $id, %p );
+}
 
 # SIP
-sub refer { my ($s, $id, %p) = @_; $s->_execute('calling.refer', $id, %p) }
+sub refer { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.refer', $id, %p ) }
 
 # Custom events
-sub user_event { my ($s, $id, %p) = @_; $s->_execute('calling.user_event', $id, %p) }
+sub user_event { my ( $s, $id, %p ) = @_; $s->_execute( 'calling.user_event', $id, %p ) }
 
 1;

--- a/lib/SignalWire/REST/Namespaces/Chat.pm
+++ b/lib/SignalWire/REST/Namespaces/Chat.pm
@@ -5,8 +5,8 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub create_token {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_base_path, body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_base_path, body => \%kwargs );
 }
 
 1;

--- a/lib/SignalWire/REST/Namespaces/Compat.pm
+++ b/lib/SignalWire/REST/Namespaces/Compat.pm
@@ -9,24 +9,24 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub create {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_base_path, body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_base_path, body => \%kwargs );
 }
 
 sub get {
-    my ($self, $sid) = @_;
-    return $self->_http->get($self->_path($sid));
+    my ( $self, $sid ) = @_;
+    return $self->_http->get( $self->_path($sid) );
 }
 
 sub update {
-    my ($self, $sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($sid), body => \%kwargs);
+    my ( $self, $sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path($sid), body => \%kwargs );
 }
 
 # --- CompatCalls ---
@@ -35,28 +35,30 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::CrudResource';
 
 sub update {
-    my ($self, $sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($sid), body => \%kwargs);
+    my ( $self, $sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path($sid), body => \%kwargs );
 }
 
 sub start_recording {
-    my ($self, $call_sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($call_sid, 'Recordings'), body => \%kwargs);
+    my ( $self, $call_sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $call_sid, 'Recordings' ), body => \%kwargs );
 }
 
 sub update_recording {
-    my ($self, $call_sid, $recording_sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($call_sid, 'Recordings', $recording_sid), body => \%kwargs);
+    my ( $self, $call_sid, $recording_sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $call_sid, 'Recordings', $recording_sid ),
+        body => \%kwargs );
 }
 
 sub start_stream {
-    my ($self, $call_sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($call_sid, 'Streams'), body => \%kwargs);
+    my ( $self, $call_sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $call_sid, 'Streams' ), body => \%kwargs );
 }
 
 sub stop_stream {
-    my ($self, $call_sid, $stream_sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($call_sid, 'Streams', $stream_sid), body => \%kwargs);
+    my ( $self, $call_sid, $stream_sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $call_sid, 'Streams', $stream_sid ),
+        body => \%kwargs );
 }
 
 # --- CompatMessages ---
@@ -65,24 +67,24 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::CrudResource';
 
 sub update {
-    my ($self, $sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($sid), body => \%kwargs);
+    my ( $self, $sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path($sid), body => \%kwargs );
 }
 
 sub list_media {
-    my ($self, $message_sid, %params) = @_;
+    my ( $self, $message_sid, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($message_sid, 'Media'), params => $p);
+    return $self->_http->get( $self->_path( $message_sid, 'Media' ), params => $p );
 }
 
 sub get_media {
-    my ($self, $message_sid, $media_sid) = @_;
-    return $self->_http->get($self->_path($message_sid, 'Media', $media_sid));
+    my ( $self, $message_sid, $media_sid ) = @_;
+    return $self->_http->get( $self->_path( $message_sid, 'Media', $media_sid ) );
 }
 
 sub delete_media {
-    my ($self, $message_sid, $media_sid) = @_;
-    return $self->_http->delete_request($self->_path($message_sid, 'Media', $media_sid));
+    my ( $self, $message_sid, $media_sid ) = @_;
+    return $self->_http->delete_request( $self->_path( $message_sid, 'Media', $media_sid ) );
 }
 
 # --- CompatFaxes ---
@@ -91,24 +93,24 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::CrudResource';
 
 sub update {
-    my ($self, $sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($sid), body => \%kwargs);
+    my ( $self, $sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path($sid), body => \%kwargs );
 }
 
 sub list_media {
-    my ($self, $fax_sid, %params) = @_;
+    my ( $self, $fax_sid, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($fax_sid, 'Media'), params => $p);
+    return $self->_http->get( $self->_path( $fax_sid, 'Media' ), params => $p );
 }
 
 sub get_media {
-    my ($self, $fax_sid, $media_sid) = @_;
-    return $self->_http->get($self->_path($fax_sid, 'Media', $media_sid));
+    my ( $self, $fax_sid, $media_sid ) = @_;
+    return $self->_http->get( $self->_path( $fax_sid, 'Media', $media_sid ) );
 }
 
 sub delete_media {
-    my ($self, $fax_sid, $media_sid) = @_;
-    return $self->_http->delete_request($self->_path($fax_sid, 'Media', $media_sid));
+    my ( $self, $fax_sid, $media_sid ) = @_;
+    return $self->_http->delete_request( $self->_path( $fax_sid, 'Media', $media_sid ) );
 }
 
 # --- CompatConferences ---
@@ -117,71 +119,76 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub get {
-    my ($self, $sid) = @_;
-    return $self->_http->get($self->_path($sid));
+    my ( $self, $sid ) = @_;
+    return $self->_http->get( $self->_path($sid) );
 }
 
 sub update {
-    my ($self, $sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($sid), body => \%kwargs);
+    my ( $self, $sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path($sid), body => \%kwargs );
 }
 
 sub list_participants {
-    my ($self, $conference_sid, %params) = @_;
+    my ( $self, $conference_sid, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($conference_sid, 'Participants'), params => $p);
+    return $self->_http->get( $self->_path( $conference_sid, 'Participants' ), params => $p );
 }
 
 sub get_participant {
-    my ($self, $conference_sid, $call_sid) = @_;
-    return $self->_http->get($self->_path($conference_sid, 'Participants', $call_sid));
+    my ( $self, $conference_sid, $call_sid ) = @_;
+    return $self->_http->get( $self->_path( $conference_sid, 'Participants', $call_sid ) );
 }
 
 sub update_participant {
-    my ($self, $conference_sid, $call_sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($conference_sid, 'Participants', $call_sid), body => \%kwargs);
+    my ( $self, $conference_sid, $call_sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $conference_sid, 'Participants', $call_sid ),
+        body => \%kwargs );
 }
 
 sub remove_participant {
-    my ($self, $conference_sid, $call_sid) = @_;
-    return $self->_http->delete_request($self->_path($conference_sid, 'Participants', $call_sid));
+    my ( $self, $conference_sid, $call_sid ) = @_;
+    return $self->_http->delete_request(
+        $self->_path( $conference_sid, 'Participants', $call_sid ) );
 }
 
 sub list_recordings {
-    my ($self, $conference_sid, %params) = @_;
+    my ( $self, $conference_sid, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($conference_sid, 'Recordings'), params => $p);
+    return $self->_http->get( $self->_path( $conference_sid, 'Recordings' ), params => $p );
 }
 
 sub get_recording {
-    my ($self, $conference_sid, $recording_sid) = @_;
-    return $self->_http->get($self->_path($conference_sid, 'Recordings', $recording_sid));
+    my ( $self, $conference_sid, $recording_sid ) = @_;
+    return $self->_http->get( $self->_path( $conference_sid, 'Recordings', $recording_sid ) );
 }
 
 sub update_recording {
-    my ($self, $conference_sid, $recording_sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($conference_sid, 'Recordings', $recording_sid), body => \%kwargs);
+    my ( $self, $conference_sid, $recording_sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $conference_sid, 'Recordings', $recording_sid ),
+        body => \%kwargs );
 }
 
 sub delete_recording {
-    my ($self, $conference_sid, $recording_sid) = @_;
-    return $self->_http->delete_request($self->_path($conference_sid, 'Recordings', $recording_sid));
+    my ( $self, $conference_sid, $recording_sid ) = @_;
+    return $self->_http->delete_request(
+        $self->_path( $conference_sid, 'Recordings', $recording_sid ) );
 }
 
 sub start_stream {
-    my ($self, $conference_sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($conference_sid, 'Streams'), body => \%kwargs);
+    my ( $self, $conference_sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $conference_sid, 'Streams' ), body => \%kwargs );
 }
 
 sub stop_stream {
-    my ($self, $conference_sid, $stream_sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($conference_sid, 'Streams', $stream_sid), body => \%kwargs);
+    my ( $self, $conference_sid, $stream_sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $conference_sid, 'Streams', $stream_sid ),
+        body => \%kwargs );
 }
 
 # --- CompatPhoneNumbers ---
@@ -193,64 +200,64 @@ has '_available_base' => ( is => 'lazy' );
 
 sub _build__available_base {
     my ($self) = @_;
-    (my $path = $self->_base_path) =~ s/IncomingPhoneNumbers/AvailablePhoneNumbers/;
+    ( my $path = $self->_base_path ) =~ s/IncomingPhoneNumbers/AvailablePhoneNumbers/;
     return $path;
 }
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub purchase {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_base_path, body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_base_path, body => \%kwargs );
 }
 
 sub get {
-    my ($self, $sid) = @_;
-    return $self->_http->get($self->_path($sid));
+    my ( $self, $sid ) = @_;
+    return $self->_http->get( $self->_path($sid) );
 }
 
 sub update {
-    my ($self, $sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($sid), body => \%kwargs);
+    my ( $self, $sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path($sid), body => \%kwargs );
 }
 
 sub delete_number {
-    my ($self, $sid) = @_;
-    return $self->_http->delete_request($self->_path($sid));
+    my ( $self, $sid ) = @_;
+    return $self->_http->delete_request( $self->_path($sid) );
 }
 
 # Python parity alias.
 sub delete {
-    my ($self, $sid) = @_;
-    return $self->_http->delete_request($self->_path($sid));
+    my ( $self, $sid ) = @_;
+    return $self->_http->delete_request( $self->_path($sid) );
 }
 
 sub import_number {
-    my ($self, %kwargs) = @_;
-    (my $path = $self->_base_path) =~ s/IncomingPhoneNumbers/ImportedPhoneNumbers/;
-    return $self->_http->post($path, body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    ( my $path = $self->_base_path ) =~ s/IncomingPhoneNumbers/ImportedPhoneNumbers/;
+    return $self->_http->post( $path, body => \%kwargs );
 }
 
 sub list_available_countries {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_available_base, params => $p);
+    return $self->_http->get( $self->_available_base, params => $p );
 }
 
 sub search_local {
-    my ($self, $country, %params) = @_;
+    my ( $self, $country, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_available_base . "/$country/Local", params => $p);
+    return $self->_http->get( $self->_available_base . "/$country/Local", params => $p );
 }
 
 sub search_toll_free {
-    my ($self, $country, %params) = @_;
+    my ( $self, $country, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_available_base . "/$country/TollFree", params => $p);
+    return $self->_http->get( $self->_available_base . "/$country/TollFree", params => $p );
 }
 
 # --- CompatApplications ---
@@ -259,8 +266,8 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::CrudResource';
 
 sub update {
-    my ($self, $sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($sid), body => \%kwargs);
+    my ( $self, $sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path($sid), body => \%kwargs );
 }
 
 # --- CompatLamlBins ---
@@ -269,8 +276,8 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::CrudResource';
 
 sub update {
-    my ($self, $sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($sid), body => \%kwargs);
+    my ( $self, $sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path($sid), body => \%kwargs );
 }
 
 # --- CompatQueues ---
@@ -279,24 +286,24 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::CrudResource';
 
 sub update {
-    my ($self, $sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($sid), body => \%kwargs);
+    my ( $self, $sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path($sid), body => \%kwargs );
 }
 
 sub list_members {
-    my ($self, $queue_sid, %params) = @_;
+    my ( $self, $queue_sid, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($queue_sid, 'Members'), params => $p);
+    return $self->_http->get( $self->_path( $queue_sid, 'Members' ), params => $p );
 }
 
 sub get_member {
-    my ($self, $queue_sid, $call_sid) = @_;
-    return $self->_http->get($self->_path($queue_sid, 'Members', $call_sid));
+    my ( $self, $queue_sid, $call_sid ) = @_;
+    return $self->_http->get( $self->_path( $queue_sid, 'Members', $call_sid ) );
 }
 
 sub dequeue_member {
-    my ($self, $queue_sid, $call_sid, %kwargs) = @_;
-    return $self->_http->post($self->_path($queue_sid, 'Members', $call_sid), body => \%kwargs);
+    my ( $self, $queue_sid, $call_sid, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $queue_sid, 'Members', $call_sid ), body => \%kwargs );
 }
 
 # --- CompatRecordings ---
@@ -305,25 +312,25 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub get {
-    my ($self, $sid) = @_;
-    return $self->_http->get($self->_path($sid));
+    my ( $self, $sid ) = @_;
+    return $self->_http->get( $self->_path($sid) );
 }
 
 sub delete_recording {
-    my ($self, $sid) = @_;
-    return $self->_http->delete_request($self->_path($sid));
+    my ( $self, $sid ) = @_;
+    return $self->_http->delete_request( $self->_path($sid) );
 }
 
 # Python parity alias.
 sub delete {
-    my ($self, $sid) = @_;
-    return $self->_http->delete_request($self->_path($sid));
+    my ( $self, $sid ) = @_;
+    return $self->_http->delete_request( $self->_path($sid) );
 }
 
 # --- CompatTranscriptions ---
@@ -332,25 +339,25 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub get {
-    my ($self, $sid) = @_;
-    return $self->_http->get($self->_path($sid));
+    my ( $self, $sid ) = @_;
+    return $self->_http->get( $self->_path($sid) );
 }
 
 sub delete_transcription {
-    my ($self, $sid) = @_;
-    return $self->_http->delete_request($self->_path($sid));
+    my ( $self, $sid ) = @_;
+    return $self->_http->delete_request( $self->_path($sid) );
 }
 
 # Python parity alias.
 sub delete {
-    my ($self, $sid) = @_;
-    return $self->_http->delete_request($self->_path($sid));
+    my ( $self, $sid ) = @_;
+    return $self->_http->delete_request( $self->_path($sid) );
 }
 
 # --- CompatTokens ---
@@ -359,32 +366,32 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub create {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_base_path, body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_base_path, body => \%kwargs );
 }
 
 sub update {
-    my ($self, $token_id, %kwargs) = @_;
-    return $self->_http->patch($self->_path($token_id), body => \%kwargs);
+    my ( $self, $token_id, %kwargs ) = @_;
+    return $self->_http->patch( $self->_path($token_id), body => \%kwargs );
 }
 
 sub delete_token {
-    my ($self, $token_id) = @_;
-    return $self->_http->delete_request($self->_path($token_id));
+    my ( $self, $token_id ) = @_;
+    return $self->_http->delete_request( $self->_path($token_id) );
 }
 
 # Python parity alias.
 sub delete {
-    my ($self, $token_id) = @_;
-    return $self->_http->delete_request($self->_path($token_id));
+    my ( $self, $token_id ) = @_;
+    return $self->_http->delete_request( $self->_path($token_id) );
 }
 
 # --- CompatNamespace ---
 package SignalWire::REST::Namespaces::Compat;
 use Moo;
 
-has '_http'        => ( is => 'ro', required => 1 );
-has 'account_sid'  => ( is => 'ro', required => 1 );
+has '_http'       => ( is => 'ro', required => 1 );
+has 'account_sid' => ( is => 'ro', required => 1 );
 
 has 'accounts'       => ( is => 'lazy' );
 has 'calls'          => ( is => 'lazy' );
@@ -404,17 +411,88 @@ sub _base {
     return '/api/laml/2010-04-01/Accounts/' . $self->account_sid;
 }
 
-sub _build_accounts       { SignalWire::REST::Namespaces::Compat::Accounts->new(_http => $_[0]->_http, _base_path => '/api/laml/2010-04-01/Accounts') }
-sub _build_calls          { SignalWire::REST::Namespaces::Compat::Calls->new(_http => $_[0]->_http, _base_path => $_[0]->_base . '/Calls') }
-sub _build_messages       { SignalWire::REST::Namespaces::Compat::Messages->new(_http => $_[0]->_http, _base_path => $_[0]->_base . '/Messages') }
-sub _build_faxes          { SignalWire::REST::Namespaces::Compat::Faxes->new(_http => $_[0]->_http, _base_path => $_[0]->_base . '/Faxes') }
-sub _build_conferences    { SignalWire::REST::Namespaces::Compat::Conferences->new(_http => $_[0]->_http, _base_path => $_[0]->_base . '/Conferences') }
-sub _build_phone_numbers  { SignalWire::REST::Namespaces::Compat::PhoneNumbers->new(_http => $_[0]->_http, _base_path => $_[0]->_base . '/IncomingPhoneNumbers') }
-sub _build_applications   { SignalWire::REST::Namespaces::Compat::Applications->new(_http => $_[0]->_http, _base_path => $_[0]->_base . '/Applications') }
-sub _build_laml_bins      { SignalWire::REST::Namespaces::Compat::LamlBins->new(_http => $_[0]->_http, _base_path => $_[0]->_base . '/LamlBins') }
-sub _build_queues         { SignalWire::REST::Namespaces::Compat::Queues->new(_http => $_[0]->_http, _base_path => $_[0]->_base . '/Queues') }
-sub _build_recordings     { SignalWire::REST::Namespaces::Compat::Recordings->new(_http => $_[0]->_http, _base_path => $_[0]->_base . '/Recordings') }
-sub _build_transcriptions { SignalWire::REST::Namespaces::Compat::Transcriptions->new(_http => $_[0]->_http, _base_path => $_[0]->_base . '/Transcriptions') }
-sub _build_tokens         { SignalWire::REST::Namespaces::Compat::Tokens->new(_http => $_[0]->_http, _base_path => $_[0]->_base . '/tokens') }
+sub _build_accounts {
+    SignalWire::REST::Namespaces::Compat::Accounts->new(
+        _http      => $_[0]->_http,
+        _base_path => '/api/laml/2010-04-01/Accounts'
+    );
+}
+
+sub _build_calls {
+    SignalWire::REST::Namespaces::Compat::Calls->new(
+        _http      => $_[0]->_http,
+        _base_path => $_[0]->_base . '/Calls'
+    );
+}
+
+sub _build_messages {
+    SignalWire::REST::Namespaces::Compat::Messages->new(
+        _http      => $_[0]->_http,
+        _base_path => $_[0]->_base . '/Messages'
+    );
+}
+
+sub _build_faxes {
+    SignalWire::REST::Namespaces::Compat::Faxes->new(
+        _http      => $_[0]->_http,
+        _base_path => $_[0]->_base . '/Faxes'
+    );
+}
+
+sub _build_conferences {
+    SignalWire::REST::Namespaces::Compat::Conferences->new(
+        _http      => $_[0]->_http,
+        _base_path => $_[0]->_base . '/Conferences'
+    );
+}
+
+sub _build_phone_numbers {
+    SignalWire::REST::Namespaces::Compat::PhoneNumbers->new(
+        _http      => $_[0]->_http,
+        _base_path => $_[0]->_base . '/IncomingPhoneNumbers'
+    );
+}
+
+sub _build_applications {
+    SignalWire::REST::Namespaces::Compat::Applications->new(
+        _http      => $_[0]->_http,
+        _base_path => $_[0]->_base . '/Applications'
+    );
+}
+
+sub _build_laml_bins {
+    SignalWire::REST::Namespaces::Compat::LamlBins->new(
+        _http      => $_[0]->_http,
+        _base_path => $_[0]->_base . '/LamlBins'
+    );
+}
+
+sub _build_queues {
+    SignalWire::REST::Namespaces::Compat::Queues->new(
+        _http      => $_[0]->_http,
+        _base_path => $_[0]->_base . '/Queues'
+    );
+}
+
+sub _build_recordings {
+    SignalWire::REST::Namespaces::Compat::Recordings->new(
+        _http      => $_[0]->_http,
+        _base_path => $_[0]->_base . '/Recordings'
+    );
+}
+
+sub _build_transcriptions {
+    SignalWire::REST::Namespaces::Compat::Transcriptions->new(
+        _http      => $_[0]->_http,
+        _base_path => $_[0]->_base . '/Transcriptions'
+    );
+}
+
+sub _build_tokens {
+    SignalWire::REST::Namespaces::Compat::Tokens->new(
+        _http      => $_[0]->_http,
+        _base_path => $_[0]->_base . '/tokens'
+    );
+}
 
 1;

--- a/lib/SignalWire/REST/Namespaces/Compat.pm
+++ b/lib/SignalWire/REST/Namespaces/Compat.pm
@@ -412,86 +412,98 @@ sub _base {
 }
 
 sub _build_accounts {
-    SignalWire::REST::Namespaces::Compat::Accounts->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Compat::Accounts->new(
+        _http      => $self->_http,
         _base_path => '/api/laml/2010-04-01/Accounts'
     );
 }
 
 sub _build_calls {
-    SignalWire::REST::Namespaces::Compat::Calls->new(
-        _http      => $_[0]->_http,
-        _base_path => $_[0]->_base . '/Calls'
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Compat::Calls->new(
+        _http      => $self->_http,
+        _base_path => $self->_base . '/Calls'
     );
 }
 
 sub _build_messages {
-    SignalWire::REST::Namespaces::Compat::Messages->new(
-        _http      => $_[0]->_http,
-        _base_path => $_[0]->_base . '/Messages'
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Compat::Messages->new(
+        _http      => $self->_http,
+        _base_path => $self->_base . '/Messages'
     );
 }
 
 sub _build_faxes {
-    SignalWire::REST::Namespaces::Compat::Faxes->new(
-        _http      => $_[0]->_http,
-        _base_path => $_[0]->_base . '/Faxes'
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Compat::Faxes->new(
+        _http      => $self->_http,
+        _base_path => $self->_base . '/Faxes'
     );
 }
 
 sub _build_conferences {
-    SignalWire::REST::Namespaces::Compat::Conferences->new(
-        _http      => $_[0]->_http,
-        _base_path => $_[0]->_base . '/Conferences'
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Compat::Conferences->new(
+        _http      => $self->_http,
+        _base_path => $self->_base . '/Conferences'
     );
 }
 
 sub _build_phone_numbers {
-    SignalWire::REST::Namespaces::Compat::PhoneNumbers->new(
-        _http      => $_[0]->_http,
-        _base_path => $_[0]->_base . '/IncomingPhoneNumbers'
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Compat::PhoneNumbers->new(
+        _http      => $self->_http,
+        _base_path => $self->_base . '/IncomingPhoneNumbers'
     );
 }
 
 sub _build_applications {
-    SignalWire::REST::Namespaces::Compat::Applications->new(
-        _http      => $_[0]->_http,
-        _base_path => $_[0]->_base . '/Applications'
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Compat::Applications->new(
+        _http      => $self->_http,
+        _base_path => $self->_base . '/Applications'
     );
 }
 
 sub _build_laml_bins {
-    SignalWire::REST::Namespaces::Compat::LamlBins->new(
-        _http      => $_[0]->_http,
-        _base_path => $_[0]->_base . '/LamlBins'
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Compat::LamlBins->new(
+        _http      => $self->_http,
+        _base_path => $self->_base . '/LamlBins'
     );
 }
 
 sub _build_queues {
-    SignalWire::REST::Namespaces::Compat::Queues->new(
-        _http      => $_[0]->_http,
-        _base_path => $_[0]->_base . '/Queues'
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Compat::Queues->new(
+        _http      => $self->_http,
+        _base_path => $self->_base . '/Queues'
     );
 }
 
 sub _build_recordings {
-    SignalWire::REST::Namespaces::Compat::Recordings->new(
-        _http      => $_[0]->_http,
-        _base_path => $_[0]->_base . '/Recordings'
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Compat::Recordings->new(
+        _http      => $self->_http,
+        _base_path => $self->_base . '/Recordings'
     );
 }
 
 sub _build_transcriptions {
-    SignalWire::REST::Namespaces::Compat::Transcriptions->new(
-        _http      => $_[0]->_http,
-        _base_path => $_[0]->_base . '/Transcriptions'
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Compat::Transcriptions->new(
+        _http      => $self->_http,
+        _base_path => $self->_base . '/Transcriptions'
     );
 }
 
 sub _build_tokens {
-    SignalWire::REST::Namespaces::Compat::Tokens->new(
-        _http      => $_[0]->_http,
-        _base_path => $_[0]->_base . '/tokens'
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Compat::Tokens->new(
+        _http      => $self->_http,
+        _base_path => $self->_base . '/tokens'
     );
 }
 

--- a/lib/SignalWire/REST/Namespaces/Datasphere.pm
+++ b/lib/SignalWire/REST/Namespaces/Datasphere.pm
@@ -9,24 +9,24 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::CrudResource';
 
 sub search {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_path('search'), body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_path('search'), body => \%kwargs );
 }
 
 sub list_chunks {
-    my ($self, $document_id, %params) = @_;
+    my ( $self, $document_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($document_id, 'chunks'), params => $p);
+    return $self->_http->get( $self->_path( $document_id, 'chunks' ), params => $p );
 }
 
 sub get_chunk {
-    my ($self, $document_id, $chunk_id) = @_;
-    return $self->_http->get($self->_path($document_id, 'chunks', $chunk_id));
+    my ( $self, $document_id, $chunk_id ) = @_;
+    return $self->_http->get( $self->_path( $document_id, 'chunks', $chunk_id ) );
 }
 
 sub delete_chunk {
-    my ($self, $document_id, $chunk_id) = @_;
-    return $self->_http->delete_request($self->_path($document_id, 'chunks', $chunk_id));
+    my ( $self, $document_id, $chunk_id ) = @_;
+    return $self->_http->delete_request( $self->_path( $document_id, 'chunks', $chunk_id ) );
 }
 
 # --- DatasphereNamespace ---

--- a/lib/SignalWire/REST/Namespaces/Fabric.pm
+++ b/lib/SignalWire/REST/Namespaces/Fabric.pm
@@ -260,36 +260,59 @@ has 'tokens'                => ( is => 'lazy' );
 
 my $base = '/api/fabric/resources';
 
-sub _build_swml_scripts       { $_[0]->_mk( 'ResourcePUT', "$base/swml_scripts" ) }
-sub _build_relay_applications { $_[0]->_mk( 'ResourcePUT', "$base/relay_applications" ) }
+sub _build_swml_scripts {
+    my ($self) = @_;
+    return $self->_mk( 'ResourcePUT', "$base/swml_scripts" );
+}
+
+sub _build_relay_applications {
+    my ($self) = @_;
+    return $self->_mk( 'ResourcePUT', "$base/relay_applications" );
+}
 
 sub _build_call_flows {
-    SignalWire::REST::Namespaces::Fabric::CallFlows->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Fabric::CallFlows->new(
+        _http      => $self->_http,
         _base_path => "$base/call_flows"
     );
 }
 
 sub _build_conference_rooms {
-    SignalWire::REST::Namespaces::Fabric::ConferenceRooms->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Fabric::ConferenceRooms->new(
+        _http      => $self->_http,
         _base_path => "$base/conference_rooms"
     );
 }
-sub _build_freeswitch_connectors { $_[0]->_mk( 'ResourcePUT', "$base/freeswitch_connectors" ) }
+
+sub _build_freeswitch_connectors {
+    my ($self) = @_;
+    return $self->_mk( 'ResourcePUT', "$base/freeswitch_connectors" );
+}
 
 sub _build_subscribers {
-    SignalWire::REST::Namespaces::Fabric::Subscribers->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Fabric::Subscribers->new(
+        _http      => $self->_http,
         _base_path => "$base/subscribers"
     );
 }
-sub _build_sip_endpoints { $_[0]->_mk( 'ResourcePUT', "$base/sip_endpoints" ) }
-sub _build_cxml_scripts  { $_[0]->_mk( 'ResourcePUT', "$base/cxml_scripts" ) }
+
+sub _build_sip_endpoints {
+    my ($self) = @_;
+    return $self->_mk( 'ResourcePUT', "$base/sip_endpoints" );
+}
+
+sub _build_cxml_scripts {
+    my ($self) = @_;
+    return $self->_mk( 'ResourcePUT', "$base/cxml_scripts" );
+}
 
 sub _build_cxml_applications {
-    SignalWire::REST::Namespaces::Fabric::CxmlApplications->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Fabric::CxmlApplications->new(
+        _http      => $self->_http,
         _base_path => "$base/cxml_applications"
     );
 }
@@ -298,38 +321,43 @@ sub _build_cxml_applications {
 # phone_numbers->set_swml_webhook / set_cxml_webhook. Direct create still
 # works for backcompat but emits a deprecation warning.
 sub _build_swml_webhooks {
-    SignalWire::REST::Namespaces::Fabric::SwmlWebhooks->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Fabric::SwmlWebhooks->new(
+        _http      => $self->_http,
         _base_path => "$base/swml_webhooks"
     );
 }
-sub _build_ai_agents    { $_[0]->_mk( 'Resource', "$base/ai_agents" ) }
-sub _build_sip_gateways { $_[0]->_mk( 'Resource', "$base/sip_gateways" ) }
+sub _build_ai_agents    { my ($self) = @_; return $self->_mk( 'Resource', "$base/ai_agents" ) }
+sub _build_sip_gateways { my ($self) = @_; return $self->_mk( 'Resource', "$base/sip_gateways" ) }
 
 sub _build_cxml_webhooks {
-    SignalWire::REST::Namespaces::Fabric::CxmlWebhooks->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Fabric::CxmlWebhooks->new(
+        _http      => $self->_http,
         _base_path => "$base/cxml_webhooks"
     );
 }
 
 sub _build_resources {
-    SignalWire::REST::Namespaces::Fabric::GenericResources->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Fabric::GenericResources->new(
+        _http      => $self->_http,
         _base_path => $base
     );
 }
 
 sub _build_addresses {
-    SignalWire::REST::Namespaces::Fabric::Addresses->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Fabric::Addresses->new(
+        _http      => $self->_http,
         _base_path => '/api/fabric/addresses'
     );
 }
 
 sub _build_tokens {
-    SignalWire::REST::Namespaces::Fabric::Tokens->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Fabric::Tokens->new(
+        _http      => $self->_http,
         _base_path => '/api/fabric'
     );
 }

--- a/lib/SignalWire/REST/Namespaces/Fabric.pm
+++ b/lib/SignalWire/REST/Namespaces/Fabric.pm
@@ -10,9 +10,9 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::CrudResource';
 
 sub list_addresses {
-    my ($self, $resource_id, %params) = @_;
+    my ( $self, $resource_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($resource_id, 'addresses'), params => $p);
+    return $self->_http->get( $self->_path( $resource_id, 'addresses' ), params => $p );
 }
 
 # --- AutoMaterializedWebhook: webhook Fabric resources that are normally
@@ -30,15 +30,13 @@ has '_auto_helper_name' => (
 );
 
 sub create {
-    my ($self, %kwargs) = @_;
+    my ( $self, %kwargs ) = @_;
     my $helper = $self->_auto_helper_name;
-    Carp::carp(
-        "DEPRECATED: creating a webhook Fabric resource directly produces "
-        . "an orphan not bound to any phone number. Use $helper instead; "
-        . "it updates the phone number and the server auto-materializes "
-        . "the resource. See porting-sdk's phone-binding.md."
-    );
-    return $self->_http->post($self->_base_path, body => \%kwargs);
+    Carp::carp( "DEPRECATED: creating a webhook Fabric resource directly produces "
+            . "an orphan not bound to any phone number. Use $helper instead; "
+            . "it updates the phone number and the server auto-materializes "
+            . "the resource. See porting-sdk's phone-binding.md." );
+    return $self->_http->post( $self->_base_path, body => \%kwargs );
 }
 
 # --- SwmlWebhooks and CxmlWebhooks — concrete subclasses with specific
@@ -46,16 +44,14 @@ sub create {
 package SignalWire::REST::Namespaces::Fabric::SwmlWebhooks;
 use Moo;
 extends 'SignalWire::REST::Namespaces::Fabric::AutoMaterializedWebhook';
-has '+_auto_helper_name' => (
-    default => sub { 'phone_numbers->set_swml_webhook($sid, url => ...)' },
-);
+has '+_auto_helper_name' =>
+    ( default => sub { 'phone_numbers->set_swml_webhook($sid, url => ...)' }, );
 
 package SignalWire::REST::Namespaces::Fabric::CxmlWebhooks;
 use Moo;
 extends 'SignalWire::REST::Namespaces::Fabric::AutoMaterializedWebhook';
-has '+_auto_helper_name' => (
-    default => sub { 'phone_numbers->set_cxml_webhook($sid, url => ...)' },
-);
+has '+_auto_helper_name' =>
+    ( default => sub { 'phone_numbers->set_cxml_webhook($sid, url => ...)' }, );
 
 # --- Fabric Resource with PUT updates ---
 package SignalWire::REST::Namespaces::Fabric::ResourcePUT;
@@ -69,23 +65,23 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Fabric::ResourcePUT';
 
 sub list_addresses {
-    my ($self, $resource_id, %params) = @_;
-    (my $path = $self->_base_path) =~ s/call_flows/call_flow/;
+    my ( $self, $resource_id, %params ) = @_;
+    ( my $path = $self->_base_path ) =~ s/call_flows/call_flow/;
     my $p = %params ? \%params : undef;
-    return $self->_http->get("$path/$resource_id/addresses", params => $p);
+    return $self->_http->get( "$path/$resource_id/addresses", params => $p );
 }
 
 sub list_versions {
-    my ($self, $resource_id, %params) = @_;
-    (my $path = $self->_base_path) =~ s/call_flows/call_flow/;
+    my ( $self, $resource_id, %params ) = @_;
+    ( my $path = $self->_base_path ) =~ s/call_flows/call_flow/;
     my $p = %params ? \%params : undef;
-    return $self->_http->get("$path/$resource_id/versions", params => $p);
+    return $self->_http->get( "$path/$resource_id/versions", params => $p );
 }
 
 sub deploy_version {
-    my ($self, $resource_id, %kwargs) = @_;
-    (my $path = $self->_base_path) =~ s/call_flows/call_flow/;
-    return $self->_http->post("$path/$resource_id/versions", body => \%kwargs);
+    my ( $self, $resource_id, %kwargs ) = @_;
+    ( my $path = $self->_base_path ) =~ s/call_flows/call_flow/;
+    return $self->_http->post( "$path/$resource_id/versions", body => \%kwargs );
 }
 
 # --- ConferenceRooms ---
@@ -94,10 +90,10 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Fabric::ResourcePUT';
 
 sub list_addresses {
-    my ($self, $resource_id, %params) = @_;
-    (my $path = $self->_base_path) =~ s/conference_rooms/conference_room/;
+    my ( $self, $resource_id, %params ) = @_;
+    ( my $path = $self->_base_path ) =~ s/conference_rooms/conference_room/;
     my $p = %params ? \%params : undef;
-    return $self->_http->get("$path/$resource_id/addresses", params => $p);
+    return $self->_http->get( "$path/$resource_id/addresses", params => $p );
 }
 
 # --- Subscribers ---
@@ -106,29 +102,31 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Fabric::ResourcePUT';
 
 sub list_sip_endpoints {
-    my ($self, $subscriber_id, %params) = @_;
+    my ( $self, $subscriber_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($subscriber_id, 'sip_endpoints'), params => $p);
+    return $self->_http->get( $self->_path( $subscriber_id, 'sip_endpoints' ), params => $p );
 }
 
 sub create_sip_endpoint {
-    my ($self, $subscriber_id, %kwargs) = @_;
-    return $self->_http->post($self->_path($subscriber_id, 'sip_endpoints'), body => \%kwargs);
+    my ( $self, $subscriber_id, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $subscriber_id, 'sip_endpoints' ), body => \%kwargs );
 }
 
 sub get_sip_endpoint {
-    my ($self, $subscriber_id, $endpoint_id) = @_;
-    return $self->_http->get($self->_path($subscriber_id, 'sip_endpoints', $endpoint_id));
+    my ( $self, $subscriber_id, $endpoint_id ) = @_;
+    return $self->_http->get( $self->_path( $subscriber_id, 'sip_endpoints', $endpoint_id ) );
 }
 
 sub update_sip_endpoint {
-    my ($self, $subscriber_id, $endpoint_id, %kwargs) = @_;
-    return $self->_http->patch($self->_path($subscriber_id, 'sip_endpoints', $endpoint_id), body => \%kwargs);
+    my ( $self, $subscriber_id, $endpoint_id, %kwargs ) = @_;
+    return $self->_http->patch( $self->_path( $subscriber_id, 'sip_endpoints', $endpoint_id ),
+        body => \%kwargs );
 }
 
 sub delete_sip_endpoint {
-    my ($self, $subscriber_id, $endpoint_id) = @_;
-    return $self->_http->delete_request($self->_path($subscriber_id, 'sip_endpoints', $endpoint_id));
+    my ( $self, $subscriber_id, $endpoint_id ) = @_;
+    return $self->_http->delete_request(
+        $self->_path( $subscriber_id, 'sip_endpoints', $endpoint_id ) );
 }
 
 # --- CxmlApplications (no create) ---
@@ -137,7 +135,7 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Fabric::ResourcePUT';
 
 sub create {
-    my ($self, %kwargs) = @_;
+    my ( $self, %kwargs ) = @_;
     die "cXML applications cannot be created via this API";
 }
 
@@ -147,48 +145,47 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub get {
-    my ($self, $resource_id) = @_;
-    return $self->_http->get($self->_path($resource_id));
+    my ( $self, $resource_id ) = @_;
+    return $self->_http->get( $self->_path($resource_id) );
 }
 
 sub delete_resource {
-    my ($self, $resource_id) = @_;
-    return $self->_http->delete_request($self->_path($resource_id));
+    my ( $self, $resource_id ) = @_;
+    return $self->_http->delete_request( $self->_path($resource_id) );
 }
 
 # Python parity alias.
 sub delete {
-    my ($self, $resource_id) = @_;
-    return $self->_http->delete_request($self->_path($resource_id));
+    my ( $self, $resource_id ) = @_;
+    return $self->_http->delete_request( $self->_path($resource_id) );
 }
 
 sub list_addresses {
-    my ($self, $resource_id, %params) = @_;
+    my ( $self, $resource_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($resource_id, 'addresses'), params => $p);
+    return $self->_http->get( $self->_path( $resource_id, 'addresses' ), params => $p );
 }
 
 sub assign_phone_route {
-    my ($self, $resource_id, %kwargs) = @_;
-    Carp::carp(
-        "DEPRECATED: assign_phone_route does not bind phone numbers to "
-        . "swml_webhook/cxml_webhook/ai_agent resources — those are "
-        . "configured via phone_numbers->set_swml_webhook / set_cxml_webhook "
-        . "/ set_ai_agent. This method applies only to a narrow set of "
-        . "legacy resource types. See porting-sdk's phone-binding.md."
-    );
-    return $self->_http->post($self->_path($resource_id, 'phone_routes'), body => \%kwargs);
+    my ( $self, $resource_id, %kwargs ) = @_;
+    Carp::carp( "DEPRECATED: assign_phone_route does not bind phone numbers to "
+            . "swml_webhook/cxml_webhook/ai_agent resources — those are "
+            . "configured via phone_numbers->set_swml_webhook / set_cxml_webhook "
+            . "/ set_ai_agent. This method applies only to a narrow set of "
+            . "legacy resource types. See porting-sdk's phone-binding.md." );
+    return $self->_http->post( $self->_path( $resource_id, 'phone_routes' ), body => \%kwargs );
 }
 
 sub assign_domain_application {
-    my ($self, $resource_id, %kwargs) = @_;
-    return $self->_http->post($self->_path($resource_id, 'domain_applications'), body => \%kwargs);
+    my ( $self, $resource_id, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $resource_id, 'domain_applications' ),
+        body => \%kwargs );
 }
 
 # --- FabricAddresses (read-only) ---
@@ -197,14 +194,14 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub get {
-    my ($self, $address_id) = @_;
-    return $self->_http->get($self->_path($address_id));
+    my ( $self, $address_id ) = @_;
+    return $self->_http->get( $self->_path($address_id) );
 }
 
 # --- FabricTokens ---
@@ -213,28 +210,29 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub create_subscriber_token {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_path('subscribers', 'tokens'), body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( 'subscribers', 'tokens' ), body => \%kwargs );
 }
 
 sub refresh_subscriber_token {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_path('subscribers', 'tokens', 'refresh'), body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( 'subscribers', 'tokens', 'refresh' ),
+        body => \%kwargs );
 }
 
 sub create_invite_token {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_path('subscriber', 'invites'), body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( 'subscriber', 'invites' ), body => \%kwargs );
 }
 
 sub create_guest_token {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_path('guests', 'tokens'), body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( 'guests', 'tokens' ), body => \%kwargs );
 }
 
 sub create_embed_token {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_path('embeds', 'tokens'), body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( 'embeds', 'tokens' ), body => \%kwargs );
 }
 
 # --- FabricNamespace (top-level grouping) ---
@@ -262,30 +260,84 @@ has 'tokens'                => ( is => 'lazy' );
 
 my $base = '/api/fabric/resources';
 
-sub _build_swml_scripts          { $_[0]->_mk('ResourcePUT', "$base/swml_scripts") }
-sub _build_relay_applications    { $_[0]->_mk('ResourcePUT', "$base/relay_applications") }
-sub _build_call_flows            { SignalWire::REST::Namespaces::Fabric::CallFlows->new(_http => $_[0]->_http, _base_path => "$base/call_flows") }
-sub _build_conference_rooms      { SignalWire::REST::Namespaces::Fabric::ConferenceRooms->new(_http => $_[0]->_http, _base_path => "$base/conference_rooms") }
-sub _build_freeswitch_connectors { $_[0]->_mk('ResourcePUT', "$base/freeswitch_connectors") }
-sub _build_subscribers           { SignalWire::REST::Namespaces::Fabric::Subscribers->new(_http => $_[0]->_http, _base_path => "$base/subscribers") }
-sub _build_sip_endpoints         { $_[0]->_mk('ResourcePUT', "$base/sip_endpoints") }
-sub _build_cxml_scripts          { $_[0]->_mk('ResourcePUT', "$base/cxml_scripts") }
-sub _build_cxml_applications     { SignalWire::REST::Namespaces::Fabric::CxmlApplications->new(_http => $_[0]->_http, _base_path => "$base/cxml_applications") }
+sub _build_swml_scripts       { $_[0]->_mk( 'ResourcePUT', "$base/swml_scripts" ) }
+sub _build_relay_applications { $_[0]->_mk( 'ResourcePUT', "$base/relay_applications" ) }
+
+sub _build_call_flows {
+    SignalWire::REST::Namespaces::Fabric::CallFlows->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/call_flows"
+    );
+}
+
+sub _build_conference_rooms {
+    SignalWire::REST::Namespaces::Fabric::ConferenceRooms->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/conference_rooms"
+    );
+}
+sub _build_freeswitch_connectors { $_[0]->_mk( 'ResourcePUT', "$base/freeswitch_connectors" ) }
+
+sub _build_subscribers {
+    SignalWire::REST::Namespaces::Fabric::Subscribers->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/subscribers"
+    );
+}
+sub _build_sip_endpoints { $_[0]->_mk( 'ResourcePUT', "$base/sip_endpoints" ) }
+sub _build_cxml_scripts  { $_[0]->_mk( 'ResourcePUT', "$base/cxml_scripts" ) }
+
+sub _build_cxml_applications {
+    SignalWire::REST::Namespaces::Fabric::CxmlApplications->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/cxml_applications"
+    );
+}
+
 # swml_webhooks and cxml_webhooks are normally auto-materialized by
 # phone_numbers->set_swml_webhook / set_cxml_webhook. Direct create still
 # works for backcompat but emits a deprecation warning.
-sub _build_swml_webhooks         { SignalWire::REST::Namespaces::Fabric::SwmlWebhooks->new(_http => $_[0]->_http, _base_path => "$base/swml_webhooks") }
-sub _build_ai_agents             { $_[0]->_mk('Resource', "$base/ai_agents") }
-sub _build_sip_gateways          { $_[0]->_mk('Resource', "$base/sip_gateways") }
-sub _build_cxml_webhooks         { SignalWire::REST::Namespaces::Fabric::CxmlWebhooks->new(_http => $_[0]->_http, _base_path => "$base/cxml_webhooks") }
-sub _build_resources             { SignalWire::REST::Namespaces::Fabric::GenericResources->new(_http => $_[0]->_http, _base_path => $base) }
-sub _build_addresses             { SignalWire::REST::Namespaces::Fabric::Addresses->new(_http => $_[0]->_http, _base_path => '/api/fabric/addresses') }
-sub _build_tokens                { SignalWire::REST::Namespaces::Fabric::Tokens->new(_http => $_[0]->_http, _base_path => '/api/fabric') }
+sub _build_swml_webhooks {
+    SignalWire::REST::Namespaces::Fabric::SwmlWebhooks->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/swml_webhooks"
+    );
+}
+sub _build_ai_agents    { $_[0]->_mk( 'Resource', "$base/ai_agents" ) }
+sub _build_sip_gateways { $_[0]->_mk( 'Resource', "$base/sip_gateways" ) }
+
+sub _build_cxml_webhooks {
+    SignalWire::REST::Namespaces::Fabric::CxmlWebhooks->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/cxml_webhooks"
+    );
+}
+
+sub _build_resources {
+    SignalWire::REST::Namespaces::Fabric::GenericResources->new(
+        _http      => $_[0]->_http,
+        _base_path => $base
+    );
+}
+
+sub _build_addresses {
+    SignalWire::REST::Namespaces::Fabric::Addresses->new(
+        _http      => $_[0]->_http,
+        _base_path => '/api/fabric/addresses'
+    );
+}
+
+sub _build_tokens {
+    SignalWire::REST::Namespaces::Fabric::Tokens->new(
+        _http      => $_[0]->_http,
+        _base_path => '/api/fabric'
+    );
+}
 
 sub _mk {
-    my ($self, $type, $path) = @_;
+    my ( $self, $type, $path ) = @_;
     my $class = "SignalWire::REST::Namespaces::Fabric::$type";
-    return $class->new(_http => $self->_http, _base_path => $path);
+    return $class->new( _http => $self->_http, _base_path => $path );
 }
 
 1;

--- a/lib/SignalWire/REST/Namespaces/Logs.pm
+++ b/lib/SignalWire/REST/Namespaces/Logs.pm
@@ -79,29 +79,33 @@ has 'fax'         => ( is => 'lazy' );
 has 'conferences' => ( is => 'lazy' );
 
 sub _build_messages {
-    SignalWire::REST::Namespaces::Logs::Messages->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Logs::Messages->new(
+        _http      => $self->_http,
         _base_path => '/api/messaging/logs'
     );
 }
 
 sub _build_voice {
-    SignalWire::REST::Namespaces::Logs::Voice->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Logs::Voice->new(
+        _http      => $self->_http,
         _base_path => '/api/voice/logs'
     );
 }
 
 sub _build_fax {
-    SignalWire::REST::Namespaces::Logs::Fax->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Logs::Fax->new(
+        _http      => $self->_http,
         _base_path => '/api/fax/logs'
     );
 }
 
 sub _build_conferences {
-    SignalWire::REST::Namespaces::Logs::Conferences->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Logs::Conferences->new(
+        _http      => $self->_http,
         _base_path => '/api/logs/conferences'
     );
 }

--- a/lib/SignalWire/REST/Namespaces/Logs.pm
+++ b/lib/SignalWire/REST/Namespaces/Logs.pm
@@ -9,14 +9,14 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub get {
-    my ($self, $log_id) = @_;
-    return $self->_http->get($self->_path($log_id));
+    my ( $self, $log_id ) = @_;
+    return $self->_http->get( $self->_path($log_id) );
 }
 
 # --- VoiceLogs ---
@@ -25,20 +25,20 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub get {
-    my ($self, $log_id) = @_;
-    return $self->_http->get($self->_path($log_id));
+    my ( $self, $log_id ) = @_;
+    return $self->_http->get( $self->_path($log_id) );
 }
 
 sub list_events {
-    my ($self, $log_id, %params) = @_;
+    my ( $self, $log_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($log_id, 'events'), params => $p);
+    return $self->_http->get( $self->_path( $log_id, 'events' ), params => $p );
 }
 
 # --- FaxLogs ---
@@ -47,14 +47,14 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub get {
-    my ($self, $log_id) = @_;
-    return $self->_http->get($self->_path($log_id));
+    my ( $self, $log_id ) = @_;
+    return $self->_http->get( $self->_path($log_id) );
 }
 
 # --- ConferenceLogs ---
@@ -63,9 +63,9 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 # --- LogsNamespace ---
@@ -78,9 +78,32 @@ has 'voice'       => ( is => 'lazy' );
 has 'fax'         => ( is => 'lazy' );
 has 'conferences' => ( is => 'lazy' );
 
-sub _build_messages    { SignalWire::REST::Namespaces::Logs::Messages->new(_http => $_[0]->_http, _base_path => '/api/messaging/logs') }
-sub _build_voice       { SignalWire::REST::Namespaces::Logs::Voice->new(_http => $_[0]->_http, _base_path => '/api/voice/logs') }
-sub _build_fax         { SignalWire::REST::Namespaces::Logs::Fax->new(_http => $_[0]->_http, _base_path => '/api/fax/logs') }
-sub _build_conferences { SignalWire::REST::Namespaces::Logs::Conferences->new(_http => $_[0]->_http, _base_path => '/api/logs/conferences') }
+sub _build_messages {
+    SignalWire::REST::Namespaces::Logs::Messages->new(
+        _http      => $_[0]->_http,
+        _base_path => '/api/messaging/logs'
+    );
+}
+
+sub _build_voice {
+    SignalWire::REST::Namespaces::Logs::Voice->new(
+        _http      => $_[0]->_http,
+        _base_path => '/api/voice/logs'
+    );
+}
+
+sub _build_fax {
+    SignalWire::REST::Namespaces::Logs::Fax->new(
+        _http      => $_[0]->_http,
+        _base_path => '/api/fax/logs'
+    );
+}
+
+sub _build_conferences {
+    SignalWire::REST::Namespaces::Logs::Conferences->new(
+        _http      => $_[0]->_http,
+        _base_path => '/api/logs/conferences'
+    );
+}
 
 1;

--- a/lib/SignalWire/REST/Namespaces/PhoneNumbers.pm
+++ b/lib/SignalWire/REST/Namespaces/PhoneNumbers.pm
@@ -9,9 +9,9 @@ use SignalWire::REST::PhoneCallHandler;
 has '+_update_method' => ( default => sub { 'PUT' } );
 
 sub search {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path('search'), params => $p);
+    return $self->_http->get( $self->_path('search'), params => $p );
 }
 
 # --- Typed binding helpers -------------------------------------------------
@@ -22,7 +22,7 @@ sub search {
 # (e.g. you can pass `name => "..."` on any of them).
 
 sub set_swml_webhook {
-    my ($self, $resource_id, %args) = @_;
+    my ( $self, $resource_id, %args ) = @_;
     my $url = delete $args{url}
         or die "set_swml_webhook: 'url' is required";
     return $self->update(
@@ -34,10 +34,10 @@ sub set_swml_webhook {
 }
 
 sub set_cxml_webhook {
-    my ($self, $resource_id, %args) = @_;
+    my ( $self, $resource_id, %args ) = @_;
     my $url = delete $args{url}
         or die "set_cxml_webhook: 'url' is required";
-    my $fallback_url = delete $args{fallback_url};
+    my $fallback_url        = delete $args{fallback_url};
     my $status_callback_url = delete $args{status_callback_url};
 
     my %body = (
@@ -47,11 +47,11 @@ sub set_cxml_webhook {
     $body{call_fallback_url}        = $fallback_url        if defined $fallback_url;
     $body{call_status_callback_url} = $status_callback_url if defined $status_callback_url;
 
-    return $self->update($resource_id, %body, %args);
+    return $self->update( $resource_id, %body, %args );
 }
 
 sub set_cxml_application {
-    my ($self, $resource_id, %args) = @_;
+    my ( $self, $resource_id, %args ) = @_;
     my $application_id = delete $args{application_id}
         or die "set_cxml_application: 'application_id' is required";
     return $self->update(
@@ -63,7 +63,7 @@ sub set_cxml_application {
 }
 
 sub set_ai_agent {
-    my ($self, $resource_id, %args) = @_;
+    my ( $self, $resource_id, %args ) = @_;
     my $agent_id = delete $args{agent_id}
         or die "set_ai_agent: 'agent_id' is required";
     return $self->update(
@@ -75,7 +75,7 @@ sub set_ai_agent {
 }
 
 sub set_call_flow {
-    my ($self, $resource_id, %args) = @_;
+    my ( $self, $resource_id, %args ) = @_;
     my $flow_id = delete $args{flow_id}
         or die "set_call_flow: 'flow_id' is required";
     my $version = delete $args{version};
@@ -86,11 +86,11 @@ sub set_call_flow {
     );
     $body{call_flow_version} = $version if defined $version;
 
-    return $self->update($resource_id, %body, %args);
+    return $self->update( $resource_id, %body, %args );
 }
 
 sub set_relay_application {
-    my ($self, $resource_id, %args) = @_;
+    my ( $self, $resource_id, %args ) = @_;
     my $name = delete $args{name}
         or die "set_relay_application: 'name' is required";
     return $self->update(
@@ -102,7 +102,7 @@ sub set_relay_application {
 }
 
 sub set_relay_topic {
-    my ($self, $resource_id, %args) = @_;
+    my ( $self, $resource_id, %args ) = @_;
     my $topic = delete $args{topic}
         or die "set_relay_topic: 'topic' is required";
     my $status_callback_url = delete $args{status_callback_url};
@@ -114,7 +114,7 @@ sub set_relay_topic {
     $body{call_relay_topic_status_callback_url} = $status_callback_url
         if defined $status_callback_url;
 
-    return $self->update($resource_id, %body, %args);
+    return $self->update( $resource_id, %body, %args );
 }
 
 1;

--- a/lib/SignalWire/REST/Namespaces/Project.pm
+++ b/lib/SignalWire/REST/Namespaces/Project.pm
@@ -9,24 +9,24 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub create {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_base_path, body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_base_path, body => \%kwargs );
 }
 
 sub update {
-    my ($self, $token_id, %kwargs) = @_;
-    return $self->_http->patch($self->_path($token_id), body => \%kwargs);
+    my ( $self, $token_id, %kwargs ) = @_;
+    return $self->_http->patch( $self->_path($token_id), body => \%kwargs );
 }
 
 sub delete_token {
-    my ($self, $token_id) = @_;
-    return $self->_http->delete_request($self->_path($token_id));
+    my ( $self, $token_id ) = @_;
+    return $self->_http->delete_request( $self->_path($token_id) );
 }
 
 # Python parity alias.
 sub delete {
-    my ($self, $token_id) = @_;
-    return $self->_http->delete_request($self->_path($token_id));
+    my ( $self, $token_id ) = @_;
+    return $self->_http->delete_request( $self->_path($token_id) );
 }
 
 # --- ProjectNamespace ---

--- a/lib/SignalWire/REST/Namespaces/PubSub.pm
+++ b/lib/SignalWire/REST/Namespaces/PubSub.pm
@@ -5,8 +5,8 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub create_token {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_base_path, body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_base_path, body => \%kwargs );
 }
 
 1;

--- a/lib/SignalWire/REST/Namespaces/Registry.pm
+++ b/lib/SignalWire/REST/Namespaces/Registry.pm
@@ -106,29 +106,33 @@ has 'numbers'   => ( is => 'lazy' );
 my $base = '/api/relay/rest/registry/beta';
 
 sub _build_brands {
-    SignalWire::REST::Namespaces::Registry::Brands->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Registry::Brands->new(
+        _http      => $self->_http,
         _base_path => "$base/brands"
     );
 }
 
 sub _build_campaigns {
-    SignalWire::REST::Namespaces::Registry::Campaigns->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Registry::Campaigns->new(
+        _http      => $self->_http,
         _base_path => "$base/campaigns"
     );
 }
 
 sub _build_orders {
-    SignalWire::REST::Namespaces::Registry::Orders->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Registry::Orders->new(
+        _http      => $self->_http,
         _base_path => "$base/orders"
     );
 }
 
 sub _build_numbers {
-    SignalWire::REST::Namespaces::Registry::Numbers->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Registry::Numbers->new(
+        _http      => $self->_http,
         _base_path => "$base/numbers"
     );
 }

--- a/lib/SignalWire/REST/Namespaces/Registry.pm
+++ b/lib/SignalWire/REST/Namespaces/Registry.pm
@@ -9,30 +9,30 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub create {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_base_path, body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_base_path, body => \%kwargs );
 }
 
 sub get {
-    my ($self, $brand_id) = @_;
-    return $self->_http->get($self->_path($brand_id));
+    my ( $self, $brand_id ) = @_;
+    return $self->_http->get( $self->_path($brand_id) );
 }
 
 sub list_campaigns {
-    my ($self, $brand_id, %params) = @_;
+    my ( $self, $brand_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($brand_id, 'campaigns'), params => $p);
+    return $self->_http->get( $self->_path( $brand_id, 'campaigns' ), params => $p );
 }
 
 sub create_campaign {
-    my ($self, $brand_id, %kwargs) = @_;
-    return $self->_http->post($self->_path($brand_id, 'campaigns'), body => \%kwargs);
+    my ( $self, $brand_id, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $brand_id, 'campaigns' ), body => \%kwargs );
 }
 
 # --- RegistryCampaigns ---
@@ -41,30 +41,30 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub get {
-    my ($self, $campaign_id) = @_;
-    return $self->_http->get($self->_path($campaign_id));
+    my ( $self, $campaign_id ) = @_;
+    return $self->_http->get( $self->_path($campaign_id) );
 }
 
 sub update {
-    my ($self, $campaign_id, %kwargs) = @_;
-    return $self->_http->put($self->_path($campaign_id), body => \%kwargs);
+    my ( $self, $campaign_id, %kwargs ) = @_;
+    return $self->_http->put( $self->_path($campaign_id), body => \%kwargs );
 }
 
 sub list_numbers {
-    my ($self, $campaign_id, %params) = @_;
+    my ( $self, $campaign_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($campaign_id, 'numbers'), params => $p);
+    return $self->_http->get( $self->_path( $campaign_id, 'numbers' ), params => $p );
 }
 
 sub list_orders {
-    my ($self, $campaign_id, %params) = @_;
+    my ( $self, $campaign_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($campaign_id, 'orders'), params => $p);
+    return $self->_http->get( $self->_path( $campaign_id, 'orders' ), params => $p );
 }
 
 sub create_order {
-    my ($self, $campaign_id, %kwargs) = @_;
-    return $self->_http->post($self->_path($campaign_id, 'orders'), body => \%kwargs);
+    my ( $self, $campaign_id, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $campaign_id, 'orders' ), body => \%kwargs );
 }
 
 # --- RegistryOrders ---
@@ -73,8 +73,8 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub get {
-    my ($self, $order_id) = @_;
-    return $self->_http->get($self->_path($order_id));
+    my ( $self, $order_id ) = @_;
+    return $self->_http->get( $self->_path($order_id) );
 }
 
 # --- RegistryNumbers ---
@@ -83,14 +83,14 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub delete_number {
-    my ($self, $number_id) = @_;
-    return $self->_http->delete_request($self->_path($number_id));
+    my ( $self, $number_id ) = @_;
+    return $self->_http->delete_request( $self->_path($number_id) );
 }
 
 # Python parity alias.
 sub delete {
-    my ($self, $number_id) = @_;
-    return $self->_http->delete_request($self->_path($number_id));
+    my ( $self, $number_id ) = @_;
+    return $self->_http->delete_request( $self->_path($number_id) );
 }
 
 # --- RegistryNamespace ---
@@ -105,9 +105,32 @@ has 'numbers'   => ( is => 'lazy' );
 
 my $base = '/api/relay/rest/registry/beta';
 
-sub _build_brands    { SignalWire::REST::Namespaces::Registry::Brands->new(_http => $_[0]->_http, _base_path => "$base/brands") }
-sub _build_campaigns { SignalWire::REST::Namespaces::Registry::Campaigns->new(_http => $_[0]->_http, _base_path => "$base/campaigns") }
-sub _build_orders    { SignalWire::REST::Namespaces::Registry::Orders->new(_http => $_[0]->_http, _base_path => "$base/orders") }
-sub _build_numbers   { SignalWire::REST::Namespaces::Registry::Numbers->new(_http => $_[0]->_http, _base_path => "$base/numbers") }
+sub _build_brands {
+    SignalWire::REST::Namespaces::Registry::Brands->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/brands"
+    );
+}
+
+sub _build_campaigns {
+    SignalWire::REST::Namespaces::Registry::Campaigns->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/campaigns"
+    );
+}
+
+sub _build_orders {
+    SignalWire::REST::Namespaces::Registry::Orders->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/orders"
+    );
+}
+
+sub _build_numbers {
+    SignalWire::REST::Namespaces::Registry::Numbers->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/numbers"
+    );
+}
 
 1;

--- a/lib/SignalWire/REST/Namespaces/Resources.pm
+++ b/lib/SignalWire/REST/Namespaces/Resources.pm
@@ -9,24 +9,24 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub create {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_base_path, body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_base_path, body => \%kwargs );
 }
 
 sub get {
-    my ($self, $address_id) = @_;
-    return $self->_http->get($self->_path($address_id));
+    my ( $self, $address_id ) = @_;
+    return $self->_http->get( $self->_path($address_id) );
 }
 
 sub delete {
-    my ($self, $address_id) = @_;
-    return $self->_http->delete_request($self->_path($address_id));
+    my ( $self, $address_id ) = @_;
+    return $self->_http->delete_request( $self->_path($address_id) );
 }
 
 # --- Queues ---
@@ -36,19 +36,19 @@ extends 'SignalWire::REST::Namespaces::CrudResource';
 has '+_update_method' => ( default => sub { 'PUT' } );
 
 sub list_members {
-    my ($self, $queue_id, %params) = @_;
+    my ( $self, $queue_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($queue_id, 'members'), params => $p);
+    return $self->_http->get( $self->_path( $queue_id, 'members' ), params => $p );
 }
 
 sub get_next_member {
-    my ($self, $queue_id) = @_;
-    return $self->_http->get($self->_path($queue_id, 'members', 'next'));
+    my ( $self, $queue_id ) = @_;
+    return $self->_http->get( $self->_path( $queue_id, 'members', 'next' ) );
 }
 
 sub get_member {
-    my ($self, $queue_id, $member_id) = @_;
-    return $self->_http->get($self->_path($queue_id, 'members', $member_id));
+    my ( $self, $queue_id, $member_id ) = @_;
+    return $self->_http->get( $self->_path( $queue_id, 'members', $member_id ) );
 }
 
 # --- Recordings (read-only + delete) ---
@@ -57,25 +57,25 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub get {
-    my ($self, $recording_id) = @_;
-    return $self->_http->get($self->_path($recording_id));
+    my ( $self, $recording_id ) = @_;
+    return $self->_http->get( $self->_path($recording_id) );
 }
 
 sub delete_recording {
-    my ($self, $recording_id) = @_;
-    return $self->_http->delete_request($self->_path($recording_id));
+    my ( $self, $recording_id ) = @_;
+    return $self->_http->delete_request( $self->_path($recording_id) );
 }
 
 # Python parity alias.
 sub delete {
-    my ($self, $recording_id) = @_;
-    return $self->_http->delete_request($self->_path($recording_id));
+    my ( $self, $recording_id ) = @_;
+    return $self->_http->delete_request( $self->_path($recording_id) );
 }
 
 # --- NumberGroups ---
@@ -85,23 +85,24 @@ extends 'SignalWire::REST::Namespaces::CrudResource';
 has '+_update_method' => ( default => sub { 'PUT' } );
 
 sub list_memberships {
-    my ($self, $group_id, %params) = @_;
+    my ( $self, $group_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($group_id, 'number_group_memberships'), params => $p);
+    return $self->_http->get( $self->_path( $group_id, 'number_group_memberships' ), params => $p );
 }
 
 sub add_membership {
-    my ($self, $group_id, %kwargs) = @_;
-    return $self->_http->post($self->_path($group_id, 'number_group_memberships'), body => \%kwargs);
+    my ( $self, $group_id, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $group_id, 'number_group_memberships' ),
+        body => \%kwargs );
 }
 
 sub get_membership {
-    my ($self, $membership_id) = @_;
+    my ( $self, $membership_id ) = @_;
     return $self->_http->get("/api/relay/rest/number_group_memberships/$membership_id");
 }
 
 sub delete_membership {
-    my ($self, $membership_id) = @_;
+    my ( $self, $membership_id ) = @_;
     return $self->_http->delete_request("/api/relay/rest/number_group_memberships/$membership_id");
 }
 
@@ -112,13 +113,13 @@ extends 'SignalWire::REST::Namespaces::CrudResource';
 has '+_update_method' => ( default => sub { 'PUT' } );
 
 sub redial_verification {
-    my ($self, $caller_id) = @_;
-    return $self->_http->post($self->_path($caller_id, 'verification'));
+    my ( $self, $caller_id ) = @_;
+    return $self->_http->post( $self->_path( $caller_id, 'verification' ) );
 }
 
 sub submit_verification {
-    my ($self, $caller_id, %kwargs) = @_;
-    return $self->_http->put($self->_path($caller_id, 'verification'), body => \%kwargs);
+    my ( $self, $caller_id, %kwargs ) = @_;
+    return $self->_http->put( $self->_path( $caller_id, 'verification' ), body => \%kwargs );
 }
 
 # --- SipProfile (singleton) ---
@@ -128,12 +129,12 @@ extends 'SignalWire::REST::Namespaces::Base';
 
 sub get {
     my ($self) = @_;
-    return $self->_http->get($self->_base_path);
+    return $self->_http->get( $self->_base_path );
 }
 
 sub update {
-    my ($self, %kwargs) = @_;
-    return $self->_http->put($self->_base_path, body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->put( $self->_base_path, body => \%kwargs );
 }
 
 # --- Lookup ---
@@ -142,9 +143,9 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub phone_number {
-    my ($self, $e164, %params) = @_;
+    my ( $self, $e164, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path('phone_number', $e164), params => $p);
+    return $self->_http->get( $self->_path( 'phone_number', $e164 ), params => $p );
 }
 
 # --- ShortCodes (read + update) ---
@@ -153,19 +154,19 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub get {
-    my ($self, $short_code_id) = @_;
-    return $self->_http->get($self->_path($short_code_id));
+    my ( $self, $short_code_id ) = @_;
+    return $self->_http->get( $self->_path($short_code_id) );
 }
 
 sub update {
-    my ($self, $short_code_id, %kwargs) = @_;
-    return $self->_http->put($self->_path($short_code_id), body => \%kwargs);
+    my ( $self, $short_code_id, %kwargs ) = @_;
+    return $self->_http->put( $self->_path($short_code_id), body => \%kwargs );
 }
 
 # --- ImportedNumbers (create only) ---
@@ -174,8 +175,8 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub create {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_base_path, body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_base_path, body => \%kwargs );
 }
 
 # --- MFA ---
@@ -184,18 +185,18 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub sms {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_path('sms'), body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_path('sms'), body => \%kwargs );
 }
 
 sub call {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_path('call'), body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_path('call'), body => \%kwargs );
 }
 
 sub verify {
-    my ($self, $request_id, %kwargs) = @_;
-    return $self->_http->post($self->_path($request_id, 'verify'), body => \%kwargs);
+    my ( $self, $request_id, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $request_id, 'verify' ), body => \%kwargs );
 }
 
 1;

--- a/lib/SignalWire/REST/Namespaces/Video.pm
+++ b/lib/SignalWire/REST/Namespaces/Video.pm
@@ -177,50 +177,57 @@ has 'streams'           => ( is => 'lazy' );
 my $base = '/api/video';
 
 sub _build_rooms {
-    SignalWire::REST::Namespaces::Video::Rooms->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Video::Rooms->new(
+        _http      => $self->_http,
         _base_path => "$base/rooms"
     );
 }
 
 sub _build_room_tokens {
-    SignalWire::REST::Namespaces::Video::RoomTokens->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Video::RoomTokens->new(
+        _http      => $self->_http,
         _base_path => "$base/room_tokens"
     );
 }
 
 sub _build_room_sessions {
-    SignalWire::REST::Namespaces::Video::RoomSessions->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Video::RoomSessions->new(
+        _http      => $self->_http,
         _base_path => "$base/room_sessions"
     );
 }
 
 sub _build_room_recordings {
-    SignalWire::REST::Namespaces::Video::RoomRecordings->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Video::RoomRecordings->new(
+        _http      => $self->_http,
         _base_path => "$base/room_recordings"
     );
 }
 
 sub _build_conferences {
-    SignalWire::REST::Namespaces::Video::Conferences->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Video::Conferences->new(
+        _http      => $self->_http,
         _base_path => "$base/conferences"
     );
 }
 
 sub _build_conference_tokens {
-    SignalWire::REST::Namespaces::Video::ConferenceTokens->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Video::ConferenceTokens->new(
+        _http      => $self->_http,
         _base_path => "$base/conference_tokens"
     );
 }
 
 sub _build_streams {
-    SignalWire::REST::Namespaces::Video::Streams->new(
-        _http      => $_[0]->_http,
+    my ($self) = @_;
+    return SignalWire::REST::Namespaces::Video::Streams->new(
+        _http      => $self->_http,
         _base_path => "$base/streams"
     );
 }

--- a/lib/SignalWire/REST/Namespaces/Video.pm
+++ b/lib/SignalWire/REST/Namespaces/Video.pm
@@ -10,14 +10,14 @@ extends 'SignalWire::REST::Namespaces::CrudResource';
 has '+_update_method' => ( default => sub { 'PUT' } );
 
 sub list_streams {
-    my ($self, $room_id, %params) = @_;
+    my ( $self, $room_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($room_id, 'streams'), params => $p);
+    return $self->_http->get( $self->_path( $room_id, 'streams' ), params => $p );
 }
 
 sub create_stream {
-    my ($self, $room_id, %kwargs) = @_;
-    return $self->_http->post($self->_path($room_id, 'streams'), body => \%kwargs);
+    my ( $self, $room_id, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $room_id, 'streams' ), body => \%kwargs );
 }
 
 # --- VideoRoomTokens ---
@@ -26,8 +26,8 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub create {
-    my ($self, %kwargs) = @_;
-    return $self->_http->post($self->_base_path, body => \%kwargs);
+    my ( $self, %kwargs ) = @_;
+    return $self->_http->post( $self->_base_path, body => \%kwargs );
 }
 
 # --- VideoRoomSessions ---
@@ -36,32 +36,32 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub get {
-    my ($self, $session_id) = @_;
-    return $self->_http->get($self->_path($session_id));
+    my ( $self, $session_id ) = @_;
+    return $self->_http->get( $self->_path($session_id) );
 }
 
 sub list_events {
-    my ($self, $session_id, %params) = @_;
+    my ( $self, $session_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($session_id, 'events'), params => $p);
+    return $self->_http->get( $self->_path( $session_id, 'events' ), params => $p );
 }
 
 sub list_members {
-    my ($self, $session_id, %params) = @_;
+    my ( $self, $session_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($session_id, 'members'), params => $p);
+    return $self->_http->get( $self->_path( $session_id, 'members' ), params => $p );
 }
 
 sub list_recordings {
-    my ($self, $session_id, %params) = @_;
+    my ( $self, $session_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($session_id, 'recordings'), params => $p);
+    return $self->_http->get( $self->_path( $session_id, 'recordings' ), params => $p );
 }
 
 # --- VideoRoomRecordings ---
@@ -70,31 +70,31 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub list {
-    my ($self, %params) = @_;
+    my ( $self, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_base_path, params => $p);
+    return $self->_http->get( $self->_base_path, params => $p );
 }
 
 sub get {
-    my ($self, $recording_id) = @_;
-    return $self->_http->get($self->_path($recording_id));
+    my ( $self, $recording_id ) = @_;
+    return $self->_http->get( $self->_path($recording_id) );
 }
 
 sub delete_recording {
-    my ($self, $recording_id) = @_;
-    return $self->_http->delete_request($self->_path($recording_id));
+    my ( $self, $recording_id ) = @_;
+    return $self->_http->delete_request( $self->_path($recording_id) );
 }
 
 # Python parity alias.
 sub delete {
-    my ($self, $recording_id) = @_;
-    return $self->_http->delete_request($self->_path($recording_id));
+    my ( $self, $recording_id ) = @_;
+    return $self->_http->delete_request( $self->_path($recording_id) );
 }
 
 sub list_events {
-    my ($self, $recording_id, %params) = @_;
+    my ( $self, $recording_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($recording_id, 'events'), params => $p);
+    return $self->_http->get( $self->_path( $recording_id, 'events' ), params => $p );
 }
 
 # --- VideoConferences ---
@@ -104,20 +104,20 @@ extends 'SignalWire::REST::Namespaces::CrudResource';
 has '+_update_method' => ( default => sub { 'PUT' } );
 
 sub list_conference_tokens {
-    my ($self, $conference_id, %params) = @_;
+    my ( $self, $conference_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($conference_id, 'conference_tokens'), params => $p);
+    return $self->_http->get( $self->_path( $conference_id, 'conference_tokens' ), params => $p );
 }
 
 sub list_streams {
-    my ($self, $conference_id, %params) = @_;
+    my ( $self, $conference_id, %params ) = @_;
     my $p = %params ? \%params : undef;
-    return $self->_http->get($self->_path($conference_id, 'streams'), params => $p);
+    return $self->_http->get( $self->_path( $conference_id, 'streams' ), params => $p );
 }
 
 sub create_stream {
-    my ($self, $conference_id, %kwargs) = @_;
-    return $self->_http->post($self->_path($conference_id, 'streams'), body => \%kwargs);
+    my ( $self, $conference_id, %kwargs ) = @_;
+    return $self->_http->post( $self->_path( $conference_id, 'streams' ), body => \%kwargs );
 }
 
 # --- VideoConferenceTokens ---
@@ -126,13 +126,13 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub get {
-    my ($self, $token_id) = @_;
-    return $self->_http->get($self->_path($token_id));
+    my ( $self, $token_id ) = @_;
+    return $self->_http->get( $self->_path($token_id) );
 }
 
 sub reset {
-    my ($self, $token_id) = @_;
-    return $self->_http->post($self->_path($token_id, 'reset'));
+    my ( $self, $token_id ) = @_;
+    return $self->_http->post( $self->_path( $token_id, 'reset' ) );
 }
 
 # --- VideoStreams ---
@@ -141,24 +141,24 @@ use Moo;
 extends 'SignalWire::REST::Namespaces::Base';
 
 sub get {
-    my ($self, $stream_id) = @_;
-    return $self->_http->get($self->_path($stream_id));
+    my ( $self, $stream_id ) = @_;
+    return $self->_http->get( $self->_path($stream_id) );
 }
 
 sub update {
-    my ($self, $stream_id, %kwargs) = @_;
-    return $self->_http->put($self->_path($stream_id), body => \%kwargs);
+    my ( $self, $stream_id, %kwargs ) = @_;
+    return $self->_http->put( $self->_path($stream_id), body => \%kwargs );
 }
 
 sub delete_stream {
-    my ($self, $stream_id) = @_;
-    return $self->_http->delete_request($self->_path($stream_id));
+    my ( $self, $stream_id ) = @_;
+    return $self->_http->delete_request( $self->_path($stream_id) );
 }
 
 # Python parity alias.
 sub delete {
-    my ($self, $stream_id) = @_;
-    return $self->_http->delete_request($self->_path($stream_id));
+    my ( $self, $stream_id ) = @_;
+    return $self->_http->delete_request( $self->_path($stream_id) );
 }
 
 # --- VideoNamespace ---
@@ -176,12 +176,53 @@ has 'streams'           => ( is => 'lazy' );
 
 my $base = '/api/video';
 
-sub _build_rooms             { SignalWire::REST::Namespaces::Video::Rooms->new(_http => $_[0]->_http, _base_path => "$base/rooms") }
-sub _build_room_tokens       { SignalWire::REST::Namespaces::Video::RoomTokens->new(_http => $_[0]->_http, _base_path => "$base/room_tokens") }
-sub _build_room_sessions     { SignalWire::REST::Namespaces::Video::RoomSessions->new(_http => $_[0]->_http, _base_path => "$base/room_sessions") }
-sub _build_room_recordings   { SignalWire::REST::Namespaces::Video::RoomRecordings->new(_http => $_[0]->_http, _base_path => "$base/room_recordings") }
-sub _build_conferences       { SignalWire::REST::Namespaces::Video::Conferences->new(_http => $_[0]->_http, _base_path => "$base/conferences") }
-sub _build_conference_tokens { SignalWire::REST::Namespaces::Video::ConferenceTokens->new(_http => $_[0]->_http, _base_path => "$base/conference_tokens") }
-sub _build_streams           { SignalWire::REST::Namespaces::Video::Streams->new(_http => $_[0]->_http, _base_path => "$base/streams") }
+sub _build_rooms {
+    SignalWire::REST::Namespaces::Video::Rooms->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/rooms"
+    );
+}
+
+sub _build_room_tokens {
+    SignalWire::REST::Namespaces::Video::RoomTokens->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/room_tokens"
+    );
+}
+
+sub _build_room_sessions {
+    SignalWire::REST::Namespaces::Video::RoomSessions->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/room_sessions"
+    );
+}
+
+sub _build_room_recordings {
+    SignalWire::REST::Namespaces::Video::RoomRecordings->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/room_recordings"
+    );
+}
+
+sub _build_conferences {
+    SignalWire::REST::Namespaces::Video::Conferences->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/conferences"
+    );
+}
+
+sub _build_conference_tokens {
+    SignalWire::REST::Namespaces::Video::ConferenceTokens->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/conference_tokens"
+    );
+}
+
+sub _build_streams {
+    SignalWire::REST::Namespaces::Video::Streams->new(
+        _http      => $_[0]->_http,
+        _base_path => "$base/streams"
+    );
+}
 
 1;

--- a/lib/SignalWire/REST/Pagination.pm
+++ b/lib/SignalWire/REST/Pagination.pm
@@ -25,10 +25,10 @@ package SignalWire::REST::Pagination::PaginatedIterator;
 use Moo;
 use URI;
 
-has 'http'      => ( is => 'ro', required => 1 );
-has 'path'      => ( is => 'ro', required => 1 );
-has 'params'    => ( is => 'rw', default => sub { {} } );
-has 'data_key'  => ( is => 'ro', default => sub { 'data' } );
+has 'http'     => ( is => 'ro', required => 1 );
+has 'path'     => ( is => 'ro', required => 1 );
+has 'params'   => ( is => 'rw', default  => sub { {} } );
+has 'data_key' => ( is => 'ro', default  => sub { 'data' } );
 
 # Internal mutable state mirrors Python's _items/_index/_done. We store
 # it directly on the blessed hashref under leading-underscore keys
@@ -68,14 +68,14 @@ sub __iter__ { return $_[0]; }
 # alternative to Python's StopIteration).
 sub __next__ {
     my ($self) = @_;
-    while ($self->_index >= scalar @{ $self->_items }) {
-        if ($self->_done) {
-            return; # empty list scalar context => undef; signals exhaustion
+    while ( $self->_index >= scalar @{ $self->_items } ) {
+        if ( $self->_done ) {
+            return;    # empty list scalar context => undef; signals exhaustion
         }
         $self->_fetch_next;
     }
-    my $item = $self->_items->[$self->_index];
-    $self->_index($self->_index + 1);
+    my $item = $self->_items->[ $self->_index ];
+    $self->_index( $self->_index + 1 );
     return $item;
 }
 
@@ -85,7 +85,7 @@ sub __next__ {
 sub all {
     my ($self) = @_;
     my @out;
-    while (defined(my $item = $self->__next__)) {
+    while ( defined( my $item = $self->__next__ ) ) {
         push @out, $item;
     }
     return @out;
@@ -93,18 +93,19 @@ sub all {
 
 sub _fetch_next {
     my ($self) = @_;
-    my $params = (keys %{ $self->params || {} }) ? $self->params : undef;
-    my $resp = $self->http->get($self->path, params => $params);
-    my $data = $resp->{ $self->data_key } || [];
+    my $params = ( keys %{ $self->params || {} } ) ? $self->params : undef;
+    my $resp   = $self->http->get( $self->path, params => $params );
+    my $data   = $resp->{ $self->data_key } || [];
     push @{ $self->_items }, @$data;
 
-    my $links = $resp->{links} || {};
+    my $links    = $resp->{links} || {};
     my $next_url = $links->{next};
-    if ($next_url && @$data) {
+    if ( $next_url && @$data ) {
+
         # Parse cursor/page params from next URL query.
-        my $u = URI->new($next_url);
+        my $u     = URI->new($next_url);
         my %query = $u->query_form;
-        $self->params(\%query);
+        $self->params( \%query );
     } else {
         $self->_done(1);
     }

--- a/lib/SignalWire/REST/Pagination.pm
+++ b/lib/SignalWire/REST/Pagination.pm
@@ -41,28 +41,32 @@ sub BUILD {
     $self->{_items} = [];
     $self->{_index} = 0;
     $self->{_done}  = 0;
+    return;
 }
 
 sub _items {
-    my $self = shift;
-    $self->{_items} = $_[0] if @_;
+    my ( $self, @args ) = @_;
+    $self->{_items} = $args[0] if @args;
     return $self->{_items};
 }
 
 sub _index {
-    my $self = shift;
-    $self->{_index} = $_[0] if @_;
+    my ( $self, @args ) = @_;
+    $self->{_index} = $args[0] if @args;
     return $self->{_index};
 }
 
 sub _done {
-    my $self = shift;
-    $self->{_done} = $_[0] if @_;
+    my ( $self, @args ) = @_;
+    $self->{_done} = $args[0] if @args;
     return $self->{_done};
 }
 
 # Iterable interface (Python-mirroring, returns self so `iter()` parity).
-sub __iter__ { return $_[0]; }
+sub __iter__ {
+    my ($self) = @_;
+    return $self;
+}
 
 # Pull the next item; returns undef when exhausted (Perl-idiomatic
 # alternative to Python's StopIteration).

--- a/lib/SignalWire/REST/PhoneCallHandler.pm
+++ b/lib/SignalWire/REST/PhoneCallHandler.pm
@@ -68,17 +68,9 @@ our %EXPORT_TAGS = ( all => \@EXPORT_OK );
 # values() - return all 11 wire values (authoritative list).
 sub values {
     return (
-        RELAY_SCRIPT,
-        LAML_WEBHOOKS,
-        LAML_APPLICATION,
-        AI_AGENT,
-        CALL_FLOW,
-        RELAY_APPLICATION,
-        RELAY_TOPIC,
-        RELAY_CONTEXT,
-        RELAY_CONNECTOR,
-        VIDEO_ROOM,
-        DIALOGFLOW,
+        RELAY_SCRIPT,    LAML_WEBHOOKS,     LAML_APPLICATION, AI_AGENT,
+        CALL_FLOW,       RELAY_APPLICATION, RELAY_TOPIC,      RELAY_CONTEXT,
+        RELAY_CONNECTOR, VIDEO_ROOM,        DIALOGFLOW,
     );
 }
 

--- a/lib/SignalWire/REST/RestClient.pm
+++ b/lib/SignalWire/REST/RestClient.pm
@@ -80,7 +80,7 @@ sub _build__http {
 
 sub _build_fabric {
     my ($self) = @_;
-    return SignalWire::REST::Namespaces::Fabric->new(_http => $self->_http);
+    return SignalWire::REST::Namespaces::Fabric->new( _http => $self->_http );
 }
 
 sub _build_calling {
@@ -181,27 +181,27 @@ sub _build_mfa {
 
 sub _build_registry {
     my ($self) = @_;
-    return SignalWire::REST::Namespaces::Registry->new(_http => $self->_http);
+    return SignalWire::REST::Namespaces::Registry->new( _http => $self->_http );
 }
 
 sub _build_datasphere {
     my ($self) = @_;
-    return SignalWire::REST::Namespaces::Datasphere->new(_http => $self->_http);
+    return SignalWire::REST::Namespaces::Datasphere->new( _http => $self->_http );
 }
 
 sub _build_video {
     my ($self) = @_;
-    return SignalWire::REST::Namespaces::Video->new(_http => $self->_http);
+    return SignalWire::REST::Namespaces::Video->new( _http => $self->_http );
 }
 
 sub _build_logs {
     my ($self) = @_;
-    return SignalWire::REST::Namespaces::Logs->new(_http => $self->_http);
+    return SignalWire::REST::Namespaces::Logs->new( _http => $self->_http );
 }
 
 sub _build_project_ns {
     my ($self) = @_;
-    return SignalWire::REST::Namespaces::Project->new(_http => $self->_http);
+    return SignalWire::REST::Namespaces::Project->new( _http => $self->_http );
 }
 
 sub _build_pubsub {

--- a/lib/SignalWire/Relay/Action.pm
+++ b/lib/SignalWire/Relay/Action.pm
@@ -2,10 +2,11 @@ package SignalWire::Relay::Action;
 use strict;
 use warnings;
 use Moo;
+
 # Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
 use Scalar::Util ();
-use Carp ();
+use Carp         ();
 
 # Base Action class for long-running RELAY operations.
 # Tracks control_id, completion state, and supports blocking wait.
@@ -25,23 +26,24 @@ my $HashRef = sub {
 };
 
 has 'control_id' => ( is => 'ro', required => 1, isa => $NonEmptyStr );
-has 'call_id'    => ( is => 'ro', default => sub { '' } );
-has 'node_id'    => ( is => 'ro', default => sub { '' } );
-has 'state'      => ( is => 'rw', default => sub { 'created' } );
-has 'completed'  => ( is => 'rw', default => sub { 0 } );  # boolean
-has 'result'     => ( is => 'rw', default => sub { undef } );
-has 'events'     => ( is => 'rw', default => sub { [] }, isa => $ArrayRef );
-has 'payload'    => ( is => 'rw', default => sub { {} }, isa => $HashRef ); # latest event payload
+has 'call_id'    => ( is => 'ro', default  => sub { '' } );
+has 'node_id'    => ( is => 'ro', default  => sub { '' } );
+has 'state'      => ( is => 'rw', default  => sub { 'created' } );
+has 'completed'  => ( is => 'rw', default  => sub { 0 } );                    # boolean
+has 'result'     => ( is => 'rw', default  => sub { undef } );
+has 'events'     => ( is => 'rw', default  => sub { [] }, isa => $ArrayRef );
+has 'payload'    => ( is => 'rw', default  => sub { {} }, isa => $HashRef );  # latest event payload
 
 has '_on_completed' => ( is => 'rw', default => sub { undef } );
 has '_client'       => ( is => 'rw', default => sub { undef } );
 
 # Register on_completed callback
-sub on_completed ($self, $cb = undef) {
+sub on_completed ( $self, $cb = undef ) {
     if ($cb) {
         $self->_on_completed($cb);
+
         # If already done, fire immediately
-        if ($self->completed) {
+        if ( $self->completed ) {
             eval { $cb->($self) };
             warn "on_completed callback error: $@" if $@;
         }
@@ -56,51 +58,54 @@ sub is_done ($self) {
 }
 
 # Blocking wait using select() polling loop
-sub wait ($self, %opts) {
+sub wait ( $self, %opts ) {
     my $timeout = $opts{timeout} || 30;
-    my $start = time();
-    while (!$self->completed && (time() - $start) < $timeout) {
-        select(undef, undef, undef, 0.1);  # sleep 100ms
+    my $start   = time();
+    while ( !$self->completed && ( time() - $start ) < $timeout ) {
+        select( undef, undef, undef, 0.1 );    # sleep 100ms
     }
     return $self->result;
 }
 
 # Called by event dispatch when an event is received for this action
-sub _handle_event ($self, $event) {
-    push @{$self->events}, $event;
-    $self->payload($event->params // {});
+sub _handle_event ( $self, $event ) {
+    push @{ $self->events }, $event;
+    $self->payload( $event->params // {} );
 
     my $state = $event->can('state') ? $event->state : '';
     $self->state($state) if $state;
 }
 
 # Mark the action as completed with a result
-sub _resolve ($self, $result) {
+sub _resolve ( $self, $result ) {
     return if $self->completed;
     $self->completed(1);
     $self->result($result);
 
-    if (my $cb = $self->_on_completed) {
+    if ( my $cb = $self->_on_completed ) {
         eval { $cb->($self) };
         warn "on_completed callback error: $@" if $@;
     }
 }
 
 # Send a sub-command on this action (e.g., play.stop, record.pause)
-sub _execute_subcommand ($self, $method) {
+sub _execute_subcommand ( $self, $method ) {
     my $client = $self->_client;
     return unless $client;
-    return $client->execute($method, {
-        node_id    => $self->node_id,
-        call_id    => $self->call_id,
-        control_id => $self->control_id,
-    });
+    return $client->execute(
+        $method,
+        {
+            node_id    => $self->node_id,
+            call_id    => $self->call_id,
+            control_id => $self->control_id,
+        }
+    );
 }
 
 # Stop the action
 sub stop ($self) {
     return if $self->completed;
-    return $self->_execute_subcommand($self->_stop_method);
+    return $self->_execute_subcommand( $self->_stop_method );
 }
 
 # Override in subclasses
@@ -121,15 +126,18 @@ sub resume ($self) {
     return $self->_execute_subcommand('calling.play.resume');
 }
 
-sub volume ($self, $vol) {
+sub volume ( $self, $vol ) {
     my $client = $self->_client;
     return unless $client;
-    return $client->execute('calling.play.volume', {
-        node_id    => $self->node_id,
-        call_id    => $self->call_id,
-        control_id => $self->control_id,
-        volume     => $vol,
-    });
+    return $client->execute(
+        'calling.play.volume',
+        {
+            node_id    => $self->node_id,
+            call_id    => $self->call_id,
+            control_id => $self->control_id,
+            volume     => $vol,
+        }
+    );
 }
 
 # --- RecordAction ---
@@ -139,7 +147,7 @@ extends 'SignalWire::Relay::Action';
 
 sub _stop_method { 'calling.record.stop' }
 
-sub pause ($self, %opts) {
+sub pause ( $self, %opts ) {
     my $client = $self->_client;
     return unless $client;
     my $params = {
@@ -148,7 +156,7 @@ sub pause ($self, %opts) {
         control_id => $self->control_id,
     };
     $params->{behavior} = $opts{behavior} if $opts{behavior};
-    return $client->execute('calling.record.pause', $params);
+    return $client->execute( 'calling.record.pause', $params );
 }
 
 sub resume ($self) {
@@ -157,8 +165,8 @@ sub resume ($self) {
 
 # Result accessors
 sub url      { $_[0]->payload->{url}      // '' }
-sub duration { $_[0]->payload->{duration}  // 0 }
-sub size     { $_[0]->payload->{size}      // 0 }
+sub duration { $_[0]->payload->{duration} // 0 }
+sub size     { $_[0]->payload->{size}     // 0 }
 
 # --- DetectAction ---
 package SignalWire::Relay::Action::Detect;
@@ -172,13 +180,13 @@ sub detect_result { $_[0]->payload->{detect} // {} }
 # Detect resolves on the FIRST `params.detect` payload (the actual
 # detection result), not on a state(finished). Mirror Python's
 # ``DetectAction._check_event``.
-sub _handle_event ($self, $event) {
+sub _handle_event ( $self, $event ) {
     $self->SUPER::_handle_event($event);
     return if $self->completed;
     my $params = $event->params // {};
-    if (ref $params eq 'HASH'
+    if (   ref $params eq 'HASH'
         && ref $params->{detect} eq 'HASH'
-        && %{$params->{detect}})
+        && %{ $params->{detect} } )
     {
         $self->_resolve($event);
     }
@@ -205,19 +213,20 @@ sub collect_result { $_[0]->payload->{result} // {} }
 # terminal event should — see RELAY_IMPLEMENTATION_GUIDE). Resolves on a
 # calling.call.collect event that carries a result, or a state in the
 # terminal-state map.
-sub _handle_event ($self, $event) {
+sub _handle_event ( $self, $event ) {
+
     # Defense-in-depth: even if a caller hands us a play event (e.g. the
     # legacy unit test that drives the action directly), we drop it so
     # state doesn't update.
-    if (($event->event_type // '') eq 'calling.call.play') {
+    if ( ( $event->event_type // '' ) eq 'calling.call.play' ) {
         return;
     }
     $self->SUPER::_handle_event($event);
     return if $self->completed;
-    if ($event->event_type eq 'calling.call.collect') {
+    if ( $event->event_type eq 'calling.call.collect' ) {
         my $params = $event->params // {};
         my $result = ref $params eq 'HASH' ? $params->{result} : undef;
-        if (ref $result eq 'HASH' && %$result) {
+        if ( ref $result eq 'HASH' && %$result ) {
             $self->_resolve($event);
         }
     }
@@ -226,8 +235,8 @@ sub _handle_event ($self, $event) {
 # Filter calling.call.play events: Call's dispatcher consults this method
 # before handing the event to the action so play events neither dispatch
 # nor (more importantly) trigger terminal-state auto-resolve.
-sub _should_consume_event ($self, $event) {
-    return 0 if ($event->event_type // '') eq 'calling.call.play';
+sub _should_consume_event ( $self, $event ) {
+    return 0 if ( $event->event_type // '' ) eq 'calling.call.play';
     return 1;
 }
 

--- a/lib/SignalWire/Relay/Action.pm
+++ b/lib/SignalWire/Relay/Action.pm
@@ -7,6 +7,7 @@ use Moo;
 use feature 'signatures';
 use Scalar::Util ();
 use Carp         ();
+use Time::HiRes  ();
 
 # Base Action class for long-running RELAY operations.
 # Tracks control_id, completion state, and supports blocking wait.
@@ -62,7 +63,7 @@ sub wait ( $self, %opts ) {
     my $timeout = $opts{timeout} || 30;
     my $start   = time();
     while ( !$self->completed && ( time() - $start ) < $timeout ) {
-        select( undef, undef, undef, 0.1 );    # sleep 100ms
+        Time::HiRes::sleep(0.1);    # poll every 100ms
     }
     return $self->result;
 }

--- a/lib/SignalWire/Relay/Action.pm
+++ b/lib/SignalWire/Relay/Action.pm
@@ -75,6 +75,7 @@ sub _handle_event ( $self, $event ) {
 
     my $state = $event->can('state') ? $event->state : '';
     $self->state($state) if $state;
+    return;
 }
 
 # Mark the action as completed with a result
@@ -87,6 +88,7 @@ sub _resolve ( $self, $result ) {
         eval { $cb->($self) };
         warn "on_completed callback error: $@" if $@;
     }
+    return;
 }
 
 # Send a sub-command on this action (e.g., play.stop, record.pause)
@@ -117,7 +119,7 @@ package SignalWire::Relay::Action::Play;
 use Moo;
 extends 'SignalWire::Relay::Action';
 
-sub _stop_method { 'calling.play.stop' }
+sub _stop_method { return 'calling.play.stop' }
 
 sub pause ($self) {
     return $self->_execute_subcommand('calling.play.pause');
@@ -146,7 +148,7 @@ package SignalWire::Relay::Action::Record;
 use Moo;
 extends 'SignalWire::Relay::Action';
 
-sub _stop_method { 'calling.record.stop' }
+sub _stop_method { return 'calling.record.stop' }
 
 sub pause ( $self, %opts ) {
     my $client = $self->_client;
@@ -165,18 +167,18 @@ sub resume ($self) {
 }
 
 # Result accessors
-sub url      { $_[0]->payload->{url}      // '' }
-sub duration { $_[0]->payload->{duration} // 0 }
-sub size     { $_[0]->payload->{size}     // 0 }
+sub url      { my ($self) = @_; return $self->payload->{url}      // '' }
+sub duration { my ($self) = @_; return $self->payload->{duration} // 0 }
+sub size     { my ($self) = @_; return $self->payload->{size}     // 0 }
 
 # --- DetectAction ---
 package SignalWire::Relay::Action::Detect;
 use Moo;
 extends 'SignalWire::Relay::Action';
 
-sub _stop_method { 'calling.detect.stop' }
+sub _stop_method { return 'calling.detect.stop' }
 
-sub detect_result { $_[0]->payload->{detect} // {} }
+sub detect_result { my ($self) = @_; return $self->payload->{detect} // {} }
 
 # Detect resolves on the FIRST `params.detect` payload (the actual
 # detection result), not on a state(finished). Mirror Python's
@@ -191,6 +193,7 @@ sub _handle_event ( $self, $event ) {
     {
         $self->_resolve($event);
     }
+    return;
 }
 
 # --- CollectAction (used by play_and_collect) ---
@@ -201,13 +204,13 @@ extends 'SignalWire::Relay::Action';
 # play_and_collect's stop verb is calling.play_and_collect.stop, not
 # calling.collect.stop. The standalone collect uses StandaloneCollect
 # below.
-sub _stop_method { 'calling.play_and_collect.stop' }
+sub _stop_method { return 'calling.play_and_collect.stop' }
 
 sub start_input_timers ($self) {
     return $self->_execute_subcommand('calling.collect.start_input_timers');
 }
 
-sub collect_result { $_[0]->payload->{result} // {} }
+sub collect_result { my ($self) = @_; return $self->payload->{result} // {} }
 
 # Override event handling: for play_and_collect, ignore play events
 # (play(finished) must NOT resolve a play_and_collect; only the collect
@@ -231,6 +234,7 @@ sub _handle_event ( $self, $event ) {
             $self->_resolve($event);
         }
     }
+    return;
 }
 
 # Filter calling.call.play events: Call's dispatcher consults this method
@@ -248,7 +252,7 @@ extends 'SignalWire::Relay::Action::Collect';
 
 # Standalone collect uses calling.collect.stop, not the
 # play_and_collect.stop variant.
-sub _stop_method { 'calling.collect.stop' }
+sub _stop_method { return 'calling.collect.stop' }
 
 # --- FaxAction ---
 package SignalWire::Relay::Action::Fax;
@@ -263,44 +267,44 @@ sub _stop_method ($self) {
         : 'calling.send_fax.stop';
 }
 
-sub fax_result { $_[0]->payload->{fax} // {} }
+sub fax_result { my ($self) = @_; return $self->payload->{fax} // {} }
 
 # --- TapAction ---
 package SignalWire::Relay::Action::Tap;
 use Moo;
 extends 'SignalWire::Relay::Action';
 
-sub _stop_method { 'calling.tap.stop' }
+sub _stop_method { return 'calling.tap.stop' }
 
 # --- StreamAction ---
 package SignalWire::Relay::Action::Stream;
 use Moo;
 extends 'SignalWire::Relay::Action';
 
-sub _stop_method { 'calling.stream.stop' }
+sub _stop_method { return 'calling.stream.stop' }
 
 # --- PayAction ---
 package SignalWire::Relay::Action::Pay;
 use Moo;
 extends 'SignalWire::Relay::Action';
 
-sub _stop_method { 'calling.pay.stop' }
+sub _stop_method { return 'calling.pay.stop' }
 
-sub pay_result { $_[0]->payload->{result} // {} }
+sub pay_result { my ($self) = @_; return $self->payload->{result} // {} }
 
 # --- TranscribeAction ---
 package SignalWire::Relay::Action::Transcribe;
 use Moo;
 extends 'SignalWire::Relay::Action';
 
-sub _stop_method { 'calling.transcribe.stop' }
+sub _stop_method { return 'calling.transcribe.stop' }
 
 # --- AIAction ---
 package SignalWire::Relay::Action::AI;
 use Moo;
 extends 'SignalWire::Relay::Action';
 
-sub _stop_method { 'calling.ai.stop' }
+sub _stop_method { return 'calling.ai.stop' }
 
 1;
 

--- a/lib/SignalWire/Relay/Call.pm
+++ b/lib/SignalWire/Relay/Call.pm
@@ -2,6 +2,7 @@ package SignalWire::Relay::Call;
 use strict;
 use warnings;
 use Moo;
+
 # Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
 use Carp ();
@@ -23,31 +24,31 @@ my $ArrayRef = sub {
     Carp::croak("must be an arrayref") unless ref $_[0] eq 'ARRAY';
 };
 
-has 'call_id'    => ( is => 'ro', required => 1, isa => $NonEmptyStr );
-has 'node_id'    => ( is => 'rw', default => sub { '' } );
-has 'tag'        => ( is => 'ro', default => sub { '' } );
-has 'state'      => ( is => 'rw', default => sub { 'created' } );
-has 'device'     => ( is => 'rw', default => sub { {} }, isa => $HashRef );
-has 'end_reason' => ( is => 'rw', default => sub { '' } );
-has 'peer'       => ( is => 'rw', default => sub { {} }, isa => $HashRef );
-has 'context'    => ( is => 'rw', default => sub { '' } );
-has 'dial_winner' => ( is => 'rw', default => sub { 0 } );
+has 'call_id'     => ( is => 'ro', required => 1, isa => $NonEmptyStr );
+has 'node_id'     => ( is => 'rw', default  => sub { '' } );
+has 'tag'         => ( is => 'ro', default  => sub { '' } );
+has 'state'       => ( is => 'rw', default  => sub { 'created' } );
+has 'device'      => ( is => 'rw', default  => sub { {} }, isa => $HashRef );
+has 'end_reason'  => ( is => 'rw', default  => sub { '' } );
+has 'peer'        => ( is => 'rw', default  => sub { {} }, isa => $HashRef );
+has 'context'     => ( is => 'rw', default  => sub { '' } );
+has 'dial_winner' => ( is => 'rw', default  => sub { 0 } );
 
-has '_client'  => ( is => 'rw', default => sub { undef } );
-has '_actions' => ( is => 'rw', default => sub { {} }, isa => $HashRef );   # control_id => Action
-has '_on_event' => ( is => 'rw', default => sub { [] }, isa => $ArrayRef );  # event callbacks
+has '_client'   => ( is => 'rw', default => sub { undef } );
+has '_actions'  => ( is => 'rw', default => sub { {} }, isa => $HashRef );    # control_id => Action
+has '_on_event' => ( is => 'rw', default => sub { [] }, isa => $ArrayRef );   # event callbacks
 
 # Helper to generate a UUID-like control_id
 sub _generate_uuid {
-    my @hex = map { sprintf('%02x', int(rand(256))) } 1..16;
-    $hex[6] = sprintf('%02x', (hex($hex[6]) & 0x0f) | 0x40);
-    $hex[8] = sprintf('%02x', (hex($hex[8]) & 0x3f) | 0x80);
-    return join('-',
-        join('', @hex[0..3]),
-        join('', @hex[4..5]),
-        join('', @hex[6..7]),
-        join('', @hex[8..9]),
-        join('', @hex[10..15]),
+    my @hex = map { sprintf( '%02x', int( rand(256) ) ) } 1 .. 16;
+    $hex[6] = sprintf( '%02x', ( hex( $hex[6] ) & 0x0f ) | 0x40 );
+    $hex[8] = sprintf( '%02x', ( hex( $hex[8] ) & 0x3f ) | 0x80 );
+    return join( '-',
+        join( '', @hex[ 0 .. 3 ] ),
+        join( '', @hex[ 4 .. 5 ] ),
+        join( '', @hex[ 6 .. 7 ] ),
+        join( '', @hex[ 8 .. 9 ] ),
+        join( '', @hex[ 10 .. 15 ] ),
     );
 }
 
@@ -58,17 +59,17 @@ sub _base_params ($self) {
     );
 }
 
-sub _execute ($self, $method, %extra) {
+sub _execute ( $self, $method, %extra ) {
     my $client = $self->_client;
     die "No client attached to call" unless $client;
-    my %params = ($self->_base_params, %extra);
-    return $client->execute($method, \%params);
+    my %params = ( $self->_base_params, %extra );
+    return $client->execute( $method, \%params );
 }
 
 # Start an action-based method: creates the Action, registers it, executes the RPC
-sub _start_action ($self, $method, $action_class, %extra) {
+sub _start_action ( $self, $method, $action_class, %extra ) {
     my $control_id = _generate_uuid();
-    my %params = ($self->_base_params, control_id => $control_id, %extra);
+    my %params     = ( $self->_base_params, control_id => $control_id, %extra );
 
     my $action = $action_class->new(
         control_id => $control_id,
@@ -80,9 +81,10 @@ sub _start_action ($self, $method, $action_class, %extra) {
 
     my $client = $self->_client;
     if ($client) {
-        my $result = $client->execute($method, \%params);
+        my $result = $client->execute( $method, \%params );
+
         # If call is gone (404/410), resolve action immediately
-        if (ref $result eq 'HASH' && $result->{code} && $result->{code} =~ /^(404|410)$/) {
+        if ( ref $result eq 'HASH' && $result->{code} && $result->{code} =~ /^(404|410)$/ ) {
             $action->_resolve(undef);
         }
     }
@@ -92,34 +94,35 @@ sub _start_action ($self, $method, $action_class, %extra) {
 
 # --- Event dispatch ---
 
-sub dispatch_event ($self, $event) {
+sub dispatch_event ( $self, $event ) {
     my $event_type = $event->event_type // '';
 
     # Update call state from state events
-    if ($event_type eq 'calling.call.state') {
+    if ( $event_type eq 'calling.call.state' ) {
         my $new_state = $event->call_state // '';
         $self->state($new_state);
-        $self->end_reason($event->end_reason) if $event->can('end_reason') && $event->end_reason;
-        $self->peer($event->peer) if $event->can('peer') && ref $event->peer eq 'HASH' && %{$event->peer};
+        $self->end_reason( $event->end_reason ) if $event->can('end_reason') && $event->end_reason;
+        $self->peer( $event->peer )
+            if $event->can('peer') && ref $event->peer eq 'HASH' && %{ $event->peer };
 
         # If call ended, resolve all pending actions
-        if (CALL_TERMINAL_STATES->{$new_state}) {
+        if ( CALL_TERMINAL_STATES->{$new_state} ) {
             $self->_resolve_all_actions;
         }
-    }
-    elsif ($event_type eq 'calling.call.connect') {
-        $self->peer($event->peer) if $event->can('peer');
+    } elsif ( $event_type eq 'calling.call.connect' ) {
+        $self->peer( $event->peer ) if $event->can('peer');
     }
 
     # Route to action by control_id
     my $control_id = $event->can('control_id') ? $event->control_id : '';
-    if ($control_id && exists $self->_actions->{$control_id}) {
+    if ( $control_id && exists $self->_actions->{$control_id} ) {
         my $action = $self->_actions->{$control_id};
+
         # The action decides whether to consume the event. play_and_collect's
         # CollectAction filters calling.call.play events out entirely so they
         # neither dispatch nor terminally resolve.
         my $consumed = 1;
-        if ($action->can('_should_consume_event')) {
+        if ( $action->can('_should_consume_event') ) {
             $consumed = $action->_should_consume_event($event);
         }
         if ($consumed) {
@@ -129,30 +132,30 @@ sub dispatch_event ($self, $event) {
             # the action consumed, AND only if the action hasn't already
             # decided to resolve itself in _handle_event (e.g. Detect on
             # first detect payload).
-            unless ($action->completed) {
-                my $terminal = ACTION_TERMINAL_STATES->{$event_type} // {};
-                my $action_state = $event->can('state') ? ($event->state // '') : '';
-                if ($terminal->{$action_state}) {
+            unless ( $action->completed ) {
+                my $terminal     = ACTION_TERMINAL_STATES->{$event_type} // {};
+                my $action_state = $event->can('state') ? ( $event->state // '' ) : '';
+                if ( $terminal->{$action_state} ) {
                     $action->_resolve($event);
                 }
             }
-            if ($action->completed) {
+            if ( $action->completed ) {
                 delete $self->_actions->{$control_id};
             }
         }
     }
 
     # Fire registered event callbacks
-    for my $cb (@{$self->_on_event}) {
-        eval { $cb->($self, $event) };
+    for my $cb ( @{ $self->_on_event } ) {
+        eval { $cb->( $self, $event ) };
         warn "Call event callback error: $@" if $@;
     }
 }
 
 # Register an event listener
-sub on ($self, $cb) {
+sub on ( $self, $cb ) {
     Carp::croak("on() callback must be a coderef") unless ref $cb eq 'CODE';
-    push @{$self->_on_event}, $cb;
+    push @{ $self->_on_event }, $cb;
     return $self;
 }
 
@@ -177,33 +180,33 @@ sub current_state ($self) {
 # terminal definition lives in one place; returns false (never dies) on an
 # unknown/forward-compat state.
 sub is_terminal ($self) {
-    return SignalWire::Relay::CallState->is_terminal($self->state);
+    return SignalWire::Relay::CallState->is_terminal( $self->state );
 }
 
 # Resolve all pending actions (e.g., on call ended or call-gone)
 sub _resolve_all_actions ($self) {
-    for my $action (values %{$self->_actions}) {
+    for my $action ( values %{ $self->_actions } ) {
         $action->_resolve(undef) unless $action->completed;
     }
-    $self->_actions({});
+    $self->_actions( {} );
 }
 
 # --- Simple fire-and-response methods ---
 
-sub answer ($self, %opts) {
-    return $self->_execute('calling.answer', %opts);
+sub answer ( $self, %opts ) {
+    return $self->_execute( 'calling.answer', %opts );
 }
 
-sub hangup ($self, %opts) {
-    return $self->_execute('calling.end', %opts);
+sub hangup ( $self, %opts ) {
+    return $self->_execute( 'calling.end', %opts );
 }
 
 sub pass ($self) {
     return $self->_execute('calling.pass');
 }
 
-sub connect ($self, %opts) {
-    return $self->_execute('calling.connect', %opts);
+sub connect ( $self, %opts ) {
+    return $self->_execute( 'calling.connect', %opts );
 }
 
 sub disconnect ($self) {
@@ -226,89 +229,90 @@ sub denoise_stop ($self) {
     return $self->_execute('calling.denoise.stop');
 }
 
-sub transfer ($self, %opts) {
-    return $self->_execute('calling.transfer', %opts);
+sub transfer ( $self, %opts ) {
+    return $self->_execute( 'calling.transfer', %opts );
 }
 
-sub join_conference ($self, %opts) {
-    return $self->_execute('calling.join_conference', %opts);
+sub join_conference ( $self, %opts ) {
+    return $self->_execute( 'calling.join_conference', %opts );
 }
 
-sub leave_conference ($self, %opts) {
-    return $self->_execute('calling.leave_conference', %opts);
+sub leave_conference ( $self, %opts ) {
+    return $self->_execute( 'calling.leave_conference', %opts );
 }
 
-sub echo ($self, %opts) {
-    return $self->_execute('calling.echo', %opts);
+sub echo ( $self, %opts ) {
+    return $self->_execute( 'calling.echo', %opts );
 }
 
-sub bind_digit ($self, %opts) {
-    return $self->_execute('calling.bind_digit', %opts);
+sub bind_digit ( $self, %opts ) {
+    return $self->_execute( 'calling.bind_digit', %opts );
 }
 
-sub clear_digit_bindings ($self, %opts) {
-    return $self->_execute('calling.clear_digit_bindings', %opts);
+sub clear_digit_bindings ( $self, %opts ) {
+    return $self->_execute( 'calling.clear_digit_bindings', %opts );
 }
 
-sub live_transcribe ($self, %opts) {
-    return $self->_execute('calling.live_transcribe', %opts);
+sub live_transcribe ( $self, %opts ) {
+    return $self->_execute( 'calling.live_transcribe', %opts );
 }
 
-sub live_translate ($self, %opts) {
-    return $self->_execute('calling.live_translate', %opts);
+sub live_translate ( $self, %opts ) {
+    return $self->_execute( 'calling.live_translate', %opts );
 }
 
-sub join_room ($self, %opts) {
-    return $self->_execute('calling.join_room', %opts);
+sub join_room ( $self, %opts ) {
+    return $self->_execute( 'calling.join_room', %opts );
 }
 
-sub leave_room ($self, %opts) {
+sub leave_room ( $self, %opts ) {
+
     # Python parity: Call.leave_room(**kwargs). Forwards any caller-provided
     # kwargs to the Relay leave_room dispatch (slurpy hash on the Perl side
     # ≡ **kwargs on the Python side).
-    return $self->_execute('calling.leave_room', %opts);
+    return $self->_execute( 'calling.leave_room', %opts );
 }
 
-sub amazon_bedrock ($self, %opts) {
-    return $self->_execute('calling.amazon_bedrock', %opts);
+sub amazon_bedrock ( $self, %opts ) {
+    return $self->_execute( 'calling.amazon_bedrock', %opts );
 }
 
-sub ai_message ($self, %opts) {
-    return $self->_execute('calling.ai_message', %opts);
+sub ai_message ( $self, %opts ) {
+    return $self->_execute( 'calling.ai_message', %opts );
 }
 
-sub ai_hold ($self, %opts) {
-    return $self->_execute('calling.ai_hold', %opts);
+sub ai_hold ( $self, %opts ) {
+    return $self->_execute( 'calling.ai_hold', %opts );
 }
 
-sub ai_unhold ($self, %opts) {
-    return $self->_execute('calling.ai_unhold', %opts);
+sub ai_unhold ( $self, %opts ) {
+    return $self->_execute( 'calling.ai_unhold', %opts );
 }
 
-sub user_event ($self, %opts) {
-    return $self->_execute('calling.user_event', %opts);
+sub user_event ( $self, %opts ) {
+    return $self->_execute( 'calling.user_event', %opts );
 }
 
-sub queue_enter ($self, %opts) {
-    return $self->_execute('calling.queue.enter', %opts);
+sub queue_enter ( $self, %opts ) {
+    return $self->_execute( 'calling.queue.enter', %opts );
 }
 
-sub queue_leave ($self, %opts) {
-    return $self->_execute('calling.queue.leave', %opts);
+sub queue_leave ( $self, %opts ) {
+    return $self->_execute( 'calling.queue.leave', %opts );
 }
 
-sub refer ($self, %opts) {
-    return $self->_execute('calling.refer', %opts);
+sub refer ( $self, %opts ) {
+    return $self->_execute( 'calling.refer', %opts );
 }
 
-sub send_digits ($self, %opts) {
-    return $self->_execute('calling.send_digits', %opts);
+sub send_digits ( $self, %opts ) {
+    return $self->_execute( 'calling.send_digits', %opts );
 }
 
 # --- Action-based methods (control_id tracking) ---
 
-sub play ($self, %opts) {
-    return $self->_start_action('calling.play', 'SignalWire::Relay::Action::Play', %opts);
+sub play ( $self, %opts ) {
+    return $self->_start_action( 'calling.play', 'SignalWire::Relay::Action::Play', %opts );
 }
 
 # --- Play convenience: typed wrappers over play() ---
@@ -320,45 +324,45 @@ sub play ($self, %opts) {
 # are only included when the caller supplies them, so the wire shape
 # carries no undef keys.
 
-sub play_tts ($self, $text, %opts) {
+sub play_tts ( $self, $text, %opts ) {
     my %tts = ( text => $text );
     $tts{language} = $opts{language} if defined $opts{language};
     $tts{gender}   = $opts{gender}   if defined $opts{gender};
     $tts{voice}    = $opts{voice}    if defined $opts{voice};
     my @play = ( play => [ { type => 'tts', params => \%tts } ] );
-    push @play, ( volume => $opts{volume} ) if defined $opts{volume};
+    push @play, ( volume       => $opts{volume} )       if defined $opts{volume};
     push @play, ( on_completed => $opts{on_completed} ) if defined $opts{on_completed};
     return $self->play(@play);
 }
 
-sub play_audio ($self, $url, %opts) {
+sub play_audio ( $self, $url, %opts ) {
     my @play = ( play => [ { type => 'audio', params => { url => $url } } ] );
-    push @play, ( volume => $opts{volume} ) if defined $opts{volume};
+    push @play, ( volume       => $opts{volume} )       if defined $opts{volume};
     push @play, ( on_completed => $opts{on_completed} ) if defined $opts{on_completed};
     return $self->play(@play);
 }
 
-sub play_silence ($self, $duration, %opts) {
+sub play_silence ( $self, $duration, %opts ) {
     my @play = ( play => [ { type => 'silence', params => { duration => $duration } } ] );
     push @play, ( on_completed => $opts{on_completed} ) if defined $opts{on_completed};
     return $self->play(@play);
 }
 
-sub play_ringtone ($self, $name, %opts) {
+sub play_ringtone ( $self, $name, %opts ) {
     my %rt = ( name => $name );
     $rt{duration} = $opts{duration} if defined $opts{duration};
     my @play = ( play => [ { type => 'ringtone', params => \%rt } ] );
-    push @play, ( volume => $opts{volume} ) if defined $opts{volume};
+    push @play, ( volume       => $opts{volume} )       if defined $opts{volume};
     push @play, ( on_completed => $opts{on_completed} ) if defined $opts{on_completed};
     return $self->play(@play);
 }
 
-sub record ($self, %opts) {
-    return $self->_start_action('calling.record', 'SignalWire::Relay::Action::Record', %opts);
+sub record ( $self, %opts ) {
+    return $self->_start_action( 'calling.record', 'SignalWire::Relay::Action::Record', %opts );
 }
 
-sub detect ($self, %opts) {
-    return $self->_start_action('calling.detect', 'SignalWire::Relay::Action::Detect', %opts);
+sub detect ( $self, %opts ) {
+    return $self->_start_action( 'calling.detect', 'SignalWire::Relay::Action::Detect', %opts );
 }
 
 # --- Detect convenience: typed wrappers over detect() ---
@@ -368,46 +372,52 @@ sub detect ($self, %opts) {
 # the calling.detect params, not inside the detect object — same as
 # Python's Call.detect_*.
 
-sub detect_digit ($self, %opts) {
+sub detect_digit ( $self, %opts ) {
     my %params;
     $params{digits} = $opts{digits} if defined $opts{digits};
     my @args = ( detect => { type => 'digit', params => \%params } );
-    push @args, ( timeout => $opts{timeout} ) if defined $opts{timeout};
+    push @args, ( timeout      => $opts{timeout} )      if defined $opts{timeout};
     push @args, ( on_completed => $opts{on_completed} ) if defined $opts{on_completed};
     return $self->detect(@args);
 }
 
-sub detect_answering_machine ($self, %opts) {
+sub detect_answering_machine ( $self, %opts ) {
     my %params;
+
     # Only the AMD knobs the caller actually provided land in params; the
     # server fills the rest from its defaults.
-    for my $key (qw(
+    for my $key (
+        qw(
         initial_timeout end_silence_timeout machine_voice_threshold
         machine_words_threshold detect_interruptions detect_message_end
-    )) {
+        )
+        )
+    {
         $params{$key} = $opts{$key} if defined $opts{$key};
     }
     my @args = ( detect => { type => 'machine', params => \%params } );
-    push @args, ( timeout => $opts{timeout} ) if defined $opts{timeout};
+    push @args, ( timeout      => $opts{timeout} )      if defined $opts{timeout};
     push @args, ( on_completed => $opts{on_completed} ) if defined $opts{on_completed};
     return $self->detect(@args);
 }
 
-sub detect_fax ($self, %opts) {
+sub detect_fax ( $self, %opts ) {
     my %params;
     $params{tone} = $opts{tone} if defined $opts{tone};
     my @args = ( detect => { type => 'fax', params => \%params } );
-    push @args, ( timeout => $opts{timeout} ) if defined $opts{timeout};
+    push @args, ( timeout      => $opts{timeout} )      if defined $opts{timeout};
     push @args, ( on_completed => $opts{on_completed} ) if defined $opts{on_completed};
     return $self->detect(@args);
 }
 
-sub collect ($self, %opts) {
-    return $self->_start_action('calling.collect', 'SignalWire::Relay::Action::StandaloneCollect', %opts);
+sub collect ( $self, %opts ) {
+    return $self->_start_action( 'calling.collect', 'SignalWire::Relay::Action::StandaloneCollect',
+        %opts );
 }
 
-sub play_and_collect ($self, %opts) {
-    return $self->_start_action('calling.play_and_collect', 'SignalWire::Relay::Action::Collect', %opts);
+sub play_and_collect ( $self, %opts ) {
+    return $self->_start_action( 'calling.play_and_collect', 'SignalWire::Relay::Action::Collect',
+        %opts );
 }
 
 # --- Prompt convenience: typed media over play_and_collect() ---
@@ -416,7 +426,7 @@ sub play_and_collect ($self, %opts) {
 # hashref is passed through verbatim (see RELAY guide "Collect Object");
 # only the play media is built from the typed args.
 
-sub prompt_tts ($self, $text, $collect, %opts) {
+sub prompt_tts ( $self, $text, $collect, %opts ) {
     my %tts = ( text => $text );
     $tts{language} = $opts{language} if defined $opts{language};
     $tts{gender}   = $opts{gender}   if defined $opts{gender};
@@ -425,29 +435,30 @@ sub prompt_tts ($self, $text, $collect, %opts) {
         play    => [ { type => 'tts', params => \%tts } ],
         collect => $collect,
     );
-    push @args, ( volume => $opts{volume} ) if defined $opts{volume};
+    push @args, ( volume       => $opts{volume} )       if defined $opts{volume};
     push @args, ( on_completed => $opts{on_completed} ) if defined $opts{on_completed};
     return $self->play_and_collect(@args);
 }
 
-sub prompt_audio ($self, $url, $collect, %opts) {
+sub prompt_audio ( $self, $url, $collect, %opts ) {
     my @args = (
         play    => [ { type => 'audio', params => { url => $url } } ],
         collect => $collect,
     );
-    push @args, ( volume => $opts{volume} ) if defined $opts{volume};
+    push @args, ( volume       => $opts{volume} )       if defined $opts{volume};
     push @args, ( on_completed => $opts{on_completed} ) if defined $opts{on_completed};
     return $self->play_and_collect(@args);
 }
 
-sub send_fax ($self, %opts) {
-    my $action = $self->_start_action('calling.send_fax', 'SignalWire::Relay::Action::Fax', %opts);
+sub send_fax ( $self, %opts ) {
+    my $action =
+        $self->_start_action( 'calling.send_fax', 'SignalWire::Relay::Action::Fax', %opts );
     return $action;
 }
 
-sub receive_fax ($self, %opts) {
+sub receive_fax ( $self, %opts ) {
     my $control_id = _generate_uuid();
-    my %params = ($self->_base_params, control_id => $control_id, %opts);
+    my %params     = ( $self->_base_params, control_id => $control_id, %opts );
 
     my $action = SignalWire::Relay::Action::Fax->new(
         control_id => $control_id,
@@ -460,8 +471,8 @@ sub receive_fax ($self, %opts) {
 
     my $client = $self->_client;
     if ($client) {
-        my $result = $client->execute('calling.receive_fax', \%params);
-        if (ref $result eq 'HASH' && $result->{code} && $result->{code} =~ /^(404|410)$/) {
+        my $result = $client->execute( 'calling.receive_fax', \%params );
+        if ( ref $result eq 'HASH' && $result->{code} && $result->{code} =~ /^(404|410)$/ ) {
             $action->_resolve(undef);
         }
     }
@@ -469,24 +480,25 @@ sub receive_fax ($self, %opts) {
     return $action;
 }
 
-sub tap ($self, %opts) {
-    return $self->_start_action('calling.tap', 'SignalWire::Relay::Action::Tap', %opts);
+sub tap ( $self, %opts ) {
+    return $self->_start_action( 'calling.tap', 'SignalWire::Relay::Action::Tap', %opts );
 }
 
-sub stream ($self, %opts) {
-    return $self->_start_action('calling.stream', 'SignalWire::Relay::Action::Stream', %opts);
+sub stream ( $self, %opts ) {
+    return $self->_start_action( 'calling.stream', 'SignalWire::Relay::Action::Stream', %opts );
 }
 
-sub pay ($self, %opts) {
-    return $self->_start_action('calling.pay', 'SignalWire::Relay::Action::Pay', %opts);
+sub pay ( $self, %opts ) {
+    return $self->_start_action( 'calling.pay', 'SignalWire::Relay::Action::Pay', %opts );
 }
 
-sub transcribe ($self, %opts) {
-    return $self->_start_action('calling.transcribe', 'SignalWire::Relay::Action::Transcribe', %opts);
+sub transcribe ( $self, %opts ) {
+    return $self->_start_action( 'calling.transcribe', 'SignalWire::Relay::Action::Transcribe',
+        %opts );
 }
 
-sub ai ($self, %opts) {
-    return $self->_start_action('calling.ai', 'SignalWire::Relay::Action::AI', %opts);
+sub ai ( $self, %opts ) {
+    return $self->_start_action( 'calling.ai', 'SignalWire::Relay::Action::AI', %opts );
 }
 
 1;

--- a/lib/SignalWire/Relay/Call.pm
+++ b/lib/SignalWire/Relay/Call.pm
@@ -150,6 +150,7 @@ sub dispatch_event ( $self, $event ) {
         eval { $cb->( $self, $event ) };
         warn "Call event callback error: $@" if $@;
     }
+    return;
 }
 
 # Register an event listener
@@ -189,6 +190,7 @@ sub _resolve_all_actions ($self) {
         $action->_resolve(undef) unless $action->completed;
     }
     $self->_actions( {} );
+    return;
 }
 
 # --- Simple fire-and-response methods ---

--- a/lib/SignalWire/Relay/CallState.pm
+++ b/lib/SignalWire/Relay/CallState.pm
@@ -1,4 +1,5 @@
 package SignalWire::Relay::CallState;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -61,7 +62,7 @@ use constant {
     ENDED    => 'ended',
 };
 
-our @EXPORT_OK = qw( CREATED RINGING ANSWERED ENDING ENDED );
+our @EXPORT_OK   = qw( CREATED RINGING ANSWERED ENDING ENDED );
 our %EXPORT_TAGS = ( all => [@EXPORT_OK] );
 
 # Canonical ordered set, single-sourced from Relay::Constants so this
@@ -82,7 +83,7 @@ sub states {
 # CallState->is_state($value) — true if $value is a known call state.
 # Returns false (never dies) on undef or an unknown/forward-compat value.
 sub is_state {
-    my ($class, $value) = @_;
+    my ( $class, $value ) = @_;
     return 0 unless defined $value;
     return exists $IS_STATE{$value} ? 1 : 0;
 }
@@ -91,7 +92,7 @@ sub is_state {
 # (the call has ended). Returns false on undef, a non-terminal state, or an
 # unknown/forward-compat value — it never dies.
 sub is_terminal {
-    my ($class, $value) = @_;
+    my ( $class, $value ) = @_;
     return 0 unless defined $value;
     return $IS_TERMINAL{$value} ? 1 : 0;
 }

--- a/lib/SignalWire/Relay/Client.pm
+++ b/lib/SignalWire/Relay/Client.pm
@@ -66,9 +66,9 @@ has 'connected'           => ( is => 'rw', default => sub { 0 } );
 has 'session_id'          => ( is => 'rw', default => sub { '' } );
 
 # Aliases for Python parity (same value, different names).
-sub relay_protocol       { $_[0]->protocol }
-sub _connected           { $_[0]->connected }
-sub _authorization_state { $_[0]->authorization_state }
+sub relay_protocol       { my ($self) = @_; return $self->protocol }
+sub _connected           { my ($self) = @_; return $self->connected }
+sub _authorization_state { my ($self) = @_; return $self->authorization_state }
 
 # Correlation maps
 has '_pending' => ( is => 'rw', default => sub { {} } )
@@ -391,12 +391,16 @@ sub send_message ( $self, %opts ) {
 
 # --- Context management ---
 
-sub receive {
+sub receive {    ## no critic (Subroutines::RequireArgUnpacking)
 
-    # NB: left in classic my-@_ form (NOT a signature). The canonical
-    # arg is a single ``$contexts`` arrayref (Python parity), but this also
-    # accepts a bare list via @_ introspection; a signature would either
-    # lose the list form or change the parsed arity ($contexts -> @args).
+    # NB: left in classic my-@_ form (NOT a signature) AND it re-reads @_ for
+    # the bare-list path below. Both are load-bearing for PARITY, not laziness:
+    # the regex signature extractor (signature_dump.pl) reads this exact
+    # ``my ( $self, $contexts ) = @_;`` first line to emit the audited
+    # ``contexts`` param, and the dual arrayref/bare-list calling convention
+    # needs @_ to recover the extra args. Unpacking into ``@args`` would rename
+    # the audited param and move the surface — so RequireArgUnpacking is
+    # suppressed here (changing it would change the wire/surface contract).
     my ( $self, $contexts ) = @_;
 
     # Python parity: receive(contexts: list[str]). Canonical form takes
@@ -414,10 +418,11 @@ sub receive {
     return $self->execute( 'signalwire.receive', { contexts => \@ctxs } );
 }
 
-sub unreceive {
+sub unreceive {    ## no critic (Subroutines::RequireArgUnpacking)
 
-    # Left in classic my-@_ form for the same dual arrayref/list reason
-    # as receive() above.
+    # Left in classic my-@_ form + @_ re-read for the same dual arrayref/list
+    # parity reason as receive() above (see its note); RequireArgUnpacking is
+    # suppressed because obeying it would rename the audited ``contexts`` param.
     my ( $self, $contexts ) = @_;
 
     # Python parity: unreceive(contexts: list[str]).
@@ -497,6 +502,7 @@ sub _send ( $self, $msg ) {
     if ($ws) {
         $ws->write($json);
     }
+    return;
 }
 
 # --- Internal: read one frame from WebSocket ---
@@ -518,6 +524,7 @@ sub _read_once ($self) {
             $self->connected(0);
         }
     }
+    return;
 }
 
 # --- Internal: handle an incoming WebSocket message ---
@@ -582,6 +589,7 @@ sub _handle_message ( $self, $raw ) {
         $self->_send_ack( $msg->{id} );
         $self->_handle_disconnect( $msg->{params} // {} );
     }
+    return;
 }
 
 # --- Internal: send an ACK ---
@@ -594,6 +602,7 @@ sub _send_ack ( $self, $id ) {
             result  => {},
         }
     );
+    return;
 }
 
 # --- Internal: handle events ---
@@ -675,6 +684,7 @@ sub _handle_event ( $self, $outer_params ) {
             delete $self->_calls->{$call_id};
         }
     }
+    return;
 }
 
 # --- Internal: handle inbound call ---
@@ -698,6 +708,7 @@ sub _handle_inbound_call ( $self, $event, $params ) {
         eval { $cb->($call) };
         warn "on_call callback error: $@" if $@;
     }
+    return;
 }
 
 # --- Internal: handle inbound message ---
@@ -707,6 +718,7 @@ sub _handle_inbound_message ( $self, $event ) {
         eval { $cb->($event) };
         warn "on_message callback error: $@" if $@;
     }
+    return;
 }
 
 # --- Internal: handle dial completion event ---
@@ -740,6 +752,7 @@ sub _handle_dial_event ( $self, $event, $params ) {
     } elsif ( $dial_state eq DIAL_STATE_FAILED ) {
         $pending->{reject}->("Dial failed");
     }
+    return;
 }
 
 # --- Internal: handle server disconnect ---
@@ -757,6 +770,7 @@ sub _handle_disconnect ( $self, $params ) {
     $self->connected(0);
 
     # The client should reconnect (handled by the event loop)
+    return;
 }
 
 # --- Reconnection ---
@@ -801,6 +815,7 @@ sub disconnect_ws ($self) {
         $self->_socket(undef);
     }
     $self->_ws(undef);
+    return;
 }
 
 # --- Run event loop ---
@@ -809,6 +824,7 @@ sub run ($self) {
     while ( $self->connected ) {
         $self->_read_once();
     }
+    return;
 }
 
 1;

--- a/lib/SignalWire/Relay/Client.pm
+++ b/lib/SignalWire/Relay/Client.pm
@@ -5,7 +5,8 @@ use Moo;
 
 # Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
-use Carp ();
+use Carp        ();
+use Time::HiRes ();
 
 use JSON qw(encode_json decode_json);
 use IO::Socket::INET;
@@ -780,7 +781,7 @@ sub reconnect ($self) {
     $delay = $self->_max_backoff if $delay > $self->_max_backoff;
 
     $logger->info( "Reconnecting in ${delay}s (attempt " . ( $attempts + 1 ) . ")" );
-    select( undef, undef, undef, $delay );
+    Time::HiRes::sleep($delay);
 
     $self->_reconnect_attempts( $attempts + 1 );
 
@@ -788,7 +789,7 @@ sub reconnect ($self) {
         return $self->authenticate;
     }
 
-    return undef;
+    return;
 }
 
 # --- Disconnect ---

--- a/lib/SignalWire/Relay/Client.pm
+++ b/lib/SignalWire/Relay/Client.pm
@@ -2,6 +2,7 @@ package SignalWire::Relay::Client;
 use strict;
 use warnings;
 use Moo;
+
 # Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
 use Carp ();
@@ -23,11 +24,12 @@ use SignalWire::Logging;
 
 my $logger = SignalWire::Logging->get_logger('relay_client');
 
-has 'project'  => ( is => 'ro', default => sub { '' } );
-has 'token'    => ( is => 'ro', default => sub { '' } );
+has 'project' => ( is => 'ro', default => sub { '' } );
+has 'token'   => ( is => 'ro', default => sub { '' } );
+
 # host is the required RELAY endpoint — a bad construction must die at
 # build time rather than fail later inside connect_ws.
-has 'host'     => (
+has 'host' => (
     is       => 'ro',
     required => 1,
     isa      => sub {
@@ -40,18 +42,21 @@ has 'contexts' => (
     default => sub { [] },
     isa     => sub { Carp::croak("contexts must be an arrayref") unless ref $_[0] eq 'ARRAY' },
 );
-has 'agent'    => ( is => 'ro', default => sub { 'signalwire-agents-perl/1.0' } );
+has 'agent' => ( is => 'ro', default => sub { 'signalwire-agents-perl/1.0' } );
+
 # Optional JWT-based authentication (alternative to project/token).
-has 'jwt_token' => ( is => 'ro', default => sub { '' } );
+has 'jwt_token'  => ( is => 'ro', default => sub { '' } );
 has '_jwt_token' => ( is => 'rw', default => sub { '' } );
+
 # Scheme: "wss" (production, TLS — the default) or "ws" (plain, used by
 # the local audit fixture in audit_relay_handshake.py). Keeping this
 # explicit lets the same client drive both real RELAY and a 127.0.0.1
 # fixture without forking the transport.
-has 'scheme'   => ( is => 'ro', default => sub { 'wss' } );
+has 'scheme' => ( is => 'ro', default => sub { 'wss' } );
+
 # Path component appended to the host. Defaults to '/api/relay/ws' (the
 # documented production endpoint per RELAY_IMPLEMENTATION_GUIDE).
-has 'path'     => ( is => 'ro', default => sub { '/api/relay/ws' } );
+has 'path' => ( is => 'ro', default => sub { '/api/relay/ws' } );
 
 # Connection state
 has 'protocol'            => ( is => 'rw', default => sub { '' } );
@@ -60,15 +65,17 @@ has 'connected'           => ( is => 'rw', default => sub { 0 } );
 has 'session_id'          => ( is => 'rw', default => sub { '' } );
 
 # Aliases for Python parity (same value, different names).
-sub relay_protocol { $_[0]->protocol }
-sub _connected     { $_[0]->connected }
+sub relay_protocol       { $_[0]->protocol }
+sub _connected           { $_[0]->connected }
 sub _authorization_state { $_[0]->authorization_state }
 
 # Correlation maps
-has '_pending'       => ( is => 'rw', default => sub { {} } );  # rpc_id => { resolve => sub, reject => sub }
-has '_calls'         => ( is => 'rw', default => sub { {} } );  # call_id => Call
-has '_pending_dials' => ( is => 'rw', default => sub { {} } );  # tag => { resolve => sub, reject => sub }
-has '_messages'      => ( is => 'rw', default => sub { {} } );  # message_id => Message
+has '_pending' => ( is => 'rw', default => sub { {} } )
+    ;    # rpc_id => { resolve => sub, reject => sub }
+has '_calls' => ( is => 'rw', default => sub { {} } );    # call_id => Call
+has '_pending_dials' => ( is => 'rw', default => sub { {} } )
+    ;                                                     # tag => { resolve => sub, reject => sub }
+has '_messages' => ( is => 'rw', default => sub { {} } ); # message_id => Message
 
 # WebSocket internals
 has '_socket' => ( is => 'rw', default => sub { undef } );
@@ -85,33 +92,33 @@ has '_on_event'   => ( is => 'rw', default => sub { undef } );
 
 # --- UUID generation ---
 sub _generate_uuid {
-    my @hex = map { sprintf('%02x', int(rand(256))) } 1..16;
-    $hex[6] = sprintf('%02x', (hex($hex[6]) & 0x0f) | 0x40);
-    $hex[8] = sprintf('%02x', (hex($hex[8]) & 0x3f) | 0x80);
-    return join('-',
-        join('', @hex[0..3]),
-        join('', @hex[4..5]),
-        join('', @hex[6..7]),
-        join('', @hex[8..9]),
-        join('', @hex[10..15]),
+    my @hex = map { sprintf( '%02x', int( rand(256) ) ) } 1 .. 16;
+    $hex[6] = sprintf( '%02x', ( hex( $hex[6] ) & 0x0f ) | 0x40 );
+    $hex[8] = sprintf( '%02x', ( hex( $hex[8] ) & 0x3f ) | 0x80 );
+    return join( '-',
+        join( '', @hex[ 0 .. 3 ] ),
+        join( '', @hex[ 4 .. 5 ] ),
+        join( '', @hex[ 6 .. 7 ] ),
+        join( '', @hex[ 8 .. 9 ] ),
+        join( '', @hex[ 10 .. 15 ] ),
     );
 }
 
 # --- Public API: register handlers ---
 
-sub on_call ($self, $cb) {
+sub on_call ( $self, $cb ) {
     Carp::croak("on_call() callback must be a coderef") unless ref $cb eq 'CODE';
     $self->_on_call($cb);
     return $self;
 }
 
-sub on_message ($self, $cb) {
+sub on_message ( $self, $cb ) {
     Carp::croak("on_message() callback must be a coderef") unless ref $cb eq 'CODE';
     $self->_on_message($cb);
     return $self;
 }
 
-sub on_event ($self, $cb) {
+sub on_event ( $self, $cb ) {
     Carp::croak("on_event() callback must be a coderef") unless ref $cb eq 'CODE';
     $self->_on_event($cb);
     return $self;
@@ -124,7 +131,7 @@ sub on_event ($self, $cb) {
 # the authenticate result hashref on success, dies on failure.
 sub connect ($self) {
     die "project and token are required (or jwt_token)"
-        unless ($self->project && $self->token) || $self->jwt_token || $self->_jwt_token;
+        unless ( $self->project && $self->token ) || $self->jwt_token || $self->_jwt_token;
     my $ok = $self->connect_ws;
     die "WebSocket connect failed" unless $ok;
     return $self->authenticate;
@@ -137,25 +144,26 @@ sub disconnect ($self) {
 }
 
 sub connect_ws ($self) {
-    my $scheme = $self->scheme || 'wss';
+    my $scheme   = $self->scheme || 'wss';
     my $raw_host = $self->host;
 
     # `host` may be a bare hostname ("example.com") or a hostname+port
     # ("127.0.0.1:9000"). Split if needed; otherwise pick the default
     # port for the scheme.
-    my ($host, $port);
-    if ($raw_host =~ /^(.+):(\d+)$/) {
-        ($host, $port) = ($1, $2);
+    my ( $host, $port );
+    if ( $raw_host =~ /^(.+):(\d+)$/ ) {
+        ( $host, $port ) = ( $1, $2 );
     } else {
         $host = $raw_host;
-        $port = ($scheme eq 'ws') ? 80 : 443;
+        $port = ( $scheme eq 'ws' ) ? 80 : 443;
     }
 
     my $url = "$scheme://$raw_host" . $self->path;
     $logger->debug("Connecting to $url");
 
     my $socket;
-    if ($scheme eq 'ws') {
+    if ( $scheme eq 'ws' ) {
+
         # Plain TCP — used by the local audit fixture. No TLS, no
         # certificate validation. Production relay never runs over
         # plain ws://.
@@ -182,26 +190,34 @@ sub connect_ws ($self) {
         }
     }
 
-    my $ws = Protocol::WebSocket::Client->new(url => $url);
+    my $ws = Protocol::WebSocket::Client->new( url => $url );
 
-    $ws->on(write => sub {
-        my ($ws_client, $buf) = @_;
-        syswrite($socket, $buf);
-    });
+    $ws->on(
+        write => sub {
+            my ( $ws_client, $buf ) = @_;
+            syswrite( $socket, $buf );
+        }
+    );
 
-    $ws->on(connect => sub {
-        $logger->debug("WebSocket connected");
-    });
+    $ws->on(
+        connect => sub {
+            $logger->debug("WebSocket connected");
+        }
+    );
 
-    $ws->on(error => sub {
-        my ($ws_client, $error) = @_;
-        $logger->error("WebSocket error: $error");
-    });
+    $ws->on(
+        error => sub {
+            my ( $ws_client, $error ) = @_;
+            $logger->error("WebSocket error: $error");
+        }
+    );
 
-    $ws->on(read => sub {
-        my ($ws_client, $message) = @_;
-        $self->_handle_message($message);
-    });
+    $ws->on(
+        read => sub {
+            my ( $ws_client, $message ) = @_;
+            $self->_handle_message($message);
+        }
+    );
 
     $self->_socket($socket);
     $self->_ws($ws);
@@ -211,7 +227,7 @@ sub connect_ws ($self) {
 
     # Read the handshake response
     my $buf = '';
-    while (my $bytes = sysread($socket, $buf, 4096, length($buf))) {
+    while ( my $bytes = sysread( $socket, $buf, 4096, length($buf) ) ) {
         $ws->read($buf);
         $buf = '';
         last if $ws->{hs}->is_done;
@@ -223,6 +239,7 @@ sub connect_ws ($self) {
 }
 
 sub authenticate ($self) {
+
     # Build authentication block: either project/token or jwt_token.
     my %auth;
     my $jwt = $self->jwt_token || $self->_jwt_token;
@@ -239,6 +256,7 @@ sub authenticate ($self) {
         event_acks     => JSON::true,
         authentication => \%auth,
     );
+
     # Mirror project/token at the top level when not using JWT (Rust agent
     # convention; production tolerates both shapes).
     unless ($jwt) {
@@ -247,30 +265,31 @@ sub authenticate ($self) {
     }
 
     # Add contexts if any
-    if (@{$self->contexts}) {
+    if ( @{ $self->contexts } ) {
         $params{contexts} = $self->contexts;
     }
 
     # Add protocol for session resume
-    if ($self->protocol) {
+    if ( $self->protocol ) {
         $params{protocol} = $self->protocol;
     }
 
     # Add authorization_state for fast re-auth
-    if ($self->authorization_state) {
+    if ( $self->authorization_state ) {
         $params{authorization_state} = $self->authorization_state;
     }
 
-    my $result = $self->execute('signalwire.connect', \%params);
+    my $result = $self->execute( 'signalwire.connect', \%params );
 
-    if (ref $result eq 'HASH') {
-        $self->protocol($result->{protocol}) if $result->{protocol};
+    if ( ref $result eq 'HASH' ) {
+        $self->protocol( $result->{protocol} ) if $result->{protocol};
+
         # The RELAY connect handshake returns the server-assigned session id
         # under the key `sessionid` (no underscore) — see the ConnectResult
         # wire shape (mock_relay connect_result_payload / production switchblade).
         # Capturing it lets a test scope its journal/scenario calls to its own
         # session for parallel-safe isolation.
-        $self->session_id($result->{sessionid}) if $result->{sessionid};
+        $self->session_id( $result->{sessionid} ) if $result->{sessionid};
     }
 
     return $result;
@@ -278,13 +297,13 @@ sub authenticate ($self) {
 
 # --- JSON-RPC execute ---
 
-sub execute ($self, $method, $params = undef) {
+sub execute ( $self, $method, $params = undef ) {
     $params //= {};
 
     my $id = _generate_uuid();
 
     # Add protocol to params (except for signalwire.connect itself)
-    if ($method ne 'signalwire.connect' && $self->protocol) {
+    if ( $method ne 'signalwire.connect' && $self->protocol ) {
         $params->{protocol} = $self->protocol;
     }
 
@@ -301,15 +320,15 @@ sub execute ($self, $method, $params = undef) {
     my $error;
     $self->_pending->{$id} = {
         resolve => sub { $result = $_[0]; $done = 1 },
-        reject  => sub { $error = $_[0]; $done = 1 },
+        reject  => sub { $error  = $_[0]; $done = 1 },
     };
 
     $self->_send($request);
 
     # Poll for response (synchronous in this implementation)
     my $timeout = 30;
-    my $start = time();
-    while (!$done && (time() - $start) < $timeout) {
+    my $start   = time();
+    while ( !$done && ( time() - $start ) < $timeout ) {
         $self->_read_once();
     }
 
@@ -324,10 +343,10 @@ sub execute ($self, $method, $params = undef) {
 
 # --- Messaging ---
 
-sub send_message ($self, %opts) {
+sub send_message ( $self, %opts ) {
     die "At least one of body or media is required"
-        unless (defined $opts{body} && length $opts{body})
-            || (ref $opts{media} eq 'ARRAY' && @{$opts{media}});
+        unless ( defined $opts{body} && length $opts{body} )
+        || ( ref $opts{media} eq 'ARRAY' && @{ $opts{media} } );
 
     # Default context to the relay protocol or 'default' (matches Python).
     my $msg_context = $opts{context} // $self->protocol // '';
@@ -338,17 +357,17 @@ sub send_message ($self, %opts) {
         to_number   => $opts{to_number}   // '',
         from_number => $opts{from_number} // '',
     );
-    $params{body}   = $opts{body}   if defined $opts{body}   && length $opts{body};
-    $params{media}  = $opts{media}  if ref $opts{media} eq 'ARRAY' && @{$opts{media}};
-    $params{tags}   = $opts{tags}   if ref $opts{tags}  eq 'ARRAY' && @{$opts{tags}};
-    $params{region} = $opts{region} if defined $opts{region} && length $opts{region};
+    $params{body}   = $opts{body}   if defined $opts{body}         && length $opts{body};
+    $params{media}  = $opts{media}  if ref $opts{media} eq 'ARRAY' && @{ $opts{media} };
+    $params{tags}   = $opts{tags}   if ref $opts{tags} eq 'ARRAY'  && @{ $opts{tags} };
+    $params{region} = $opts{region} if defined $opts{region}       && length $opts{region};
 
-    my $result = $self->execute('messaging.send', \%params);
+    my $result = $self->execute( 'messaging.send', \%params );
 
-    if (ref $result eq 'HASH' && $result->{message_id}) {
+    if ( ref $result eq 'HASH' && $result->{message_id} ) {
         my $msg = SignalWire::Relay::Message->new(
             message_id  => $result->{message_id},
-            context     => $opts{context}     // '',
+            context     => $opts{context} // '',
             direction   => 'outbound',
             from_number => $opts{from_number} // '',
             to_number   => $opts{to_number}   // '',
@@ -357,10 +376,10 @@ sub send_message ($self, %opts) {
             tags        => $opts{tags}        // [],
             state       => 'queued',
         );
-        $self->_messages->{$result->{message_id}} = $msg;
+        $self->_messages->{ $result->{message_id} } = $msg;
 
-        if ($opts{on_completed}) {
-            $msg->on_completed($opts{on_completed});
+        if ( $opts{on_completed} ) {
+            $msg->on_completed( $opts{on_completed} );
         }
 
         return $msg;
@@ -372,65 +391,70 @@ sub send_message ($self, %opts) {
 # --- Context management ---
 
 sub receive {
+
     # NB: left in classic my-@_ form (NOT a signature). The canonical
     # arg is a single ``$contexts`` arrayref (Python parity), but this also
     # accepts a bare list via @_ introspection; a signature would either
     # lose the list form or change the parsed arity ($contexts -> @args).
-    my ($self, $contexts) = @_;
+    my ( $self, $contexts ) = @_;
+
     # Python parity: receive(contexts: list[str]). Canonical form takes
     # an arrayref. Backward-compat: also accept slurpy
     # (``$client->receive('ctx1', 'ctx2')``) — re-grab @_ when the first
     # arg is a string and there are extras.
     my @ctxs;
-    if (ref $contexts eq 'ARRAY') {
+    if ( ref $contexts eq 'ARRAY' ) {
         @ctxs = @$contexts;
     } else {
         @ctxs = @_;
-        shift @ctxs;  # drop $self
+        shift @ctxs;    # drop $self
     }
     return unless @ctxs;
-    return $self->execute('signalwire.receive', { contexts => \@ctxs });
+    return $self->execute( 'signalwire.receive', { contexts => \@ctxs } );
 }
 
 sub unreceive {
+
     # Left in classic my-@_ form for the same dual arrayref/list reason
     # as receive() above.
-    my ($self, $contexts) = @_;
+    my ( $self, $contexts ) = @_;
+
     # Python parity: unreceive(contexts: list[str]).
     my @ctxs;
-    if (ref $contexts eq 'ARRAY') {
+    if ( ref $contexts eq 'ARRAY' ) {
         @ctxs = @$contexts;
     } else {
         @ctxs = @_;
-        shift @ctxs;  # drop $self
+        shift @ctxs;    # drop $self
     }
     return unless @ctxs;
-    return $self->execute('signalwire.unreceive', { contexts => \@ctxs });
+    return $self->execute( 'signalwire.unreceive', { contexts => \@ctxs } );
 }
 
 # --- Dial ---
 
-sub dial ($self, %opts) {
-    my $tag = $opts{tag} || _generate_uuid();
-    my $timeout = delete $opts{timeout} || 120;
+sub dial ( $self, %opts ) {
+    my $tag          = $opts{tag}            || _generate_uuid();
+    my $timeout      = delete $opts{timeout} || 120;
     my $on_completed = delete $opts{on_completed};
 
     my %params = ( tag => $tag );
-    $params{devices} = $opts{devices} if $opts{devices};
-    $params{region} = $opts{region} if $opts{region};
-    $params{max_price_per_minute} = $opts{max_price_per_minute} if exists $opts{max_price_per_minute};
+    $params{devices}              = $opts{devices} if $opts{devices};
+    $params{region}               = $opts{region}  if $opts{region};
+    $params{max_price_per_minute} = $opts{max_price_per_minute}
+        if exists $opts{max_price_per_minute};
 
     # Register pending dial BEFORE sending RPC
     my $call;
     my $done = 0;
     my $dial_error;
     $self->_pending_dials->{$tag} = {
-        resolve => sub { $call = $_[0]; $done = 1 },
+        resolve => sub { $call       = $_[0]; $done = 1 },
         reject  => sub { $dial_error = $_[0]; $done = 1 },
     };
 
     # Send the RPC -- response is just {code:200, message:"Dialing"}
-    eval { $self->execute('calling.dial', \%params) };
+    eval { $self->execute( 'calling.dial', \%params ) };
     if ($@) {
         delete $self->_pending_dials->{$tag};
         die $@;
@@ -438,7 +462,7 @@ sub dial ($self, %opts) {
 
     # Wait for calling.call.dial event to resolve
     my $start = time();
-    while (!$done && (time() - $start) < $timeout) {
+    while ( !$done && ( time() - $start ) < $timeout ) {
         $self->_read_once();
     }
 
@@ -448,14 +472,16 @@ sub dial ($self, %opts) {
         die "Dial failed: $dial_error";
     }
 
-    if ($call && $on_completed) {
-        $call->on(sub {
-            my ($c, $event) = @_;
-            if ($event->event_type eq 'calling.call.state' && $event->call_state eq 'ended') {
-                eval { $on_completed->($c) };
-                warn "dial on_completed error: $@" if $@;
+    if ( $call && $on_completed ) {
+        $call->on(
+            sub {
+                my ( $c, $event ) = @_;
+                if ( $event->event_type eq 'calling.call.state' && $event->call_state eq 'ended' ) {
+                    eval { $on_completed->($c) };
+                    warn "dial on_completed error: $@" if $@;
+                }
             }
-        });
+        );
     }
 
     return $call;
@@ -463,7 +489,7 @@ sub dial ($self, %opts) {
 
 # --- Internal: send a JSON-RPC message ---
 
-sub _send ($self, $msg) {
+sub _send ( $self, $msg ) {
     my $json = encode_json($msg);
     $logger->debug("SEND: $json");
     my $ws = $self->_ws;
@@ -478,14 +504,15 @@ sub _read_once ($self) {
     my $socket = $self->_socket;
     return unless $socket;
 
-    my $buf = '';
+    my $buf   = '';
     my $ready = '';
-    vec($ready, fileno($socket), 1) = 1;
-    if (select($ready, undef, undef, 0.1)) {
-        my $bytes = sysread($socket, $buf, 4096);
-        if ($bytes && $bytes > 0) {
+    vec( $ready, fileno($socket), 1 ) = 1;
+    if ( select( $ready, undef, undef, 0.1 ) ) {
+        my $bytes = sysread( $socket, $buf, 4096 );
+        if ( $bytes && $bytes > 0 ) {
             $self->_ws->read($buf);
-        } elsif (!defined $bytes || $bytes == 0) {
+        } elsif ( !defined $bytes || $bytes == 0 ) {
+
             # Connection lost
             $self->connected(0);
         }
@@ -494,7 +521,7 @@ sub _read_once ($self) {
 
 # --- Internal: handle an incoming WebSocket message ---
 
-sub _handle_message ($self, $raw) {
+sub _handle_message ( $self, $raw ) {
     $logger->debug("RECV: $raw");
 
     # Skip non-JSON-text frames. Protocol::WebSocket::Client doesn't
@@ -504,10 +531,10 @@ sub _handle_message ($self, $raw) {
     # '{', and decoding them as JSON would just spam the log.
     return unless defined $raw && length $raw;
     my $first;
-    if (utf8::is_utf8($raw)) {
-        $first = substr($raw, 0, 1);
+    if ( utf8::is_utf8($raw) ) {
+        $first = substr( $raw, 0, 1 );
     } else {
-        $first = substr($raw, 0, 1);
+        $first = substr( $raw, 0, 1 );
     }
     return unless defined $first && $first eq '{';
 
@@ -515,7 +542,7 @@ sub _handle_message ($self, $raw) {
     # utf8 (Perl saw a multibyte char in transit) we need to re-encode
     # before parsing. Otherwise we hit "Wide character in subroutine entry".
     my $msg;
-    if (utf8::is_utf8($raw)) {
+    if ( utf8::is_utf8($raw) ) {
         my $bytes = $raw;
         utf8::encode($bytes);
         eval { $msg = decode_json($bytes) };
@@ -528,13 +555,13 @@ sub _handle_message ($self, $raw) {
     }
 
     # JSON-RPC response (has "result" or "error", matched by "id")
-    if (exists $msg->{result} || exists $msg->{error}) {
+    if ( exists $msg->{result} || exists $msg->{error} ) {
         my $id = $msg->{id} // '';
-        if (my $pending = delete $self->_pending->{$id}) {
-            if (exists $msg->{error}) {
-                $pending->{reject}->($msg->{error});
+        if ( my $pending = delete $self->_pending->{$id} ) {
+            if ( exists $msg->{error} ) {
+                $pending->{reject}->( $msg->{error} );
             } else {
-                $pending->{resolve}->($msg->{result});
+                $pending->{resolve}->( $msg->{result} );
             }
         }
         return;
@@ -543,69 +570,70 @@ sub _handle_message ($self, $raw) {
     # Server-initiated method call
     my $method = $msg->{method} // '';
 
-    if ($method eq 'signalwire.event') {
+    if ( $method eq 'signalwire.event' ) {
+
         # ACK the event immediately
-        $self->_send_ack($msg->{id});
-        $self->_handle_event($msg->{params} // {});
-    }
-    elsif ($method eq 'signalwire.ping') {
-        $self->_send_ack($msg->{id});
-    }
-    elsif ($method eq 'signalwire.disconnect') {
-        $self->_send_ack($msg->{id});
-        $self->_handle_disconnect($msg->{params} // {});
+        $self->_send_ack( $msg->{id} );
+        $self->_handle_event( $msg->{params} // {} );
+    } elsif ( $method eq 'signalwire.ping' ) {
+        $self->_send_ack( $msg->{id} );
+    } elsif ( $method eq 'signalwire.disconnect' ) {
+        $self->_send_ack( $msg->{id} );
+        $self->_handle_disconnect( $msg->{params} // {} );
     }
 }
 
 # --- Internal: send an ACK ---
 
-sub _send_ack ($self, $id) {
-    $self->_send({
-        jsonrpc => '2.0',
-        id      => $id,
-        result  => {},
-    });
+sub _send_ack ( $self, $id ) {
+    $self->_send(
+        {
+            jsonrpc => '2.0',
+            id      => $id,
+            result  => {},
+        }
+    );
 }
 
 # --- Internal: handle events ---
 
-sub _handle_event ($self, $outer_params) {
-    my $event_type = $outer_params->{event_type} // '';
-    my $inner_params = $outer_params->{params} // {};
+sub _handle_event ( $self, $outer_params ) {
+    my $event_type   = $outer_params->{event_type} // '';
+    my $inner_params = $outer_params->{params}     // {};
 
     # Parse into typed event object
-    my $event = SignalWire::Relay::Event->parse_event($event_type, $inner_params);
+    my $event = SignalWire::Relay::Event->parse_event( $event_type, $inner_params );
 
     # Fire global event callback
-    if (my $cb = $self->_on_event) {
+    if ( my $cb = $self->_on_event ) {
         eval { $cb->($event) };
         warn "on_event callback error: $@" if $@;
     }
 
     # --- Authorization state ---
-    if ($event_type eq 'signalwire.authorization.state') {
-        $self->authorization_state($inner_params->{authorization_state} // '');
+    if ( $event_type eq 'signalwire.authorization.state' ) {
+        $self->authorization_state( $inner_params->{authorization_state} // '' );
         return;
     }
 
     # --- Inbound call ---
-    if ($event_type eq 'calling.call.receive') {
-        $self->_handle_inbound_call($event, $inner_params);
+    if ( $event_type eq 'calling.call.receive' ) {
+        $self->_handle_inbound_call( $event, $inner_params );
         return;
     }
 
     # --- Inbound message ---
-    if ($event_type eq 'messaging.receive') {
+    if ( $event_type eq 'messaging.receive' ) {
         $self->_handle_inbound_message($event);
         return;
     }
 
     # --- Message state ---
-    if ($event_type eq 'messaging.state') {
+    if ( $event_type eq 'messaging.state' ) {
         my $message_id = $inner_params->{message_id} // '';
-        if (my $msg = $self->_messages->{$message_id}) {
+        if ( my $msg = $self->_messages->{$message_id} ) {
             $msg->dispatch_event($event);
-            if ($msg->completed) {
+            if ( $msg->completed ) {
                 delete $self->_messages->{$message_id};
             }
         }
@@ -613,17 +641,18 @@ sub _handle_event ($self, $outer_params) {
     }
 
     # --- Dial completion ---
-    if ($event_type eq 'calling.call.dial') {
-        $self->_handle_dial_event($event, $inner_params);
+    if ( $event_type eq 'calling.call.dial' ) {
+        $self->_handle_dial_event( $event, $inner_params );
         return;
     }
 
     # --- State events during dial (call not registered yet) ---
     my $call_id = $inner_params->{call_id} // '';
-    my $tag = $inner_params->{tag} // '';
+    my $tag     = $inner_params->{tag}     // '';
 
-    if ($event_type eq 'calling.call.state' && $tag && exists $self->_pending_dials->{$tag}) {
-        if (!exists $self->_calls->{$call_id} && $call_id) {
+    if ( $event_type eq 'calling.call.state' && $tag && exists $self->_pending_dials->{$tag} ) {
+        if ( !exists $self->_calls->{$call_id} && $call_id ) {
+
             # Create the Call object so events route correctly
             my $call = SignalWire::Relay::Call->new(
                 call_id => $call_id,
@@ -637,11 +666,11 @@ sub _handle_event ($self, $outer_params) {
     }
 
     # --- Normal routing by call_id ---
-    if ($call_id && (my $call = $self->_calls->{$call_id})) {
+    if ( $call_id && ( my $call = $self->_calls->{$call_id} ) ) {
         $call->dispatch_event($event);
 
         # Clean up ended calls
-        if ($call->state eq 'ended') {
+        if ( $call->state eq 'ended' ) {
             delete $self->_calls->{$call_id};
         }
     }
@@ -649,22 +678,22 @@ sub _handle_event ($self, $outer_params) {
 
 # --- Internal: handle inbound call ---
 
-sub _handle_inbound_call ($self, $event, $params) {
+sub _handle_inbound_call ( $self, $event, $params ) {
     my $call_id = $params->{call_id} // '';
     return unless $call_id;
 
     my $call = SignalWire::Relay::Call->new(
         call_id => $call_id,
-        node_id => $params->{node_id} // '',
-        tag     => $params->{tag}     // '',
-        device  => $params->{device}  // {},
-        context => $params->{context} // '',
+        node_id => $params->{node_id}    // '',
+        tag     => $params->{tag}        // '',
+        device  => $params->{device}     // {},
+        context => $params->{context}    // '',
         state   => $params->{call_state} // 'ringing',
         _client => $self,
     );
     $self->_calls->{$call_id} = $call;
 
-    if (my $cb = $self->_on_call) {
+    if ( my $cb = $self->_on_call ) {
         eval { $cb->($call) };
         warn "on_call callback error: $@" if $@;
     }
@@ -672,8 +701,8 @@ sub _handle_inbound_call ($self, $event, $params) {
 
 # --- Internal: handle inbound message ---
 
-sub _handle_inbound_message ($self, $event) {
-    if (my $cb = $self->_on_message) {
+sub _handle_inbound_message ( $self, $event ) {
+    if ( my $cb = $self->_on_message ) {
         eval { $cb->($event) };
         warn "on_message callback error: $@" if $@;
     }
@@ -681,17 +710,17 @@ sub _handle_inbound_message ($self, $event) {
 
 # --- Internal: handle dial completion event ---
 
-sub _handle_dial_event ($self, $event, $params) {
-    my $tag = $params->{tag} // '';
+sub _handle_dial_event ( $self, $event, $params ) {
+    my $tag        = $params->{tag}        // '';
     my $dial_state = $params->{dial_state} // '';
-    my $call_info = $params->{call} // {};
+    my $call_info  = $params->{call}       // {};
 
     my $pending = $self->_pending_dials->{$tag};
     return unless $pending;
 
-    if ($dial_state eq DIAL_STATE_ANSWERED) {
+    if ( $dial_state eq DIAL_STATE_ANSWERED ) {
         my $call_id = $call_info->{call_id} // '';
-        my $call = $self->_calls->{$call_id};
+        my $call    = $self->_calls->{$call_id};
         unless ($call) {
             $call = SignalWire::Relay::Call->new(
                 call_id     => $call_id,
@@ -707,53 +736,55 @@ sub _handle_dial_event ($self, $event, $params) {
         $call->state('answered');
         $call->dial_winner(1);
         $pending->{resolve}->($call);
-    }
-    elsif ($dial_state eq DIAL_STATE_FAILED) {
+    } elsif ( $dial_state eq DIAL_STATE_FAILED ) {
         $pending->{reject}->("Dial failed");
     }
 }
 
 # --- Internal: handle server disconnect ---
 
-sub _handle_disconnect ($self, $params) {
+sub _handle_disconnect ( $self, $params ) {
     my $restart = $params->{restart} || 0;
 
     if ($restart) {
+
         # Clear session state, connect fresh
         $self->protocol('');
         $self->authorization_state('');
     }
 
     $self->connected(0);
+
     # The client should reconnect (handled by the event loop)
 }
 
 # --- Reconnection ---
 
 sub reconnect ($self) {
+
     # Reject all pending requests
-    for my $id (keys %{$self->_pending}) {
+    for my $id ( keys %{ $self->_pending } ) {
         my $p = delete $self->_pending->{$id};
         $p->{reject}->("Disconnected") if $p;
     }
 
     # Reject all pending dials
-    for my $tag (keys %{$self->_pending_dials}) {
+    for my $tag ( keys %{ $self->_pending_dials } ) {
         my $p = delete $self->_pending_dials->{$tag};
         $p->{reject}->("Disconnected") if $p;
     }
 
     # Exponential backoff: 1s, 2s, 4s, ... up to max_backoff
     my $attempts = $self->_reconnect_attempts;
-    my $delay = 2 ** $attempts;
+    my $delay    = 2**$attempts;
     $delay = $self->_max_backoff if $delay > $self->_max_backoff;
 
-    $logger->info("Reconnecting in ${delay}s (attempt " . ($attempts + 1) . ")");
-    select(undef, undef, undef, $delay);
+    $logger->info( "Reconnecting in ${delay}s (attempt " . ( $attempts + 1 ) . ")" );
+    select( undef, undef, undef, $delay );
 
-    $self->_reconnect_attempts($attempts + 1);
+    $self->_reconnect_attempts( $attempts + 1 );
 
-    if ($self->connect_ws) {
+    if ( $self->connect_ws ) {
         return $self->authenticate;
     }
 
@@ -764,8 +795,8 @@ sub reconnect ($self) {
 
 sub disconnect_ws ($self) {
     $self->connected(0);
-    if ($self->_socket) {
-        close($self->_socket);
+    if ( $self->_socket ) {
+        close( $self->_socket );
         $self->_socket(undef);
     }
     $self->_ws(undef);
@@ -774,7 +805,7 @@ sub disconnect_ws ($self) {
 # --- Run event loop ---
 
 sub run ($self) {
-    while ($self->connected) {
+    while ( $self->connected ) {
         $self->_read_once();
     }
 }

--- a/lib/SignalWire/Relay/Constants.pm
+++ b/lib/SignalWire/Relay/Constants.pm
@@ -17,9 +17,7 @@ our @EXPORT_OK = qw(
     ACTION_TERMINAL_STATES
 );
 
-our %EXPORT_TAGS = (
-    all => \@EXPORT_OK,
-);
+our %EXPORT_TAGS = ( all => \@EXPORT_OK, );
 
 # Protocol version for signalwire.connect
 use constant PROTOCOL_VERSION => { major => 2, minor => 0, revision => 0 };
@@ -32,25 +30,20 @@ use constant CALL_STATE_ENDING   => 'ending';
 use constant CALL_STATE_ENDED    => 'ended';
 
 use constant CALL_STATES => [
-    CALL_STATE_CREATED,
-    CALL_STATE_RINGING,
-    CALL_STATE_ANSWERED,
-    CALL_STATE_ENDING,
+    CALL_STATE_CREATED, CALL_STATE_RINGING, CALL_STATE_ANSWERED, CALL_STATE_ENDING,
     CALL_STATE_ENDED,
 ];
 
-use constant CALL_TERMINAL_STATES => {
-    (CALL_STATE_ENDED) => 1,
-};
+use constant CALL_TERMINAL_STATES => { (CALL_STATE_ENDED) => 1, };
 
 # --- Call End Reasons ---
 use constant CALL_END_REASONS => {
-    hangup    => 'hangup',
-    cancel    => 'cancel',
-    busy      => 'busy',
-    noAnswer  => 'noAnswer',
-    decline   => 'decline',
-    error     => 'error',
+    hangup   => 'hangup',
+    cancel   => 'cancel',
+    busy     => 'busy',
+    noAnswer => 'noAnswer',
+    decline  => 'decline',
+    error    => 'error',
 };
 
 # --- Dial States ---
@@ -58,11 +51,7 @@ use constant DIAL_STATE_DIALING  => 'dialing';
 use constant DIAL_STATE_ANSWERED => 'answered';
 use constant DIAL_STATE_FAILED   => 'failed';
 
-use constant DIAL_STATES => [
-    DIAL_STATE_DIALING,
-    DIAL_STATE_ANSWERED,
-    DIAL_STATE_FAILED,
-];
+use constant DIAL_STATES => [ DIAL_STATE_DIALING, DIAL_STATE_ANSWERED, DIAL_STATE_FAILED, ];
 
 # A dial completes when it is answered (success) or failed (failure);
 # 'dialing' is the in-progress, non-terminal state. This matches the
@@ -83,12 +72,9 @@ use constant MESSAGE_STATE_FAILED      => 'failed';
 use constant MESSAGE_STATE_RECEIVED    => 'received';
 
 use constant MESSAGE_STATES => [
-    MESSAGE_STATE_QUEUED,
-    MESSAGE_STATE_INITIATED,
-    MESSAGE_STATE_SENT,
-    MESSAGE_STATE_DELIVERED,
-    MESSAGE_STATE_UNDELIVERED,
-    MESSAGE_STATE_FAILED,
+    MESSAGE_STATE_QUEUED,      MESSAGE_STATE_INITIATED,
+    MESSAGE_STATE_SENT,        MESSAGE_STATE_DELIVERED,
+    MESSAGE_STATE_UNDELIVERED, MESSAGE_STATE_FAILED,
     MESSAGE_STATE_RECEIVED,
 ];
 
@@ -100,35 +86,36 @@ use constant MESSAGE_TERMINAL_STATES => {
 
 # --- Event Types ---
 use constant EVENT_TYPES => {
+
     # Call state events
-    'calling.call.state'            => 'CallState',
-    'calling.call.receive'          => 'CallReceive',
-    'calling.call.dial'             => 'CallDial',
-    'calling.call.connect'          => 'CallConnect',
-    'calling.call.disconnect'       => 'CallDisconnect',
+    'calling.call.state'      => 'CallState',
+    'calling.call.receive'    => 'CallReceive',
+    'calling.call.dial'       => 'CallDial',
+    'calling.call.connect'    => 'CallConnect',
+    'calling.call.disconnect' => 'CallDisconnect',
 
     # Action events
-    'calling.call.play'             => 'CallPlay',
-    'calling.call.record'           => 'CallRecord',
-    'calling.call.collect'          => 'CallCollect',
-    'calling.call.detect'           => 'CallDetect',
-    'calling.call.fax'              => 'CallFax',
-    'calling.call.tap'              => 'CallTap',
-    'calling.call.stream'           => 'CallStream',
-    'calling.call.transcribe'       => 'CallTranscribe',
-    'calling.call.pay'              => 'CallPay',
-    'calling.call.send_digits'      => 'CallSendDigits',
-    'calling.call.refer'            => 'CallRefer',
+    'calling.call.play'        => 'CallPlay',
+    'calling.call.record'      => 'CallRecord',
+    'calling.call.collect'     => 'CallCollect',
+    'calling.call.detect'      => 'CallDetect',
+    'calling.call.fax'         => 'CallFax',
+    'calling.call.tap'         => 'CallTap',
+    'calling.call.stream'      => 'CallStream',
+    'calling.call.transcribe'  => 'CallTranscribe',
+    'calling.call.pay'         => 'CallPay',
+    'calling.call.send_digits' => 'CallSendDigits',
+    'calling.call.refer'       => 'CallRefer',
 
     # Conference events
-    'calling.conference'            => 'Conference',
+    'calling.conference' => 'Conference',
 
     # AI events
-    'calling.call.ai'               => 'CallAI',
+    'calling.call.ai' => 'CallAI',
 
     # Messaging events
-    'messaging.receive'             => 'MessageReceive',
-    'messaging.state'               => 'MessageState',
+    'messaging.receive' => 'MessageReceive',
+    'messaging.state'   => 'MessageState',
 
     # System events
     'signalwire.authorization.state' => 'AuthorizationState',
@@ -137,11 +124,11 @@ use constant EVENT_TYPES => {
 
 # --- Action Terminal States (per event type) ---
 use constant ACTION_TERMINAL_STATES => {
-    'calling.call.play'       => { finished => 1, error => 1 },
+    'calling.call.play'       => { finished => 1, error    => 1 },
     'calling.call.record'     => { finished => 1, no_input => 1 },
-    'calling.call.detect'     => { finished => 1, error => 1 },
-    'calling.call.collect'    => { finished => 1, error => 1, no_input => 1, no_match => 1 },
-    'calling.call.fax'        => { finished => 1, error => 1 },
+    'calling.call.detect'     => { finished => 1, error    => 1 },
+    'calling.call.collect'    => { finished => 1, error    => 1, no_input => 1, no_match => 1 },
+    'calling.call.fax'        => { finished => 1, error    => 1 },
     'calling.call.tap'        => { finished => 1 },
     'calling.call.stream'     => { finished => 1 },
     'calling.call.transcribe' => { finished => 1 },

--- a/lib/SignalWire/Relay/Device.pm
+++ b/lib/SignalWire/Relay/Device.pm
@@ -2,6 +2,7 @@ package SignalWire::Relay::Device;
 use strict;
 use warnings;
 use Moo;
+
 # Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
 use Carp ();
@@ -56,10 +57,10 @@ my $HashRef = sub {
 # passed through untouched so the `isa` constraint below rejects it cleanly.
 my $CopyHash = sub {
     my ($v) = @_;
-    return ref $v eq 'HASH' ? { %$v } : $v;
+    return ref $v eq 'HASH' ? {%$v} : $v;
 };
 
-has 'type'   => ( is => 'ro', required => 1, isa => $NonEmptyStr );
+has 'type' => ( is => 'ro', required => 1, isa => $NonEmptyStr );
 has 'params' => (
     is      => 'ro',
     default => sub { {} },

--- a/lib/SignalWire/Relay/DialState.pm
+++ b/lib/SignalWire/Relay/DialState.pm
@@ -1,4 +1,5 @@
 package SignalWire::Relay::DialState;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -63,7 +64,7 @@ use constant {
     FAILED   => 'failed',
 };
 
-our @EXPORT_OK = qw( DIALING ANSWERED FAILED );
+our @EXPORT_OK   = qw( DIALING ANSWERED FAILED );
 our %EXPORT_TAGS = ( all => [@EXPORT_OK] );
 
 # Canonical ordered set, single-sourced from Relay::Constants.
@@ -83,7 +84,7 @@ sub states {
 # DialState->is_state($value) — true if $value is a known dial state.
 # Returns false (never dies) on undef or an unknown/forward-compat value.
 sub is_state {
-    my ($class, $value) = @_;
+    my ( $class, $value ) = @_;
     return 0 unless defined $value;
     return exists $IS_STATE{$value} ? 1 : 0;
 }
@@ -93,7 +94,7 @@ sub is_state {
 # in-progress 'dialing' state, or an unknown/forward-compat value — it
 # never dies.
 sub is_terminal {
-    my ($class, $value) = @_;
+    my ( $class, $value ) = @_;
     return 0 unless defined $value;
     return $IS_TERMINAL{$value} ? 1 : 0;
 }

--- a/lib/SignalWire/Relay/Event.pm
+++ b/lib/SignalWire/Relay/Event.pm
@@ -2,6 +2,7 @@ package SignalWire::Relay::Event;
 use strict;
 use warnings;
 use Moo;
+
 # Subroutine signatures (stable since Perl 5.36, the SDK's floor), enabled
 # file-wide.
 use feature 'signatures';
@@ -161,8 +162,8 @@ has 'state'      => ( is => 'ro', default => sub { '' } );
 package SignalWire::Relay::Event::CallRefer;
 use Moo;
 extends 'SignalWire::Relay::Event';
-has 'call_id'    => ( is => 'ro', default => sub { '' } );
-has 'node_id'    => ( is => 'ro', default => sub { '' } );
+has 'call_id'     => ( is => 'ro', default => sub { '' } );
+has 'node_id'     => ( is => 'ro', default => sub { '' } );
 has 'refer_state' => ( is => 'ro', default => sub { '' } );
 
 # Conference event
@@ -253,11 +254,12 @@ my %EVENT_CLASS_MAP = (
     'signalwire.disconnect'          => 'SignalWire::Relay::Event::Disconnect',
 );
 
-sub parse_event ($class_or_self, $event_type, $params = undef) {
+sub parse_event ( $class_or_self, $event_type, $params = undef ) {
     $params //= {};
 
     my $event_class = $EVENT_CLASS_MAP{$event_type};
     unless ($event_class) {
+
         # Return base event for unknown types
         return SignalWire::Relay::Event->new(
             event_type => $event_type,
@@ -272,7 +274,8 @@ sub parse_event ($class_or_self, $event_type, $params = undef) {
     );
 
     # Copy known fields from params into top-level attributes
-    for my $key (keys %$params) {
+    for my $key ( keys %$params ) {
+
         # Moo will silently ignore unknown attrs, so we just pass everything
         $args{$key} = $params->{$key};
     }

--- a/lib/SignalWire/Relay/Message.pm
+++ b/lib/SignalWire/Relay/Message.pm
@@ -7,6 +7,7 @@ use Moo;
 use feature 'signatures';
 use Scalar::Util ();
 use Carp         ();
+use Time::HiRes  ();
 
 use SignalWire::Relay::Constants    qw(MESSAGE_TERMINAL_STATES);
 use SignalWire::Relay::MessageState ();
@@ -104,7 +105,7 @@ sub wait ( $self, %opts ) {
     my $timeout = $opts{timeout} || 30;
     my $start   = time();
     while ( !$self->completed && ( time() - $start ) < $timeout ) {
-        select( undef, undef, undef, 0.1 );
+        Time::HiRes::sleep(0.1);
     }
     return $self->result;
 }

--- a/lib/SignalWire/Relay/Message.pm
+++ b/lib/SignalWire/Relay/Message.pm
@@ -134,6 +134,7 @@ sub dispatch_event ( $self, $event ) {
             warn "Message on_completed callback error: $@" if $@;
         }
     }
+    return;
 }
 
 1;

--- a/lib/SignalWire/Relay/Message.pm
+++ b/lib/SignalWire/Relay/Message.pm
@@ -2,12 +2,13 @@ package SignalWire::Relay::Message;
 use strict;
 use warnings;
 use Moo;
+
 # Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
 use Scalar::Util ();
-use Carp ();
+use Carp         ();
 
-use SignalWire::Relay::Constants qw(MESSAGE_TERMINAL_STATES);
+use SignalWire::Relay::Constants    qw(MESSAGE_TERMINAL_STATES);
 use SignalWire::Relay::MessageState ();
 
 # --- isa constraint helpers (coderefs; no extra deps). Each dies on a
@@ -19,7 +20,7 @@ my $NonEmptyStr = sub {
 };
 my $Num = sub {
     Carp::croak("must be a number")
-        unless defined $_[0] && !ref $_[0] && Scalar::Util::looks_like_number($_[0]);
+        unless defined $_[0] && !ref $_[0] && Scalar::Util::looks_like_number( $_[0] );
 };
 my $ArrayRef = sub {
     Carp::croak("must be an arrayref") unless ref $_[0] eq 'ARRAY';
@@ -29,22 +30,22 @@ my $CodeRef = sub {
 };
 
 has 'message_id'  => ( is => 'ro', required => 1, isa => $NonEmptyStr );
-has 'context'     => ( is => 'rw', default => sub { '' } );
-has 'direction'   => ( is => 'rw', default => sub { '' } );
-has 'from_number' => ( is => 'rw', default => sub { '' } );
-has 'to_number'   => ( is => 'rw', default => sub { '' } );
-has 'body'        => ( is => 'rw', default => sub { '' } );
-has 'media'       => ( is => 'rw', default => sub { [] }, isa => $ArrayRef );
-has 'segments'    => ( is => 'rw', default => sub { 0 }, isa => $Num );
-has 'state'       => ( is => 'rw', default => sub { '' } );
-has 'reason'      => ( is => 'rw', default => sub { '' } );
-has 'tags'        => ( is => 'rw', default => sub { [] }, isa => $ArrayRef );
+has 'context'     => ( is => 'rw', default  => sub { '' } );
+has 'direction'   => ( is => 'rw', default  => sub { '' } );
+has 'from_number' => ( is => 'rw', default  => sub { '' } );
+has 'to_number'   => ( is => 'rw', default  => sub { '' } );
+has 'body'        => ( is => 'rw', default  => sub { '' } );
+has 'media'       => ( is => 'rw', default  => sub { [] }, isa => $ArrayRef );
+has 'segments'    => ( is => 'rw', default  => sub { 0 }, isa => $Num );
+has 'state'       => ( is => 'rw', default  => sub { '' } );
+has 'reason'      => ( is => 'rw', default  => sub { '' } );
+has 'tags'        => ( is => 'rw', default  => sub { [] }, isa => $ArrayRef );
 
 has 'completed' => ( is => 'rw', default => sub { 0 } );
 has 'result'    => ( is => 'rw', default => sub { undef } );
 
 has '_on_completed' => ( is => 'rw', default => sub { undef } );
-has '_on_event'     => ( is => 'rw', default => sub { [] }, isa => $ArrayRef );
+has '_on_event' => ( is => 'rw', default => sub { [] }, isa => $ArrayRef );
 
 # Check if message has reached a terminal state
 sub is_done ($self) {
@@ -74,15 +75,15 @@ sub current_state ($self) {
 # by dispatch_event, whereas is_terminal classifies the current `state`
 # string itself via the MessageState vocabulary.
 sub is_terminal ($self) {
-    return SignalWire::Relay::MessageState->is_terminal($self->state);
+    return SignalWire::Relay::MessageState->is_terminal( $self->state );
 }
 
 # Register on_completed callback
-sub on_completed ($self, $cb = undef) {
+sub on_completed ( $self, $cb = undef ) {
     if ($cb) {
         $CodeRef->($cb);
         $self->_on_completed($cb);
-        if ($self->completed) {
+        if ( $self->completed ) {
             eval { $cb->($self) };
             warn "Message on_completed callback error: $@" if $@;
         }
@@ -92,42 +93,42 @@ sub on_completed ($self, $cb = undef) {
 }
 
 # Register event listener
-sub on ($self, $cb) {
+sub on ( $self, $cb ) {
     $CodeRef->($cb);
-    push @{$self->_on_event}, $cb;
+    push @{ $self->_on_event }, $cb;
     return $self;
 }
 
 # Blocking wait
-sub wait ($self, %opts) {
+sub wait ( $self, %opts ) {
     my $timeout = $opts{timeout} || 30;
-    my $start = time();
-    while (!$self->completed && (time() - $start) < $timeout) {
-        select(undef, undef, undef, 0.1);
+    my $start   = time();
+    while ( !$self->completed && ( time() - $start ) < $timeout ) {
+        select( undef, undef, undef, 0.1 );
     }
     return $self->result;
 }
 
 # Handle a messaging.state event
-sub dispatch_event ($self, $event) {
+sub dispatch_event ( $self, $event ) {
 
     my $message_state = $event->can('message_state') ? $event->message_state : '';
     $self->state($message_state) if $message_state;
 
     # Update fields from event
-    $self->reason($event->reason) if $event->can('reason') && $event->reason;
+    $self->reason( $event->reason ) if $event->can('reason') && $event->reason;
 
     # Fire event callbacks
-    for my $cb (@{$self->_on_event}) {
-        eval { $cb->($self, $event) };
+    for my $cb ( @{ $self->_on_event } ) {
+        eval { $cb->( $self, $event ) };
         warn "Message event callback error: $@" if $@;
     }
 
     # Check for terminal state
-    if (MESSAGE_TERMINAL_STATES->{$message_state}) {
+    if ( MESSAGE_TERMINAL_STATES->{$message_state} ) {
         $self->completed(1);
         $self->result($event);
-        if (my $cb = $self->_on_completed) {
+        if ( my $cb = $self->_on_completed ) {
             eval { $cb->($self) };
             warn "Message on_completed callback error: $@" if $@;
         }

--- a/lib/SignalWire/Relay/MessageState.pm
+++ b/lib/SignalWire/Relay/MessageState.pm
@@ -1,4 +1,5 @@
 package SignalWire::Relay::MessageState;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -86,7 +87,7 @@ sub states {
 # MessageState->is_state($value) — true if $value is a known message state.
 # Returns false (never dies) on undef or an unknown/forward-compat value.
 sub is_state {
-    my ($class, $value) = @_;
+    my ( $class, $value ) = @_;
     return 0 unless defined $value;
     return exists $IS_STATE{$value} ? 1 : 0;
 }
@@ -96,7 +97,7 @@ sub is_state {
 # in-flight state (queued/initiated/sent) or 'received', or an
 # unknown/forward-compat value — it never dies.
 sub is_terminal {
-    my ($class, $value) = @_;
+    my ( $class, $value ) = @_;
     return 0 unless defined $value;
     return $IS_TERMINAL{$value} ? 1 : 0;
 }

--- a/lib/SignalWire/SWAIG/FunctionResult.pm
+++ b/lib/SignalWire/SWAIG/FunctionResult.pm
@@ -2,6 +2,7 @@ package SignalWire::SWAIG::FunctionResult;
 use strict;
 use warnings;
 use Moo;
+
 # Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
 use JSON ();
@@ -31,10 +32,10 @@ has 'post_process' => (
 sub _py_truthy {
     my ($v) = @_;
     return 0 unless defined $v;
-    if (ref $v eq 'HASH') {
-        return scalar(keys %$v) ? 1 : 0;
+    if ( ref $v eq 'HASH' ) {
+        return scalar( keys %$v ) ? 1 : 0;
     }
-    if (ref $v eq 'ARRAY') {
+    if ( ref $v eq 'ARRAY' ) {
         return scalar(@$v) ? 1 : 0;
     }
     return $v ? 1 : 0;
@@ -42,42 +43,42 @@ sub _py_truthy {
 
 # Constructor: new(response => "text") or new("text") or new("text", post_process => 1)
 around BUILDARGS => sub {
-    my ($orig, $class, @args) = @_;
-    if (@args == 1 && !ref $args[0]) {
-        return $class->$orig(response => $args[0]);
+    my ( $orig, $class, @args ) = @_;
+    if ( @args == 1 && !ref $args[0] ) {
+        return $class->$orig( response => $args[0] );
     }
-    if (@args >= 1 && !ref $args[0] && $args[0] !~ /^(response|action|post_process)$/) {
+    if ( @args >= 1 && !ref $args[0] && $args[0] !~ /^(response|action|post_process)$/ ) {
         my $resp = shift @args;
-        return $class->$orig(response => $resp, @args);
+        return $class->$orig( response => $resp, @args );
     }
     return $class->$orig(@args);
 };
 
 # --- Core methods ---
 
-sub set_response ($self, $response) {
+sub set_response ( $self, $response ) {
     $self->response($response);
     return $self;
 }
 
-sub set_post_process ($self, $post_process) {
-    $self->post_process($post_process ? 1 : 0);
+sub set_post_process ( $self, $post_process ) {
+    $self->post_process( $post_process ? 1 : 0 );
     return $self;
 }
 
-sub add_action ($self, $name, $data) {
+sub add_action ( $self, $name, $data ) {
     push @{ $self->action }, { $name => $data };
     return $self;
 }
 
-sub add_actions ($self, $actions) {
+sub add_actions ( $self, $actions ) {
     push @{ $self->action }, @$actions;
     return $self;
 }
 
 # --- Call Control ---
 
-sub connect ($self, $destination, %opts) {
+sub connect ( $self, $destination, %opts ) {
     my $final = exists $opts{final} ? $opts{final} : 1;
     my $from  = $opts{from};
 
@@ -87,7 +88,7 @@ sub connect ($self, $destination, %opts) {
     my $swml_action = {
         SWML => {
             sections => {
-                main => [{ connect => $connect_params }],
+                main => [ { connect => $connect_params } ],
             },
             version => '1.0.0',
         },
@@ -98,7 +99,7 @@ sub connect ($self, $destination, %opts) {
     return $self;
 }
 
-sub swml_transfer ($self, $dest, $ai_response, %opts) {
+sub swml_transfer ( $self, $dest, $ai_response, %opts ) {
     my $final = exists $opts{final} ? $opts{final} : 1;
 
     my $swml_action = {
@@ -119,17 +120,17 @@ sub swml_transfer ($self, $dest, $ai_response, %opts) {
 }
 
 sub hangup ($self) {
-    return $self->add_action('hangup', JSON::true);
+    return $self->add_action( 'hangup', JSON::true );
 }
 
-sub hold ($self, $timeout = undef) {
+sub hold ( $self, $timeout = undef ) {
     $timeout //= 300;
     $timeout = 0   if $timeout < 0;
     $timeout = 900 if $timeout > 900;
-    return $self->add_action('hold', $timeout);
+    return $self->add_action( 'hold', $timeout );
 }
 
-sub wait_for_user ($self, %opts) {
+sub wait_for_user ( $self, %opts ) {
     my $enabled      = $opts{enabled};
     my $timeout      = $opts{timeout};
     my $answer_first = $opts{answer_first};
@@ -137,66 +138,68 @@ sub wait_for_user ($self, %opts) {
     my $value;
     if ($answer_first) {
         $value = 'answer_first';
-    } elsif (defined $timeout) {
+    } elsif ( defined $timeout ) {
         $value = $timeout;
-    } elsif (defined $enabled) {
+    } elsif ( defined $enabled ) {
         $value = $enabled ? JSON::true : JSON::false;
     } else {
         $value = JSON::true;
     }
-    return $self->add_action('wait_for_user', $value);
+    return $self->add_action( 'wait_for_user', $value );
 }
 
 sub stop ($self) {
-    return $self->add_action('stop', JSON::true);
+    return $self->add_action( 'stop', JSON::true );
 }
 
 # --- State & Data ---
 
-sub update_global_data ($self, $data) {
-    return $self->add_action('set_global_data', $data);
+sub update_global_data ( $self, $data ) {
+    return $self->add_action( 'set_global_data', $data );
 }
 
-sub remove_global_data ($self, $keys) {
-    return $self->add_action('unset_global_data', $keys);
+sub remove_global_data ( $self, $keys ) {
+    return $self->add_action( 'unset_global_data', $keys );
 }
 
-sub set_metadata ($self, $data) {
-    return $self->add_action('set_meta_data', $data);
+sub set_metadata ( $self, $data ) {
+    return $self->add_action( 'set_meta_data', $data );
 }
 
-sub remove_metadata ($self, $keys) {
-    return $self->add_action('unset_meta_data', $keys);
+sub remove_metadata ( $self, $keys ) {
+    return $self->add_action( 'unset_meta_data', $keys );
 }
 
-sub swml_user_event ($self, $event_data) {
+sub swml_user_event ( $self, $event_data ) {
     my $swml_action = {
         sections => {
-            main => [{
-                user_event => { event => $event_data },
-            }],
+            main => [
+                {
+                    user_event => { event => $event_data },
+                }
+            ],
         },
         version => '1.0.0',
     };
-    return $self->add_action('SWML', $swml_action);
+    return $self->add_action( 'SWML', $swml_action );
 }
 
-sub swml_change_step ($self, $step_name) {
-    return $self->add_action('change_step', $step_name);
+sub swml_change_step ( $self, $step_name ) {
+    return $self->add_action( 'change_step', $step_name );
 }
 
-sub swml_change_context ($self, $context_name) {
-    return $self->add_action('change_context', $context_name);
+sub swml_change_context ( $self, $context_name ) {
+    return $self->add_action( 'change_context', $context_name );
 }
 
-sub switch_context ($self, %opts) {
+sub switch_context ( $self, %opts ) {
     my $system_prompt = $opts{system_prompt};
     my $user_prompt   = $opts{user_prompt};
     my $consolidate   = $opts{consolidate};
     my $full_reset    = $opts{full_reset};
 
-    if ($system_prompt && !$user_prompt && !$consolidate && !$full_reset) {
-        return $self->add_action('context_switch', $system_prompt);
+    if ( $system_prompt && !$user_prompt && !$consolidate && !$full_reset ) {
+        return $self->add_action( 'context_switch', $system_prompt );
     }
 
     my %ctx;
@@ -204,47 +207,49 @@ sub switch_context ($self, %opts) {
     $ctx{user_prompt}   = $user_prompt   if $user_prompt;
     $ctx{consolidate}   = JSON::true     if $consolidate;
     $ctx{full_reset}    = JSON::true     if $full_reset;
-    return $self->add_action('context_switch', \%ctx);
+    return $self->add_action( 'context_switch', \%ctx );
 }
 
-sub replace_in_history ($self, $text = undef) {
+sub replace_in_history ( $self, $text = undef ) {
     $text //= JSON::true;
-    return $self->add_action('replace_in_history', $text);
+    return $self->add_action( 'replace_in_history', $text );
 }
 
 # --- Media ---
 
-sub say ($self, $text) {
-    return $self->add_action('say', $text);
+sub say ( $self, $text ) {
+    return $self->add_action( 'say', $text );
 }
 
-sub play_background_file ($self, $filename, %opts) {
+sub play_background_file ( $self, $filename, %opts ) {
     my $wait = $opts{wait};
     if ($wait) {
-        return $self->add_action('playback_bg', { file => $filename, wait => JSON::true });
+        return $self->add_action( 'playback_bg', { file => $filename, wait => JSON::true } );
     }
-    return $self->add_action('playback_bg', $filename);
+    return $self->add_action( 'playback_bg', $filename );
 }
 
 sub stop_background_file ($self) {
-    return $self->add_action('stop_playback_bg', JSON::true);
+    return $self->add_action( 'stop_playback_bg', JSON::true );
 }
 
-sub record_call ($self, %opts) {
+sub record_call ( $self, %opts ) {
+
     # Defaults mirror the Python reference's argument defaults.
     my $control_id          = $opts{control_id};
-    my $stereo              = $opts{stereo}            // 0;
-    my $format              = $opts{format}            // 'wav';
-    my $direction           = $opts{direction}         // 'both';
+    my $stereo              = $opts{stereo}    // 0;
+    my $format              = $opts{format}    // 'wav';
+    my $direction           = $opts{direction} // 'both';
     my $terminators         = $opts{terminators};
-    my $beep                = $opts{beep}              // 0;
+    my $beep                = $opts{beep} // 0;
     my $input_sensitivity   = exists $opts{input_sensitivity} ? $opts{input_sensitivity} : 44.0;
     my $initial_timeout     = $opts{initial_timeout};
     my $end_silence_timeout = $opts{end_silence_timeout};
     my $max_length          = $opts{max_length};
     my $status_url          = $opts{status_url};
 
-    die "format must be 'wav', 'mp3', or 'mp4'" unless $format eq 'wav' || $format eq 'mp3' || $format eq 'mp4';
+    die "format must be 'wav', 'mp3', or 'mp4'"
+        unless $format eq 'wav' || $format eq 'mp3' || $format eq 'mp4';
     die "direction must be 'speak', 'listen', or 'both'"
         unless $direction eq 'speak' || $direction eq 'listen' || $direction eq 'both';
 
@@ -264,36 +269,36 @@ sub record_call ($self, %opts) {
     # Conditional keys. control_id/terminators/status_url use Python's
     # truthiness gate (`if x:`); the three numeric timeouts use the
     # `is not None` gate, so a literal 0 still emits — `defined` mirrors that.
-    $params{control_id}          = $control_id          if $control_id;
-    $params{terminators}         = $terminators         if $terminators;
+    $params{control_id}          = $control_id              if $control_id;
+    $params{terminators}         = $terminators             if $terminators;
     $params{initial_timeout}     = $initial_timeout + 0     if defined $initial_timeout;
     $params{end_silence_timeout} = $end_silence_timeout + 0 if defined $end_silence_timeout;
     $params{max_length}          = $max_length + 0          if defined $max_length;
-    $params{status_url}          = $status_url          if $status_url;
+    $params{status_url}          = $status_url              if $status_url;
 
     my $swml_doc = {
         version  => '1.0.0',
-        sections => { main => [{ record_call => \%params }] },
+        sections => { main => [ { record_call => \%params } ] },
     };
     return $self->execute_swml($swml_doc);
 }
 
-sub stop_record_call ($self, %opts) {
+sub stop_record_call ( $self, %opts ) {
     my $control_id = $opts{control_id};
     my %params;
     $params{control_id} = $control_id if $control_id;
 
     my $swml_doc = {
         version  => '1.0.0',
-        sections => { main => [{ stop_record_call => \%params }] },
+        sections => { main => [ { stop_record_call => \%params } ] },
     };
     return $self->execute_swml($swml_doc);
 }
 
 # --- Speech & AI ---
 
-sub add_dynamic_hints ($self, $hints) {
-    return $self->add_action('add_dynamic_hints', $hints);
+sub add_dynamic_hints ( $self, $hints ) {
+    return $self->add_action( 'add_dynamic_hints', $hints );
 }
 
 sub clear_dynamic_hints ($self) {
@@ -301,46 +306,46 @@ sub clear_dynamic_hints ($self) {
     return $self;
 }
 
-sub set_end_of_speech_timeout ($self, $ms) {
-    return $self->add_action('end_of_speech_timeout', $ms);
+sub set_end_of_speech_timeout ( $self, $ms ) {
+    return $self->add_action( 'end_of_speech_timeout', $ms );
 }
 
-sub set_speech_event_timeout ($self, $ms) {
-    return $self->add_action('speech_event_timeout', $ms);
+sub set_speech_event_timeout ( $self, $ms ) {
+    return $self->add_action( 'speech_event_timeout', $ms );
 }
 
-sub toggle_functions ($self, $toggles) {
-    return $self->add_action('toggle_functions', $toggles);
+sub toggle_functions ( $self, $toggles ) {
+    return $self->add_action( 'toggle_functions', $toggles );
 }
 
-sub enable_functions_on_timeout ($self, $enabled = undef) {
+sub enable_functions_on_timeout ( $self, $enabled = undef ) {
     $enabled //= 1;
-    return $self->add_action('functions_on_speaker_timeout', $enabled ? JSON::true : JSON::false);
+    return $self->add_action( 'functions_on_speaker_timeout', $enabled ? JSON::true : JSON::false );
 }
 
-sub enable_extensive_data ($self, $enabled = undef) {
+sub enable_extensive_data ( $self, $enabled = undef ) {
     $enabled //= 1;
-    return $self->add_action('extensive_data', $enabled ? JSON::true : JSON::false);
+    return $self->add_action( 'extensive_data', $enabled ? JSON::true : JSON::false );
 }
 
-sub update_settings ($self, $settings) {
-    return $self->add_action('settings', $settings);
+sub update_settings ( $self, $settings ) {
+    return $self->add_action( 'settings', $settings );
 }
 
 # --- Advanced ---
 
-sub execute_swml ($self, $swml_content, %opts) {
+sub execute_swml ( $self, $swml_content, %opts ) {
     my $transfer = $opts{transfer} // 0;
 
     my $swml_data;
-    if (ref $swml_content eq 'HASH') {
+    if ( ref $swml_content eq 'HASH' ) {
+
         # Deep-copy to avoid mutating caller's data
-        $swml_data = JSON::decode_json(JSON::encode_json($swml_content));
-    } elsif (!ref $swml_content) {
+        $swml_data = JSON::decode_json( JSON::encode_json($swml_content) );
+    } elsif ( !ref $swml_content ) {
+
         # String - try parsing as JSON
-        eval {
-            $swml_data = JSON::decode_json($swml_content);
-        };
+        eval { $swml_data = JSON::decode_json($swml_content); };
         if ($@) {
             $swml_data = { raw_swml => $swml_content };
         }
@@ -352,7 +357,7 @@ sub execute_swml ($self, $swml_content, %opts) {
         $swml_data->{transfer} = 'true';
     }
 
-    return $self->add_action('SWML', $swml_data);
+    return $self->add_action( 'SWML', $swml_data );
 }
 
 # join_conference — join an ad-hoc audio conference (RELAY + CXML) via
@@ -365,21 +370,22 @@ sub execute_swml ($self, $swml_content, %opts) {
 # (BEEP/RECORD/TRIM/METHOD), but the `die` guards here are the single
 # source of truth at runtime — they reproduce Python's f-string list
 # rendering ("beep must be one of ['true', 'false', 'onEnter', 'onExit']").
-sub join_conference ($self, $name, %opts) {
+sub join_conference ( $self, $name, %opts ) {
+
     # Defaults — exactly the Python reference's argument defaults.
-    my $muted                            = $opts{muted}                            // 0;
-    my $beep                             = $opts{beep}                             // 'true';
+    my $muted                            = $opts{muted} // 0;
+    my $beep                             = $opts{beep}  // 'true';
     my $start_on_enter                   = exists $opts{start_on_enter} ? $opts{start_on_enter} : 1;
-    my $end_on_exit                      = $opts{end_on_exit}                      // 0;
+    my $end_on_exit                      = $opts{end_on_exit} // 0;
     my $wait_url                         = $opts{wait_url};
-    my $max_participants                 = $opts{max_participants}                 // 250;
-    my $record                           = $opts{record}                           // 'do-not-record';
+    my $max_participants                 = $opts{max_participants} // 250;
+    my $record                           = $opts{record}           // 'do-not-record';
     my $region                           = $opts{region};
-    my $trim                             = $opts{trim}                             // 'trim-silence';
+    my $trim                             = $opts{trim} // 'trim-silence';
     my $coach                            = $opts{coach};
     my $status_callback_event            = $opts{status_callback_event};
     my $status_callback                  = $opts{status_callback};
-    my $status_callback_method           = $opts{status_callback_method}           // 'POST';
+    my $status_callback_method           = $opts{status_callback_method} // 'POST';
     my $recording_status_callback        = $opts{recording_status_callback};
     my $recording_status_callback_method = $opts{recording_status_callback_method} // 'POST';
     my $recording_status_callback_event  = $opts{recording_status_callback_event}  // 'completed';
@@ -389,8 +395,10 @@ sub join_conference ($self, $name, %opts) {
 
     # beep ∈ {true, false, onEnter, onExit}
     die "beep must be one of ['true', 'false', 'onEnter', 'onExit']"
-        unless $beep eq 'true' || $beep eq 'false'
-            || $beep eq 'onEnter' || $beep eq 'onExit';
+        unless $beep eq 'true'
+        || $beep eq 'false'
+        || $beep eq 'onEnter'
+        || $beep eq 'onExit';
 
     # 0 < max_participants <= 250
     die "max_participants must be a positive integer <= 250"
@@ -411,7 +419,7 @@ sub join_conference ($self, $name, %opts) {
     # recording_status_callback_method ∈ {GET, POST}
     die "recording_status_callback_method must be one of ['GET', 'POST']"
         unless $recording_status_callback_method eq 'GET'
-            || $recording_status_callback_method eq 'POST';
+        || $recording_status_callback_method eq 'POST';
 
     # name not empty after trimming whitespace
     my $trimmed = defined $name ? $name : '';
@@ -422,7 +430,7 @@ sub join_conference ($self, $name, %opts) {
     # --- Build the join_conference payload ---
 
     my $join_params;
-    if (   !$muted
+    if (  !$muted
         && $beep eq 'true'
         && $start_on_enter
         && !$end_on_exit
@@ -438,62 +446,69 @@ sub join_conference ($self, $name, %opts) {
         && !defined $recording_status_callback
         && $recording_status_callback_method eq 'POST'
         && $recording_status_callback_event eq 'completed'
-        && !defined $result)
+        && !defined $result )
     {
         # Simple form — just the conference name as a bare string.
         $join_params = $name;
-    }
-    else {
+    } else {
+
         # Full-object form: name + every NON-DEFAULT param under its
         # snake_case wire key. Each key is emitted only when ≠ default.
-        $join_params = { name => $name };
-        $join_params->{muted}                            = JSON::true        if $muted;
-        $join_params->{beep}                             = $beep             if $beep ne 'true';
-        $join_params->{start_on_enter}                   = JSON::false       if !$start_on_enter;
-        $join_params->{end_on_exit}                      = JSON::true        if $end_on_exit;
+        $join_params                   = { name => $name };
+        $join_params->{muted}          = JSON::true  if $muted;
+        $join_params->{beep}           = $beep       if $beep ne 'true';
+        $join_params->{start_on_enter} = JSON::false if !$start_on_enter;
+        $join_params->{end_on_exit}    = JSON::true  if $end_on_exit;
+
         # The six Optional[str] params use Python's truthiness emission
         # gate (`if wait_url:`), i.e. omit when undef OR empty string,
         # while emitting the literal "0" (Python treats "" / None as falsy
         # but "0" as truthy for str). `defined && length` reproduces that.
-        $join_params->{wait_url}                         = $wait_url         if defined $wait_url && length $wait_url;
-        $join_params->{max_participants}                 = $max_participants if $max_participants != 250;
-        $join_params->{record}                           = $record           if $record ne 'do-not-record';
-        $join_params->{region}                           = $region           if defined $region && length $region;
-        $join_params->{trim}                             = $trim             if $trim ne 'trim-silence';
-        $join_params->{coach}                            = $coach            if defined $coach && length $coach;
-        $join_params->{status_callback_event}            = $status_callback_event            if defined $status_callback_event && length $status_callback_event;
-        $join_params->{status_callback}                  = $status_callback                  if defined $status_callback && length $status_callback;
-        $join_params->{status_callback_method}           = $status_callback_method           if $status_callback_method ne 'POST';
-        $join_params->{recording_status_callback}        = $recording_status_callback        if defined $recording_status_callback && length $recording_status_callback;
-        $join_params->{recording_status_callback_method} = $recording_status_callback_method if $recording_status_callback_method ne 'POST';
-        $join_params->{recording_status_callback_event}  = $recording_status_callback_event  if $recording_status_callback_event ne 'completed';
-        $join_params->{result}                           = $result           if defined $result;
+        $join_params->{wait_url}         = $wait_url if defined $wait_url && length $wait_url;
+        $join_params->{max_participants} = $max_participants if $max_participants != 250;
+        $join_params->{record}           = $record           if $record ne 'do-not-record';
+        $join_params->{region}           = $region           if defined $region && length $region;
+        $join_params->{trim}             = $trim             if $trim ne 'trim-silence';
+        $join_params->{coach}            = $coach            if defined $coach && length $coach;
+        $join_params->{status_callback_event} = $status_callback_event
+            if defined $status_callback_event && length $status_callback_event;
+        $join_params->{status_callback} = $status_callback
+            if defined $status_callback && length $status_callback;
+        $join_params->{status_callback_method} = $status_callback_method
+            if $status_callback_method ne 'POST';
+        $join_params->{recording_status_callback} = $recording_status_callback
+            if defined $recording_status_callback && length $recording_status_callback;
+        $join_params->{recording_status_callback_method} = $recording_status_callback_method
+            if $recording_status_callback_method ne 'POST';
+        $join_params->{recording_status_callback_event} = $recording_status_callback_event
+            if $recording_status_callback_event ne 'completed';
+        $join_params->{result} = $result if defined $result;
     }
 
     my $swml_doc = {
         version  => '1.0.0',
-        sections => { main => [{ join_conference => $join_params }] },
+        sections => { main => [ { join_conference => $join_params } ] },
     };
     return $self->execute_swml($swml_doc);
 }
 
-sub join_room ($self, $name) {
+sub join_room ( $self, $name ) {
     my $swml_doc = {
         version  => '1.0.0',
-        sections => { main => [{ join_room => { name => $name } }] },
+        sections => { main => [ { join_room => { name => $name } } ] },
     };
     return $self->execute_swml($swml_doc);
 }
 
-sub sip_refer ($self, $to_uri) {
+sub sip_refer ( $self, $to_uri ) {
     my $swml_doc = {
         version  => '1.0.0',
-        sections => { main => [{ sip_refer => { to_uri => $to_uri } }] },
+        sections => { main => [ { sip_refer => { to_uri => $to_uri } } ] },
     };
     return $self->execute_swml($swml_doc);
 }
 
-sub tap ($self, $uri, %opts) {
+sub tap ( $self, $uri, %opts ) {
     my $control_id = $opts{control_id};
     my $direction  = $opts{direction} // 'both';
     my $codec      = $opts{codec}     // 'PCMU';
@@ -504,38 +519,40 @@ sub tap ($self, $uri, %opts) {
         unless $direction eq 'speak' || $direction eq 'hear' || $direction eq 'both';
     die "codec must be 'PCMU' or 'PCMA'"
         unless $codec eq 'PCMU' || $codec eq 'PCMA';
+
     # Python: `if rtp_ptime <= 0: raise ValueError(...)`.
     die "rtp_ptime must be a positive integer" if $rtp_ptime <= 0;
 
-    my %params = (uri => $uri);
+    my %params = ( uri => $uri );
+
     # Conditional keys — each emitted only when it differs from its default,
     # matching Python's per-key gating.
-    $params{control_id} = $control_id   if $control_id;
-    $params{direction}  = $direction    if $direction ne 'both';
-    $params{codec}      = $codec        if $codec ne 'PCMU';
+    $params{control_id} = $control_id    if $control_id;
+    $params{direction}  = $direction     if $direction ne 'both';
+    $params{codec}      = $codec         if $codec ne 'PCMU';
     $params{rtp_ptime}  = $rtp_ptime + 0 if $rtp_ptime != 20;
-    $params{status_url} = $status_url   if $status_url;
+    $params{status_url} = $status_url    if $status_url;
 
     my $swml_doc = {
         version  => '1.0.0',
-        sections => { main => [{ tap => \%params }] },
+        sections => { main => [ { tap => \%params } ] },
     };
     return $self->execute_swml($swml_doc);
 }
 
-sub stop_tap ($self, %opts) {
+sub stop_tap ( $self, %opts ) {
     my $control_id = $opts{control_id};
     my %params;
     $params{control_id} = $control_id if $control_id;
 
     my $swml_doc = {
         version  => '1.0.0',
-        sections => { main => [{ stop_tap => \%params }] },
+        sections => { main => [ { stop_tap => \%params } ] },
     };
     return $self->execute_swml($swml_doc);
 }
 
-sub send_sms ($self, %opts) {
+sub send_sms ( $self, %opts ) {
     my $to_number   = $opts{to_number}   // die "to_number is required";
     my $from_number = $opts{from_number} // die "from_number is required";
     my $body        = $opts{body};
@@ -549,7 +566,8 @@ sub send_sms ($self, %opts) {
         to_number   => $to_number,
         from_number => $from_number,
     );
-    $sms_params{body}   = $body   if $body;
+    $sms_params{body} = $body if $body;
+
     # Python gates media/tags with `if media:` / `if tags:` — an EMPTY list is
     # falsy and omitted. A Perl arrayref is truthy even when empty, so use the
     # Python-truthiness helper (an empty [] must not reach the wire).
@@ -559,17 +577,18 @@ sub send_sms ($self, %opts) {
 
     my $swml_doc = {
         version  => '1.0.0',
-        sections => { main => [{ send_sms => \%sms_params }] },
+        sections => { main => [ { send_sms => \%sms_params } ] },
     };
     return $self->execute_swml($swml_doc);
 }
 
-sub pay ($self, %opts) {
+sub pay ( $self, %opts ) {
     my $connector_url = $opts{payment_connector_url} // die "payment_connector_url required";
-    my $input_method  = $opts{input_method}  // 'dtmf';
-    my $timeout       = $opts{timeout}       // 5;
-    my $max_attempts  = $opts{max_attempts}  // 1;
-    my $ai_response   = $opts{ai_response}   // 'The payment status is ${pay_result}, do not mention anything else about collecting payment if successful.';
+    my $input_method  = $opts{input_method}          // 'dtmf';
+    my $timeout       = $opts{timeout}               // 5;
+    my $max_attempts  = $opts{max_attempts}          // 1;
+    my $ai_response   = $opts{ai_response}
+        // 'The payment status is ${pay_result}, do not mention anything else about collecting payment if successful.';
 
     # min_postal_code_length is an always-on key in Python
     # (str(min_postal_code_length), default "0"); emit it as a string too.
@@ -581,17 +600,17 @@ sub pay ($self, %opts) {
         payment_method         => $opts{payment_method} // 'credit-card',
         timeout                => "$timeout",
         max_attempts           => "$max_attempts",
-        security_code          => (($opts{security_code} // 1) ? 'true' : 'false'),
+        security_code          => ( ( $opts{security_code} // 1 ) ? 'true' : 'false' ),
         min_postal_code_length => "$min_postal_code_length",
-        token_type             => $opts{token_type}  // 'reusable',
-        currency               => $opts{currency}    // 'usd',
-        language               => $opts{language}    // 'en-US',
-        voice                  => $opts{voice}       // 'woman',
+        token_type             => $opts{token_type}       // 'reusable',
+        currency               => $opts{currency}         // 'usd',
+        language               => $opts{language}         // 'en-US',
+        voice                  => $opts{voice}            // 'woman',
         valid_card_types       => $opts{valid_card_types} // 'visa mastercard amex',
     );
 
     my $postal = $opts{postal_code} // 1;
-    if (ref $postal || $postal =~ /^[01]$/) {
+    if ( ref $postal || $postal =~ /^[01]$/ ) {
         $pay_params{postal_code} = $postal ? 'true' : 'false';
     } else {
         $pay_params{postal_code} = $postal;
@@ -600,18 +619,16 @@ sub pay ($self, %opts) {
     $pay_params{status_url}    = $opts{status_url}    if $opts{status_url};
     $pay_params{charge_amount} = $opts{charge_amount} if $opts{charge_amount};
     $pay_params{description}   = $opts{description}   if $opts{description};
+
     # Python gates parameters/prompts with `if parameters:` / `if prompts:` — an
     # EMPTY list is falsy and omitted. Mirror that (a Perl [] is truthy).
-    $pay_params{parameters}    = $opts{parameters}    if _py_truthy($opts{parameters});
-    $pay_params{prompts}       = $opts{prompts}       if _py_truthy($opts{prompts});
+    $pay_params{parameters} = $opts{parameters} if _py_truthy( $opts{parameters} );
+    $pay_params{prompts}    = $opts{prompts}    if _py_truthy( $opts{prompts} );
 
     my $swml_doc = {
         version  => '1.0.0',
         sections => {
-            main => [
-                { set => { ai_response => $ai_response } },
-                { pay => \%pay_params },
-            ],
+            main => [ { set => { ai_response => $ai_response } }, { pay => \%pay_params }, ],
         },
     };
     return $self->execute_swml($swml_doc);
@@ -619,15 +636,16 @@ sub pay ($self, %opts) {
 
 # --- RPC ---
 
-sub execute_rpc ($self, %opts) {
-    my $method  = $opts{method}  // die "method is required";
+sub execute_rpc ( $self, %opts ) {
+    my $method  = $opts{method} // die "method is required";
     my $params  = $opts{params};
     my $call_id = $opts{call_id};
     my $node_id = $opts{node_id};
 
-    my %rpc_params = (method => $method);
+    my %rpc_params = ( method => $method );
     $rpc_params{call_id} = $call_id if $call_id;
     $rpc_params{node_id} = $node_id if $node_id;
+
     # Python gates this with `if params:`, where an EMPTY dict {} is falsy and
     # therefore OMITTED (rpc_ai_unhold passes params={}, which never reaches the
     # wire). A Perl hashref is truthy even when empty, so mirror Python's
@@ -637,12 +655,12 @@ sub execute_rpc ($self, %opts) {
 
     my $swml_doc = {
         version  => '1.0.0',
-        sections => { main => [{ execute_rpc => \%rpc_params }] },
+        sections => { main => [ { execute_rpc => \%rpc_params } ] },
     };
     return $self->execute_swml($swml_doc);
 }
 
-sub rpc_dial ($self, %opts) {
+sub rpc_dial ( $self, %opts ) {
     my $to_number   = $opts{to_number}   // die "to_number is required";
     my $from_number = $opts{from_number} // die "from_number is required";
     my $dest_swml   = $opts{dest_swml}   // die "dest_swml is required";
@@ -663,7 +681,7 @@ sub rpc_dial ($self, %opts) {
     );
 }
 
-sub rpc_ai_message ($self, %opts) {
+sub rpc_ai_message ( $self, %opts ) {
     my $call_id      = $opts{call_id}      // die "call_id is required";
     my $message_text = $opts{message_text} // die "message_text is required";
     my $role         = $opts{role}         // 'system';
@@ -678,7 +696,7 @@ sub rpc_ai_message ($self, %opts) {
     );
 }
 
-sub rpc_ai_unhold ($self, %opts) {
+sub rpc_ai_unhold ( $self, %opts ) {
     my $call_id = $opts{call_id} // die "call_id is required";
 
     return $self->execute_rpc(
@@ -688,13 +706,13 @@ sub rpc_ai_unhold ($self, %opts) {
     );
 }
 
-sub simulate_user_input ($self, $text) {
-    return $self->add_action('user_input', $text);
+sub simulate_user_input ( $self, $text ) {
+    return $self->add_action( 'user_input', $text );
 }
 
 # --- Payment helpers (class methods) ---
 
-sub create_payment_prompt ($class_or_self, %opts) {
+sub create_payment_prompt ( $class_or_self, %opts ) {
     my $for_situation = $opts{for_situation} // die "for_situation is required";
     my $actions       = $opts{actions}       // die "actions is required";
     my $card_type     = $opts{card_type};
@@ -710,11 +728,11 @@ sub create_payment_prompt ($class_or_self, %opts) {
     return \%prompt;
 }
 
-sub create_payment_action ($class_or_self, $action_type, $phrase) {
+sub create_payment_action ( $class_or_self, $action_type, $phrase ) {
     return { type => $action_type, phrase => $phrase };
 }
 
-sub create_payment_parameter ($class_or_self, $name, $value) {
+sub create_payment_parameter ( $class_or_self, $name, $value ) {
     return { name => $name, value => $value };
 }
 
@@ -725,13 +743,13 @@ sub to_hash ($self) {
 
     $result{response} = $self->response if length $self->response;
 
-    if (@{ $self->action }) {
-        $result{action} = $self->action;
+    if ( @{ $self->action } ) {
+        $result{action}       = $self->action;
         $result{post_process} = JSON::true if $self->post_process;
     }
 
     # Ensure at least one of response or action
-    if (!keys %result) {
+    if ( !keys %result ) {
         $result{response} = 'Action completed.';
     }
 
@@ -739,7 +757,7 @@ sub to_hash ($self) {
 }
 
 sub to_json ($self) {
-    return JSON::encode_json($self->to_hash);
+    return JSON::encode_json( $self->to_hash );
 }
 
 1;

--- a/lib/SignalWire/SWAIG/JoinConference.pm
+++ b/lib/SignalWire/SWAIG/JoinConference.pm
@@ -1,4 +1,5 @@
 package SignalWire::SWAIG::JoinConference;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -92,7 +93,7 @@ our %EXPORT_TAGS = (
 # validation messages (matching Python's list rendering exactly).
 my @BEEPS   = qw( true false onEnter onExit );
 my @RECORDS = ( 'do-not-record', 'record-from-start' );
-my @TRIMS   = ( 'trim-silence', 'do-not-trim' );
+my @TRIMS   = ( 'trim-silence',  'do-not-trim' );
 my @METHODS = qw( GET POST );
 
 my %IS_BEEP   = map { $_ => 1 } @BEEPS;
@@ -101,13 +102,13 @@ my %IS_TRIM   = map { $_ => 1 } @TRIMS;
 my %IS_METHOD = map { $_ => 1 } @METHODS;
 
 # JoinConference->beeps — arrayref of the accepted beep strings.
-sub beeps   { return [@BEEPS]; }
+sub beeps { return [@BEEPS]; }
 
 # JoinConference->records — arrayref of the accepted record-mode strings.
 sub records { return [@RECORDS]; }
 
 # JoinConference->trims — arrayref of the accepted trim strings.
-sub trims   { return [@TRIMS]; }
+sub trims { return [@TRIMS]; }
 
 # JoinConference->methods — arrayref of the accepted callback HTTP methods.
 sub methods { return [@METHODS]; }
@@ -115,7 +116,7 @@ sub methods { return [@METHODS]; }
 # JoinConference->is_beep($value) — true if $value is an accepted beep
 # value. Accepts the bareword constant too (it's just the string).
 sub is_beep {
-    my ($class, $value) = @_;
+    my ( $class, $value ) = @_;
     return 0 unless defined $value;
     return exists $IS_BEEP{$value} ? 1 : 0;
 }
@@ -123,7 +124,7 @@ sub is_beep {
 # JoinConference->is_record($value) — true if $value is an accepted record
 # mode.
 sub is_record {
-    my ($class, $value) = @_;
+    my ( $class, $value ) = @_;
     return 0 unless defined $value;
     return exists $IS_RECORD{$value} ? 1 : 0;
 }
@@ -131,7 +132,7 @@ sub is_record {
 # JoinConference->is_trim($value) — true if $value is an accepted trim
 # value.
 sub is_trim {
-    my ($class, $value) = @_;
+    my ( $class, $value ) = @_;
     return 0 unless defined $value;
     return exists $IS_TRIM{$value} ? 1 : 0;
 }
@@ -139,7 +140,7 @@ sub is_trim {
 # JoinConference->is_method($value) — true if $value is an accepted
 # callback HTTP method.
 sub is_method {
-    my ($class, $value) = @_;
+    my ( $class, $value ) = @_;
     return 0 unless defined $value;
     return exists $IS_METHOD{$value} ? 1 : 0;
 }

--- a/lib/SignalWire/SWAIG/ParameterSchema.pm
+++ b/lib/SignalWire/SWAIG/ParameterSchema.pm
@@ -1,4 +1,5 @@
 package SignalWire::SWAIG::ParameterSchema;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -57,9 +58,10 @@ package SignalWire::SWAIG::ParameterSchema;
 use strict;
 use warnings;
 use Moo;
+
 # Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
-use Carp qw(croak);
+use Carp         qw(croak);
 use Scalar::Util qw(blessed reftype);
 use Tie::IxHash;
 
@@ -97,23 +99,23 @@ has _required => (
 # Every method returns $self so calls chain.
 
 # A free-form string property: { type => 'string', ... }.
-sub string ($self, $name, $description = undef, %opts) {
-    return $self->_add($name, 'string', $description, {}, %opts);
+sub string ( $self, $name, $description = undef, %opts ) {
+    return $self->_add( $name, 'string', $description, {}, %opts );
 }
 
 # A JSON number (float) property: { type => 'number', ... }.
-sub number ($self, $name, $description = undef, %opts) {
-    return $self->_add($name, 'number', $description, {}, %opts);
+sub number ( $self, $name, $description = undef, %opts ) {
+    return $self->_add( $name, 'number', $description, {}, %opts );
 }
 
 # An integer property: { type => 'integer', ... }.
-sub integer ($self, $name, $description = undef, %opts) {
-    return $self->_add($name, 'integer', $description, {}, %opts);
+sub integer ( $self, $name, $description = undef, %opts ) {
+    return $self->_add( $name, 'integer', $description, {}, %opts );
 }
 
 # A boolean property: { type => 'boolean', ... }.
-sub boolean ($self, $name, $description = undef, %opts) {
-    return $self->_add($name, 'boolean', $description, {}, %opts);
+sub boolean ( $self, $name, $description = undef, %opts ) {
+    return $self->_add( $name, 'boolean', $description, {}, %opts );
 }
 
 # A closed-set string property: { type => 'string', enum => [...], ... }.
@@ -123,14 +125,13 @@ sub boolean ($self, $name, $description = undef, %opts) {
 # the schema verbatim as `enum`. Defaults the JSON type to 'string' (the
 # usual case); override with type => 'integer' etc. via %opts for a
 # numeric-enum.
-sub enum ($self, $name, $values, $description = undef, %opts) {
+sub enum ( $self, $name, $values, $description = undef, %opts ) {
     croak("enum('$name', ...) requires an arrayref of accepted values")
         unless ref $values eq 'ARRAY';
     croak("enum('$name', ...) requires a non-empty value set")
         unless @$values;
     my $type = delete $opts{type} // 'string';
-    return $self->_add($name, $type, $description,
-        { enum => [@$values] }, %opts);
+    return $self->_add( $name, $type, $description, { enum => [@$values] }, %opts );
 }
 
 # An array property: { type => 'array', items => {...}, ... }.
@@ -143,14 +144,14 @@ sub enum ($self, $name, $values, $description = undef, %opts) {
 #   * a raw hashref items schema, used verbatim.
 # `of` is optional: omit it for an untyped array (no `items`), which is how
 # the hand-written `{ type => 'array' }` form is most often written.
-sub array ($self, $name, $description = undef, %opts) {
-    my $of    = delete $opts{of};
+sub array ( $self, $name, $description = undef, %opts ) {
+    my $of = delete $opts{of};
     my %facets;
     tie %facets, 'Tie::IxHash';
-    if (defined $of) {
-        $facets{items} = $self->_items_schema($name, $of);
+    if ( defined $of ) {
+        $facets{items} = $self->_items_schema( $name, $of );
     }
-    return $self->_add($name, 'array', $description, \%facets, %opts);
+    return $self->_add( $name, 'array', $description, \%facets, %opts );
 }
 
 # A nested object property: { type => 'object', properties => {...},
@@ -170,20 +171,20 @@ sub array ($self, $name, $description = undef, %opts) {
 # this property's body — they are emitted verbatim and must not be confused
 # with the property-level `required => 1` shorthand (which marks THIS object
 # property required on the PARENT). _add keeps the two apart.
-sub object ($self, $name, $description = undef, %opts) {
+sub object ( $self, $name, $description = undef, %opts ) {
     my $props = delete $opts{properties};
     my %facets;
     tie %facets, 'Tie::IxHash';
-    if (defined $props) {
-        my %body = $self->_object_body($name, $props);
+    if ( defined $props ) {
+        my %body = $self->_object_body( $name, $props );
         $facets{$_} = $body{$_} for keys %body;
     }
-    return $self->_add($name, 'object', $description, \%facets, %opts);
+    return $self->_add( $name, 'object', $description, \%facets, %opts );
 }
 
 # Mark one or more already-declared properties as required. Accumulates across
 # calls and de-duplicates on emit, preserving first-seen order. Returns $self.
-sub required ($self, @names) {
+sub required ( $self, @names ) {
     for my $n (@names) {
         croak("required(...) takes property name strings")
             if ref $n;
@@ -207,8 +208,8 @@ sub required ($self, @names) {
 sub to_hash ($self) {
     my %properties;
     my $props = $self->_properties;
-    for my $name (keys %$props) {
-        $properties{$name} = $self->_clone($props->{$name});
+    for my $name ( keys %$props ) {
+        $properties{$name} = $self->_clone( $props->{$name} );
     }
 
     my %schema = (
@@ -238,7 +239,7 @@ sub to_dict ($self) { return $self->to_hash }
 # parent (stripped from the body), `description` is the alt description
 # channel, and everything else (default / format / minimum / ...) is a scalar
 # JSON-Schema facet emitted verbatim.
-sub _add ($self, $name, $type, $description, $facets, %opts) {
+sub _add ( $self, $name, $type, $description, $facets, %opts ) {
     croak("property name is required") unless defined $name && length $name;
     croak("property '$name' is already defined")
         if exists $self->_properties->{$name};
@@ -256,19 +257,19 @@ sub _add ($self, $name, $type, $description, $facets, %opts) {
 
     my %prop;
     tie %prop, 'Tie::IxHash';
-    $prop{type} = $type;
+    $prop{type}        = $type;
     $prop{description} = $desc if defined $desc;
 
     # Structural facets first (enum / items / properties / nested required),
     # in the order the kind method assembled them.
-    for my $k (keys %$facets) {
+    for my $k ( keys %$facets ) {
         $prop{$k} = $facets->{$k};
     }
 
     # Then trailing scalar facets (default / format / minimum / ...) in
     # caller-given order. `default` may legitimately be false-y (0, '', []),
     # so they are copied unconditionally rather than truth-gated.
-    for my $k (keys %opts) {
+    for my $k ( keys %opts ) {
         $prop{$k} = $opts{$k};
     }
 
@@ -278,54 +279,55 @@ sub _add ($self, $name, $type, $description, $facets, %opts) {
 }
 
 # Resolve an array `of => ...` element spec to an items schema hashref.
-sub _items_schema ($self, $name, $of) {
-    if (blessed($of) && $of->isa(__PACKAGE__)) {
+sub _items_schema ( $self, $name, $of ) {
+    if ( blessed($of) && $of->isa(__PACKAGE__) ) {
         return $of->to_hash;
     }
-    if (ref $of eq 'HASH') {
+    if ( ref $of eq 'HASH' ) {
         return $self->_clone($of);
     }
-    if (!ref $of) {
+    if ( !ref $of ) {
         my %items;
         tie %items, 'Tie::IxHash';
         $items{type} = $of;
         return \%items;
     }
-    croak("array('$name', of => ...): 'of' must be a kind name, a "
-        . "ParameterSchema, or a hashref items schema");
+    croak(    "array('$name', of => ...): 'of' must be a kind name, a "
+            . "ParameterSchema, or a hashref items schema" );
 }
 
 # Resolve an object `properties => ...` spec to the (properties => ...,
 # required => ...) pair to splice into the property body.
-sub _object_body ($self, $name, $props) {
-    if (blessed($props) && $props->isa(__PACKAGE__)) {
-        return $self->_object_body_from_hash($props->to_hash);
+sub _object_body ( $self, $name, $props ) {
+    if ( blessed($props) && $props->isa(__PACKAGE__) ) {
+        return $self->_object_body_from_hash( $props->to_hash );
     }
-    if (ref $props eq 'CODE') {
+    if ( ref $props eq 'CODE' ) {
         my $child = __PACKAGE__->new;
         $props->($child);
-        return $self->_object_body_from_hash($child->to_hash);
+        return $self->_object_body_from_hash( $child->to_hash );
     }
-    if (ref $props eq 'HASH') {
+    if ( ref $props eq 'HASH' ) {
+
         # Either a full { type=>object, properties=>..., required=>... } or a
         # bare properties map. Detect the former by its `properties` key.
-        if (exists $props->{properties}) {
+        if ( exists $props->{properties} ) {
             return $self->_object_body_from_hash($props);
         }
-        return (properties => $self->_clone($props));
+        return ( properties => $self->_clone($props) );
     }
-    croak("object('$name', properties => ...): 'properties' must be a "
-        . "ParameterSchema, a coderef, or a hashref");
+    croak(    "object('$name', properties => ...): 'properties' must be a "
+            . "ParameterSchema, a coderef, or a hashref" );
 }
 
 # Pull (properties => ..., required => ...) out of an already-built object
 # schema hashref, dropping its redundant top-level `type => 'object'` (the
 # caller's _add re-sets `type` for the nesting property).
-sub _object_body_from_hash ($self, $hash) {
+sub _object_body_from_hash ( $self, $hash ) {
     my %out;
-    $out{properties} = $self->_clone($hash->{properties})
+    $out{properties} = $self->_clone( $hash->{properties} )
         if exists $hash->{properties};
-    $out{required} = [@{ $hash->{required} }]
+    $out{required} = [ @{ $hash->{required} } ]
         if exists $hash->{required};
     return %out;
 }
@@ -343,16 +345,16 @@ sub _unique_required ($self) {
 # property bodies — yields keys in insertion order, but the COPY is a plain
 # hash (a tied copy would defeat JSON's canonical key sorting and surprise any
 # serialiser that special-cases tied hashes).
-sub _clone ($self, $value) {
+sub _clone ( $self, $value ) {
     my $r = ref $value;
-    if ($r eq 'HASH' || (blessed($value) && reftype($value) && reftype($value) eq 'HASH')) {
+    if ( $r eq 'HASH' || ( blessed($value) && reftype($value) && reftype($value) eq 'HASH' ) ) {
         my %copy;
-        for my $k (keys %$value) {
-            $copy{$k} = $self->_clone($value->{$k});
+        for my $k ( keys %$value ) {
+            $copy{$k} = $self->_clone( $value->{$k} );
         }
         return \%copy;
     }
-    if ($r eq 'ARRAY' || (blessed($value) && reftype($value) && reftype($value) eq 'ARRAY')) {
+    if ( $r eq 'ARRAY' || ( blessed($value) && reftype($value) && reftype($value) eq 'ARRAY' ) ) {
         return [ map { $self->_clone($_) } @$value ];
     }
     return $value;

--- a/lib/SignalWire/SWAIG/RecordCall.pm
+++ b/lib/SignalWire/SWAIG/RecordCall.pm
@@ -1,4 +1,5 @@
 package SignalWire::SWAIG::RecordCall;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -59,7 +60,7 @@ use constant {
     BOTH   => 'both',
 };
 
-our @EXPORT_OK = qw( WAV MP3 MP4 SPEAK LISTEN BOTH );
+our @EXPORT_OK   = qw( WAV MP3 MP4 SPEAK LISTEN BOTH );
 our %EXPORT_TAGS = (
     all        => [@EXPORT_OK],
     formats    => [qw( WAV MP3 MP4 )],
@@ -87,7 +88,7 @@ sub directions {
 # RecordCall->is_format($value) — true if $value is an accepted recording
 # format. Accepts the bareword constant too (it's just the string).
 sub is_format {
-    my ($class, $value) = @_;
+    my ( $class, $value ) = @_;
     return 0 unless defined $value;
     return exists $IS_FORMAT{$value} ? 1 : 0;
 }
@@ -95,7 +96,7 @@ sub is_format {
 # RecordCall->is_direction($value) — true if $value is an accepted record
 # direction. Accepts the bareword constant too.
 sub is_direction {
-    my ($class, $value) = @_;
+    my ( $class, $value ) = @_;
     return 0 unless defined $value;
     return exists $IS_DIRECTION{$value} ? 1 : 0;
 }

--- a/lib/SignalWire/SWAIG/Tap.pm
+++ b/lib/SignalWire/SWAIG/Tap.pm
@@ -1,4 +1,5 @@
 package SignalWire::SWAIG::Tap;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -61,7 +62,7 @@ use constant {
     PCMA => 'PCMA',
 };
 
-our @EXPORT_OK = qw( SPEAK HEAR BOTH PCMU PCMA );
+our @EXPORT_OK   = qw( SPEAK HEAR BOTH PCMU PCMA );
 our %EXPORT_TAGS = (
     all        => [@EXPORT_OK],
     directions => [qw( SPEAK HEAR BOTH )],
@@ -89,7 +90,7 @@ sub codecs {
 # Tap->is_direction($value) — true if $value is an accepted tap direction.
 # Accepts the bareword constant too (it's just the string).
 sub is_direction {
-    my ($class, $value) = @_;
+    my ( $class, $value ) = @_;
     return 0 unless defined $value;
     return exists $IS_DIRECTION{$value} ? 1 : 0;
 }
@@ -97,7 +98,7 @@ sub is_direction {
 # Tap->is_codec($value) — true if $value is an accepted tap codec.
 # Accepts the bareword constant too.
 sub is_codec {
-    my ($class, $value) = @_;
+    my ( $class, $value ) = @_;
     return 0 unless defined $value;
     return exists $IS_CODEC{$value} ? 1 : 0;
 }

--- a/lib/SignalWire/SWML/Document.pm
+++ b/lib/SignalWire/SWML/Document.pm
@@ -15,37 +15,37 @@ has 'sections' => (
 );
 
 sub add_section {
-    my ($self, $name) = @_;
+    my ( $self, $name ) = @_;
     $self->sections->{$name} //= [];
     return $self;
 }
 
 sub add_verb {
-    my ($self, $section_name, $verb_name, $verb_data) = @_;
+    my ( $self, $section_name, $verb_name, $verb_data ) = @_;
     $self->sections->{$section_name} //= [];
     push @{ $self->sections->{$section_name} }, { $verb_name => $verb_data };
     return $self;
 }
 
 sub add_raw_verb {
-    my ($self, $section_name, $verb_hash) = @_;
+    my ( $self, $section_name, $verb_hash ) = @_;
     $self->sections->{$section_name} //= [];
     push @{ $self->sections->{$section_name} }, $verb_hash;
     return $self;
 }
 
 sub get_section {
-    my ($self, $name) = @_;
+    my ( $self, $name ) = @_;
     return $self->sections->{$name};
 }
 
 sub has_section {
-    my ($self, $name) = @_;
+    my ( $self, $name ) = @_;
     return exists $self->sections->{$name};
 }
 
 sub clear_section {
-    my ($self, $name) = @_;
+    my ( $self, $name ) = @_;
     $self->sections->{$name} = [];
     return $self;
 }
@@ -60,13 +60,13 @@ sub to_hash {
 
 sub to_json {
     my ($self) = @_;
-    return JSON::encode_json($self->to_hash);
+    return JSON::encode_json( $self->to_hash );
 }
 
 sub to_pretty_json {
     my ($self) = @_;
     my $json = JSON->new->utf8->canonical->pretty;
-    return $json->encode($self->to_hash);
+    return $json->encode( $self->to_hash );
 }
 
 1;

--- a/lib/SignalWire/SWML/Schema.pm
+++ b/lib/SignalWire/SWML/Schema.pm
@@ -21,6 +21,7 @@ has 'schema_data' => (
 sub BUILD {
     my ($self) = @_;
     $self->_load_schema();
+    return;
 }
 
 sub _load_schema {
@@ -62,6 +63,7 @@ sub _load_schema {
     }
 
     $self->{verbs} = \%verbs;
+    return;
 }
 
 sub instance {

--- a/lib/SignalWire/SWML/Schema.pm
+++ b/lib/SignalWire/SWML/Schema.pm
@@ -2,7 +2,7 @@ package SignalWire::SWML::Schema;
 use strict;
 use warnings;
 use Moo;
-use JSON ();
+use JSON           ();
 use File::Basename ();
 
 # Singleton instance
@@ -24,8 +24,8 @@ sub BUILD {
 }
 
 sub _load_schema {
-    my ($self) = @_;
-    my $dir = File::Basename::dirname(__FILE__);
+    my ($self)      = @_;
+    my $dir         = File::Basename::dirname(__FILE__);
     my $schema_file = "$dir/schema.json";
 
     open my $fh, '<', $schema_file
@@ -37,17 +37,17 @@ sub _load_schema {
     my $data = JSON::decode_json($json_text);
     $self->{schema_data} = $data;
 
-    my $defs = $data->{'$defs'} || {};
-    my $swml_method = $defs->{SWMLMethod} || {};
-    my $any_of = $swml_method->{anyOf} || [];
+    my $defs        = $data->{'$defs'}      || {};
+    my $swml_method = $defs->{SWMLMethod}   || {};
+    my $any_of      = $swml_method->{anyOf} || [];
 
     my %verbs;
     for my $entry (@$any_of) {
         my $ref = $entry->{'$ref'} || next;
-        (my $def_name) = $ref =~ m{/([^/]+)$};
+        ( my $def_name ) = $ref =~ m{/([^/]+)$};
         next unless $def_name;
 
-        my $def = $defs->{$def_name} || next;
+        my $def   = $defs->{$def_name} || next;
         my $props = $def->{properties} || next;
 
         my @keys = keys %$props;
@@ -76,12 +76,12 @@ sub get_verb_names {
 }
 
 sub has_verb {
-    my ($self, $name) = @_;
+    my ( $self, $name ) = @_;
     return exists $self->verbs->{$name};
 }
 
 sub get_verb {
-    my ($self, $name) = @_;
+    my ( $self, $name ) = @_;
     return $self->verbs->{$name};
 }
 

--- a/lib/SignalWire/SWML/Schema.pm
+++ b/lib/SignalWire/SWML/Schema.pm
@@ -72,7 +72,8 @@ sub instance {
 
 sub get_verb_names {
     my ($self) = @_;
-    return sort keys %{ $self->verbs };
+    my @names = sort keys %{ $self->verbs };
+    return @names;
 }
 
 sub has_verb {

--- a/lib/SignalWire/SWML/Service.pm
+++ b/lib/SignalWire/SWML/Service.pm
@@ -158,7 +158,7 @@ sub can {
     if ( $schema && $schema->has_verb($method) ) {
         return sub { $self->$method(@_) };
     }
-    return undef;
+    return;
 }
 
 sub _random_hex {
@@ -247,16 +247,16 @@ sub extract_sip_username {
     if ( !defined $request_body && ref $class_or_self eq 'HASH' ) {
         $request_body = $class_or_self;
     }
-    return undef unless ref $request_body eq 'HASH';
+    return unless ref $request_body eq 'HASH';
     my $call = $request_body->{call};
-    return undef unless ref $call eq 'HASH';
+    return unless ref $call eq 'HASH';
     my $to = $call->{to};
 
     # Python's implementation calls ``to_field.startswith(...)`` which
     # raises AttributeError for non-string values (None / int / list)
     # and returns None via the except path. Mirror that policy: any
     # non-defined or ref value short-circuits to undef.
-    return undef unless defined $to && !ref $to;
+    return unless defined $to && !ref $to;
 
     if ( $to =~ m{^sip:([^@]+)\@}i ) {
         return $1;
@@ -402,7 +402,7 @@ sub on_request {
 # direct request access can ignore it.
 sub on_swml_request {
     my ( $self, $request_data, $callback_path, $request ) = @_;
-    return undef;
+    return;
 }
 
 # ------------------------------------------------------------------
@@ -496,7 +496,7 @@ sub define_tools {
 sub on_function_call {
     my ( $self, $name, $args, $raw_data ) = @_;
     my $tool = $self->tools->{$name};
-    return undef unless $tool && $tool->{_handler};
+    return unless $tool && $tool->{_handler};
     return $tool->{_handler}->( $args, $raw_data );
 }
 
@@ -520,7 +520,7 @@ sub swaig_pre_dispatch {
 # Returns a PSGI response triple, or undef if not handled.
 sub handle_additional_route {
     my ( $self, $sub_path, $request_data, $env ) = @_;
-    return undef;
+    return;
 }
 
 # Register a routing callback at a given sub-path under the service route.

--- a/lib/SignalWire/SWML/Service.pm
+++ b/lib/SignalWire/SWML/Service.pm
@@ -2,8 +2,8 @@ package SignalWire::SWML::Service;
 use strict;
 use warnings;
 use Moo;
-use JSON ();
-use Digest::SHA qw(hmac_sha256_hex);
+use JSON         ();
+use Digest::SHA  qw(hmac_sha256_hex);
 use MIME::Base64 ();
 use Scalar::Util ();
 use SignalWire::SWML::Document;
@@ -79,6 +79,7 @@ has 'schema_utils' => (
 has 'verb_registry' => (
     is      => 'lazy',
     default => sub {
+
         # Tiny stand-in registry for verb-handler dispatch. The Perl SDK
         # uses AUTOLOAD against the schema for verb lookup; this hashref
         # mirrors Python's VerbHandlerRegistry surface (handlers indexed
@@ -91,6 +92,7 @@ has 'security' => (
     is      => 'lazy',
     default => sub {
         my ($self) = @_;
+
         # Python's SWMLService.security is a SecurityConfig instance that
         # bundles SSL + basic-auth + CORS knobs. Perl SWMLService models
         # those as direct ``has`` attributes (basic_auth_user, etc.); the
@@ -99,8 +101,7 @@ has 'security' => (
         # working. Wrap in a blessed Moo-ish object so introspection still
         # sees it as an object (Python parity).
         require SignalWire::Security::SessionManager;
-        return $self->{_session_manager}
-            //= SignalWire::Security::SessionManager->new();
+        return $self->{_session_manager} //= SignalWire::Security::SessionManager->new();
     },
 );
 
@@ -117,25 +118,27 @@ sub _get_schema {
 }
 
 sub AUTOLOAD {
-    my $self = shift;
+    my $self   = shift;
     my $method = $AUTOLOAD;
-    $method =~ s/.*:://;  # strip package name
+    $method =~ s/.*:://;    # strip package name
 
     return if $method eq 'DESTROY';
 
     my $schema = _get_schema();
-    if ($schema->has_verb($method)) {
+    if ( $schema->has_verb($method) ) {
+
         # For 'sleep' verb: takes an integer (milliseconds), not a hashref
         my $section = shift // 'main';
         my $data;
-        if ($method eq 'sleep') {
+        if ( $method eq 'sleep' ) {
             $data = shift // 0;
+
             # Ensure it is a numeric value
             $data = int($data);
         } else {
             $data = shift // {};
         }
-        $self->document->add_verb($section, $method, $data);
+        $self->document->add_verb( $section, $method, $data );
         return $self;
     }
 
@@ -144,13 +147,15 @@ sub AUTOLOAD {
 
 # Provide can() that knows about schema verbs
 sub can {
-    my ($self, $method) = @_;
+    my ( $self, $method ) = @_;
+
     # Check if it is a regular method first
     my $code = $self->SUPER::can($method);
     return $code if $code;
+
     # Check schema verbs
     my $schema = _get_schema();
-    if ($schema && $schema->has_verb($method)) {
+    if ( $schema && $schema->has_verb($method) ) {
         return sub { $self->$method(@_) };
     }
     return undef;
@@ -158,38 +163,40 @@ sub can {
 
 sub _random_hex {
     my ($len) = @_;
+
     # Use /dev/urandom for cryptographically secure random bytes.
     # Die on failure rather than falling back to weak randomness.
-    if (open my $fh, '<:raw', '/dev/urandom') {
+    if ( open my $fh, '<:raw', '/dev/urandom' ) {
         my $bytes;
-        my $read = read($fh, $bytes, $len);
+        my $read = read( $fh, $bytes, $len );
         close $fh;
-        if (defined $read && $read == $len) {
-            return unpack('H*', $bytes);
+        if ( defined $read && $read == $len ) {
+            return unpack( 'H*', $bytes );
         }
     }
     die "FATAL: Cannot generate secure random bytes - /dev/urandom unavailable or read failed. "
-      . "Set SWML_BASIC_AUTH_USER and SWML_BASIC_AUTH_PASSWORD environment variables instead.\n";
+        . "Set SWML_BASIC_AUTH_USER and SWML_BASIC_AUTH_PASSWORD environment variables instead.\n";
 }
 
 sub _timing_safe_compare {
-    my ($a, $b) = @_;
+    my ( $a, $b ) = @_;
+
     # Compare HMAC of both values with a fixed key for constant-time comparison
-    my $key = 'timing-safe-comparison-key';
-    my $hmac_a = hmac_sha256_hex($a, $key);
-    my $hmac_b = hmac_sha256_hex($b, $key);
+    my $key    = 'timing-safe-comparison-key';
+    my $hmac_a = hmac_sha256_hex( $a, $key );
+    my $hmac_b = hmac_sha256_hex( $b, $key );
     return $hmac_a eq $hmac_b;
 }
 
 # Validate provided basic-auth credentials. (Python parity:
 # AuthMixin.validate_basic_auth(username, password).)
 sub validate_basic_auth {
-    my ($self, $username, $password) = @_;
+    my ( $self, $username, $password ) = @_;
     my $u = $self->basic_auth_user;
     my $p = $self->basic_auth_password;
     return 0 unless defined $u && defined $p;
-    return _timing_safe_compare($username, $u)
-        && _timing_safe_compare($password, $p);
+    return _timing_safe_compare( $username, $u )
+        && _timing_safe_compare( $password, $p );
 }
 
 # Returns ($user, $password) by default; if $include_source is truthy,
@@ -197,21 +204,21 @@ sub validate_basic_auth {
 # "environment", or "generated". (Python parity:
 # AuthMixin.get_basic_auth_credentials(include_source=False).)
 sub get_basic_auth_credentials {
-    my ($self, $include_source) = @_;
-    my $user = $self->basic_auth_user // '';
+    my ( $self, $include_source ) = @_;
+    my $user = $self->basic_auth_user     // '';
     my $pass = $self->basic_auth_password // '';
-    return ($user, $pass) unless $include_source;
-    my $env_user = $ENV{SWML_BASIC_AUTH_USER} // '';
+    return ( $user, $pass ) unless $include_source;
+    my $env_user = $ENV{SWML_BASIC_AUTH_USER}     // '';
     my $env_pass = $ENV{SWML_BASIC_AUTH_PASSWORD} // '';
     my $source;
-    if ($env_user ne '' && $env_pass ne '' && $user eq $env_user && $pass eq $env_pass) {
+    if ( $env_user ne '' && $env_pass ne '' && $user eq $env_user && $pass eq $env_pass ) {
         $source = 'environment';
-    } elsif ($user =~ /^user_/ && length($pass) > 20) {
+    } elsif ( $user =~ /^user_/ && length($pass) > 20 ) {
         $source = 'generated';
     } else {
         $source = 'provided';
     }
-    return ($user, $pass, $source);
+    return ( $user, $pass, $source );
 }
 
 # Backward-compat alias for Perl callers that used the named-helper form.
@@ -233,58 +240,60 @@ sub get_basic_auth_credentials_with_source {
 # what Python expresses with @staticmethod). The class_or_self receiver
 # is mirrored from FunctionResult and other static-method-shaped helpers.
 sub extract_sip_username {
-    my ($class_or_self, $request_body) = @_;
+    my ( $class_or_self, $request_body ) = @_;
+
     # Allow being called as a free function (single-arg form): if the
     # first arg is itself the request_body hashref, shift it forward.
-    if (!defined $request_body && ref $class_or_self eq 'HASH') {
+    if ( !defined $request_body && ref $class_or_self eq 'HASH' ) {
         $request_body = $class_or_self;
     }
     return undef unless ref $request_body eq 'HASH';
     my $call = $request_body->{call};
     return undef unless ref $call eq 'HASH';
     my $to = $call->{to};
+
     # Python's implementation calls ``to_field.startswith(...)`` which
     # raises AttributeError for non-string values (None / int / list)
     # and returns None via the except path. Mirror that policy: any
     # non-defined or ref value short-circuits to undef.
     return undef unless defined $to && !ref $to;
 
-    if ($to =~ m{^sip:([^@]+)\@}i) {
+    if ( $to =~ m{^sip:([^@]+)\@}i ) {
         return $1;
     }
-    if ($to =~ m{^tel:(.+)$}i) {
+    if ( $to =~ m{^tel:(.+)$}i ) {
         return $1;
     }
     return $to;
 }
 
 sub _check_basic_auth {
-    my ($self, $env) = @_;
+    my ( $self, $env ) = @_;
     my $auth = $env->{HTTP_AUTHORIZATION} // '';
     return 0 unless $auth =~ /^Basic\s+(.+)$/i;
     my $decoded = MIME::Base64::decode_base64($1);
-    my ($user, $pass) = split(/:/, $decoded, 2);
+    my ( $user, $pass ) = split( /:/, $decoded, 2 );
     return 0 unless defined $user && defined $pass;
-    return _timing_safe_compare($user, $self->basic_auth_user)
-        && _timing_safe_compare($pass, $self->basic_auth_password);
+    return _timing_safe_compare( $user, $self->basic_auth_user )
+        && _timing_safe_compare( $pass, $self->basic_auth_password );
 }
 
 sub _security_headers {
     return (
-        'X-Content-Type-Options'  => 'nosniff',
-        'X-Frame-Options'         => 'DENY',
-        'X-XSS-Protection'        => '1; mode=block',
-        'Cache-Control'           => 'no-store, no-cache, must-revalidate',
-        'Pragma'                  => 'no-cache',
-        'Content-Type'            => 'application/json',
+        'X-Content-Type-Options' => 'nosniff',
+        'X-Frame-Options'        => 'DENY',
+        'X-XSS-Protection'       => '1; mode=block',
+        'Cache-Control'          => 'no-store, no-cache, must-revalidate',
+        'Pragma'                 => 'no-cache',
+        'Content-Type'           => 'application/json',
     );
 }
 
 sub _json_response {
-    my ($status, $data) = @_;
+    my ( $status, $data ) = @_;
     my @headers = _security_headers();
-    my $body = JSON::encode_json($data);
-    return [$status, \@headers, [$body]];
+    my $body    = JSON::encode_json($data);
+    return [ $status, \@headers, [$body] ];
 }
 
 sub _read_body {
@@ -300,33 +309,37 @@ sub to_psgi_app {
     my ($self) = @_;
 
     return sub {
-        my ($env) = @_;
+        my ($env)  = @_;
         my $method = $env->{REQUEST_METHOD};
         my $path   = $env->{PATH_INFO} // '/';
 
         # Health/ready endpoints (no auth)
-        if ($path eq '/health' || $path eq '/ready') {
-            return _json_response(200, { status => 'ok' });
+        if ( $path eq '/health' || $path eq '/ready' ) {
+            return _json_response( 200, { status => 'ok' } );
         }
 
         # Normalize route for matching
         my $route = $self->route;
-        $route =~ s{/$}{};       # strip trailing slash
-        $path  =~ s{/$}{};       # strip trailing slash
+        $route =~ s{/$}{};    # strip trailing slash
+        $path  =~ s{/$}{};    # strip trailing slash
         $route = '' if $route eq '/';
         $path  = '' if $path eq '/';
 
         # Check if this request matches our routes
-        my $is_swml_route   = ($path eq $route);
-        my $is_swaig_route  = ($path eq "$route/swaig");
-        my $is_post_prompt  = ($path eq "$route/post_prompt");
+        my $is_swml_route  = ( $path eq $route );
+        my $is_swaig_route = ( $path eq "$route/swaig" );
+        my $is_post_prompt = ( $path eq "$route/post_prompt" );
 
-        if ($is_swml_route || $is_swaig_route || $is_post_prompt) {
+        if ( $is_swml_route || $is_swaig_route || $is_post_prompt ) {
+
             # Require basic auth for protected routes
-            unless ($self->_check_basic_auth($env)) {
+            unless ( $self->_check_basic_auth($env) ) {
                 return [
                     401,
-                    ['Content-Type' => 'text/plain', 'WWW-Authenticate' => 'Basic realm="SignalWire"'],
+                    [
+                        'Content-Type'     => 'text/plain',
+                        'WWW-Authenticate' => 'Basic realm="SignalWire"'
+                    ],
                     ['Authentication required'],
                 ];
             }
@@ -340,27 +353,27 @@ sub to_psgi_app {
             }
         }
 
-        return _json_response(404, { error => 'Not found' });
+        return _json_response( 404, { error => 'Not found' } );
     };
 }
 
 sub _handle_swml_request {
-    my ($self, $env) = @_;
+    my ( $self, $env ) = @_;
     my $doc = $self->render_main_swml($env);
-    return _json_response(200, $doc);
+    return _json_response( 200, $doc );
 }
 
 # Extension point: render the SWML document for the main path or for
 # GET /swaig. Default returns the currently-built Document. AgentBase
 # overrides to emit prompt + AI verb at request time.
 sub render_main_swml {
-    my ($self, $env) = @_;
+    my ( $self, $env ) = @_;
     return $self->document->to_hash;
 }
 
 # Backwards-compatible alias kept for subclasses that override render_swml.
 sub render_swml {
-    my ($self, $env) = @_;
+    my ( $self, $env ) = @_;
     return $self->render_main_swml($env);
 }
 
@@ -375,8 +388,8 @@ sub render_swml {
 # The Python third `request` argument is FastAPI-specific and
 # intentionally not mirrored.
 sub on_request {
-    my ($self, $request_data, $callback_path) = @_;
-    return $self->on_swml_request($request_data, $callback_path);
+    my ( $self, $request_data, $callback_path ) = @_;
+    return $self->on_swml_request( $request_data, $callback_path );
 }
 
 # Customization point for subclasses to modify SWML based on request
@@ -388,7 +401,7 @@ sub on_request {
 # wrapper produced by the calling code). Subclasses that don't need
 # direct request access can ignore it.
 sub on_swml_request {
-    my ($self, $request_data, $callback_path, $request) = @_;
+    my ( $self, $request_data, $callback_path, $request ) = @_;
     return undef;
 }
 
@@ -400,9 +413,8 @@ sub on_swml_request {
 # parameter descriptions are LLM-facing prompt engineering — see
 # PORTING_GUIDE for guidance.
 sub define_tool {
-    my ($self, %opts) = @_;
-    my $name        = $opts{name}
-        // die("define_tool requires 'name'");
+    my ( $self, %opts ) = @_;
+    my $name        = $opts{name}        // die("define_tool requires 'name'");
     my $description = $opts{description} // '';
     my $parameters  = $opts{parameters}  // { type => 'object', properties => {} };
     my $handler     = $opts{handler};
@@ -411,9 +423,9 @@ sub define_tool {
         function    => $name,
         description => $description,
         parameters  => $parameters,
-        (defined $handler ? (_handler => $handler) : ()),
+        ( defined $handler ? ( _handler => $handler ) : () ),
     };
-    for my $k (keys %opts) {
+    for my $k ( keys %opts ) {
         next if $k =~ /^(name|description|parameters|handler)$/;
         $tool_def->{$k} = $opts{$k};
     }
@@ -425,7 +437,7 @@ sub define_tool {
 
 # Register a raw SWAIG function definition (e.g. from DataMap).
 sub register_swaig_function {
-    my ($self, $func_def) = @_;
+    my ( $self, $func_def ) = @_;
     my $name = $func_def->{function} // die("register_swaig_function needs 'function' key");
     $self->tools->{$name} = $func_def;
     push @{ $self->tool_order }, $name
@@ -436,14 +448,14 @@ sub register_swaig_function {
 # Whether a SWAIG function with the given name is registered.
 # (Python parity: ToolRegistry.has_function.)
 sub has_function {
-    my ($self, $name) = @_;
+    my ( $self, $name ) = @_;
     return exists $self->tools->{$name} ? 1 : 0;
 }
 
 # Get a registered SWAIG function by name, or undef when absent.
 # (Python parity: ToolRegistry.get_function.)
 sub get_function {
-    my ($self, $name) = @_;
+    my ( $self, $name ) = @_;
     return $self->tools->{$name};
 }
 
@@ -457,7 +469,7 @@ sub get_all_functions {
 # Remove a registered SWAIG function. Returns 1 on success, 0 if absent.
 # (Python parity: ToolRegistry.remove_function.)
 sub remove_function {
-    my ($self, $name) = @_;
+    my ( $self, $name ) = @_;
     return 0 unless exists $self->tools->{$name};
     delete $self->tools->{$name};
     @{ $self->tool_order } = grep { $_ ne $name } @{ $self->tool_order };
@@ -466,10 +478,10 @@ sub remove_function {
 
 # Register multiple tool definitions at once.
 sub define_tools {
-    my ($self, @tool_defs) = @_;
+    my ( $self, @tool_defs ) = @_;
     for my $t (@tool_defs) {
-        if (ref $t eq 'HASH') {
-            if (exists $t->{function}) {
+        if ( ref $t eq 'HASH' ) {
+            if ( exists $t->{function} ) {
                 $self->register_swaig_function($t);
             } else {
                 $self->define_tool(%$t);
@@ -482,10 +494,10 @@ sub define_tools {
 # Dispatch a function call to the registered handler. Default plain
 # implementation. AgentBase may override to add token validation.
 sub on_function_call {
-    my ($self, $name, $args, $raw_data) = @_;
+    my ( $self, $name, $args, $raw_data ) = @_;
     my $tool = $self->tools->{$name};
     return undef unless $tool && $tool->{_handler};
-    return $tool->{_handler}->($args, $raw_data);
+    return $tool->{_handler}->( $args, $raw_data );
 }
 
 # List registered SWAIG tool names in registration order.
@@ -499,82 +511,82 @@ sub list_tool_names {
 # defined, it's encoded as the SWAIG response without calling
 # on_function_call. AgentBase may override to add session-token validation.
 sub swaig_pre_dispatch {
-    my ($self, $request_data, $func_name, $env) = @_;
-    return ($self, undef);
+    my ( $self, $request_data, $func_name, $env ) = @_;
+    return ( $self, undef );
 }
 
 # Extension point: subclasses may override to add /post_prompt, /mcp etc.
 # Receives the relative sub-path (after the route prefix) and parsed body.
 # Returns a PSGI response triple, or undef if not handled.
 sub handle_additional_route {
-    my ($self, $sub_path, $request_data, $env) = @_;
+    my ( $self, $sub_path, $request_data, $env ) = @_;
     return undef;
 }
 
 # Register a routing callback at a given sub-path under the service route.
 sub register_routing_callback {
-    my ($self, $path, $cb) = @_;
+    my ( $self, $path, $cb ) = @_;
     $self->routing_callbacks->{$path} = $cb;
     return $self;
 }
 
 sub _handle_swaig_request {
-    my ($self, $env) = @_;
+    my ( $self, $env ) = @_;
     my $method = $env->{REQUEST_METHOD} // 'GET';
 
-    if ($method eq 'GET') {
+    if ( $method eq 'GET' ) {
         my $doc = $self->render_main_swml($env);
-        return _json_response(200, $doc);
+        return _json_response( 200, $doc );
     }
 
     my $body = _read_body($env);
     my $payload;
     eval { $payload = JSON::decode_json($body) if length($body) };
-    if ($@ || !$payload || ref $payload ne 'HASH') {
-        return _json_response(400, { error => 'Invalid JSON' });
+    if ( $@ || !$payload || ref $payload ne 'HASH' ) {
+        return _json_response( 400, { error => 'Invalid JSON' } );
     }
 
     my $func_name = $payload->{function};
-    if (!defined $func_name || $func_name eq '') {
-        return _json_response(400, { error => 'Missing function name' });
+    if ( !defined $func_name || $func_name eq '' ) {
+        return _json_response( 400, { error => 'Missing function name' } );
     }
-    if ($func_name !~ $SWAIG_FN_NAME) {
-        return _json_response(400, { error => "Invalid function name format: '$func_name'" });
+    if ( $func_name !~ $SWAIG_FN_NAME ) {
+        return _json_response( 400, { error => "Invalid function name format: '$func_name'" } );
     }
 
     # Argument extraction: nested {argument:{parsed:[...]}} OR flat {arguments}
     my $args = {};
-    if (ref $payload->{argument} eq 'HASH') {
+    if ( ref $payload->{argument} eq 'HASH' ) {
         my $parsed = $payload->{argument}{parsed};
         $args = $parsed->[0] if ref $parsed eq 'ARRAY' && @$parsed;
-    } elsif (ref $payload->{arguments} eq 'HASH') {
+    } elsif ( ref $payload->{arguments} eq 'HASH' ) {
         $args = $payload->{arguments};
     }
     $args //= {};
 
-    my ($target, $short_circuit) = $self->swaig_pre_dispatch($payload, $func_name, $env);
-    return _json_response(200, $short_circuit) if defined $short_circuit;
+    my ( $target, $short_circuit ) = $self->swaig_pre_dispatch( $payload, $func_name, $env );
+    return _json_response( 200, $short_circuit ) if defined $short_circuit;
 
-    my $result = $target->on_function_call($func_name, $args, $payload);
-    return _json_response(404, { error => "Unknown function: $func_name" })
+    my $result = $target->on_function_call( $func_name, $args, $payload );
+    return _json_response( 404, { error => "Unknown function: $func_name" } )
         unless defined $result;
 
     # FunctionResult-like objects respond to to_hash; handlers may also
     # return plain hashrefs.
     my $result_hash;
-    if (ref $result eq 'HASH') {
+    if ( ref $result eq 'HASH' ) {
         $result_hash = $result;
-    } elsif (Scalar::Util::blessed($result) && $result->can('to_hash')) {
+    } elsif ( Scalar::Util::blessed($result) && $result->can('to_hash') ) {
         $result_hash = $result->to_hash;
     } else {
         $result_hash = { response => "$result" };
     }
-    return _json_response(200, $result_hash);
+    return _json_response( 200, $result_hash );
 }
 
 sub _handle_post_prompt {
-    my ($self, $env) = @_;
-    return _json_response(200, { response => 'Post prompt endpoint' });
+    my ( $self, $env ) = @_;
+    return _json_response( 200, { response => 'Post prompt endpoint' } );
 }
 
 1;

--- a/lib/SignalWire/Security/SessionManager.pm
+++ b/lib/SignalWire/Security/SessionManager.pm
@@ -2,14 +2,14 @@ package SignalWire::Security::SessionManager;
 use strict;
 use warnings;
 use Moo;
-use JSON ();
-use Digest::SHA qw(hmac_sha256_hex);
+use JSON         ();
+use Digest::SHA  qw(hmac_sha256_hex);
 use MIME::Base64 ();
-use Time::HiRes ();
+use Time::HiRes  ();
 
 has 'token_expiry_secs' => (
     is      => 'ro',
-    default => sub { 900 },  # 15 minutes
+    default => sub { 900 },    # 15 minutes
 );
 
 has 'secret_key' => (
@@ -24,80 +24,80 @@ has '_debug_mode' => (
 
 sub _random_hex {
     my ($len) = @_;
+
     # Use /dev/urandom for cryptographically secure random bytes.
     # Die on failure rather than falling back to weak randomness.
-    if (open my $fh, '<:raw', '/dev/urandom') {
+    if ( open my $fh, '<:raw', '/dev/urandom' ) {
         my $bytes;
-        my $read = read($fh, $bytes, $len);
+        my $read = read( $fh, $bytes, $len );
         close $fh;
-        if (defined $read && $read == $len) {
-            return unpack('H*', $bytes);
+        if ( defined $read && $read == $len ) {
+            return unpack( 'H*', $bytes );
         }
     }
     die "FATAL: Cannot generate secure random bytes - /dev/urandom unavailable. "
-      . "This is required for session security.\n";
+        . "This is required for session security.\n";
 }
 
 sub _random_urlsafe {
     my ($len) = @_;
     my $bytes = '';
-    for (1 .. $len) {
-        $bytes .= chr(int(rand(256)));
+    for ( 1 .. $len ) {
+        $bytes .= chr( int( rand(256) ) );
     }
-    return MIME::Base64::encode_base64url($bytes, '');
+    return MIME::Base64::encode_base64url( $bytes, '' );
 }
 
 sub create_session {
-    my ($self, $call_id) = @_;
+    my ( $self, $call_id ) = @_;
     $call_id //= _random_urlsafe(16);
     return $call_id;
 }
 
 sub generate_token {
-    my ($self, $function_name, $call_id) = @_;
-    my $expiry = int(time()) + $self->token_expiry_secs;
+    my ( $self, $function_name, $call_id ) = @_;
+    my $expiry = int( time() ) + $self->token_expiry_secs;
     my $nonce  = _random_hex(8);
 
-    my $message = "$call_id:$function_name:$expiry:$nonce";
-    my $signature = hmac_sha256_hex($message, $self->secret_key);
+    my $message   = "$call_id:$function_name:$expiry:$nonce";
+    my $signature = hmac_sha256_hex( $message, $self->secret_key );
 
     my $token = "$call_id.$function_name.$expiry.$nonce.$signature";
-    return MIME::Base64::encode_base64url($token, '');
+    return MIME::Base64::encode_base64url( $token, '' );
 }
 
 # Alias
 sub create_tool_token {
-    my ($self, $function_name, $call_id) = @_;
-    return $self->generate_token($function_name, $call_id);
+    my ( $self, $function_name, $call_id ) = @_;
+    return $self->generate_token( $function_name, $call_id );
 }
 
 sub _timing_safe_compare {
-    my ($a, $b) = @_;
+    my ( $a, $b ) = @_;
+
     # Compare HMAC of both values for constant-time comparison
-    my $key = 'timing-safe-token-comparison';
-    my $hmac_a = hmac_sha256_hex($a, $key);
-    my $hmac_b = hmac_sha256_hex($b, $key);
+    my $key    = 'timing-safe-token-comparison';
+    my $hmac_a = hmac_sha256_hex( $a, $key );
+    my $hmac_b = hmac_sha256_hex( $b, $key );
     return $hmac_a eq $hmac_b;
 }
 
 sub validate_token {
-    my ($self, $call_id, $function_name, $token) = @_;
+    my ( $self, $call_id, $function_name, $token ) = @_;
 
     return 0 unless $call_id && $function_name && $token;
 
     my $decoded;
-    eval {
-        $decoded = MIME::Base64::decode_base64url($token);
-    };
+    eval { $decoded = MIME::Base64::decode_base64url($token); };
     return 0 if $@ || !$decoded;
 
-    my @parts = split(/\./, $decoded);
+    my @parts = split( /\./, $decoded );
     return 0 unless @parts == 5;
 
-    my ($token_call_id, $token_function, $token_expiry, $token_nonce, $token_signature) = @parts;
+    my ( $token_call_id, $token_function, $token_expiry, $token_nonce, $token_signature ) = @parts;
 
     # Verify function matches
-    return 0 unless _timing_safe_compare($token_function, $function_name);
+    return 0 unless _timing_safe_compare( $token_function, $function_name );
 
     # Check expiry
     my $expiry = eval { int($token_expiry) };
@@ -105,52 +105,52 @@ sub validate_token {
     return 0 if $expiry < time();
 
     # Recreate and verify signature
-    my $message = "$token_call_id:$token_function:$token_expiry:$token_nonce";
-    my $expected_signature = hmac_sha256_hex($message, $self->secret_key);
-    return 0 unless _timing_safe_compare($token_signature, $expected_signature);
+    my $message            = "$token_call_id:$token_function:$token_expiry:$token_nonce";
+    my $expected_signature = hmac_sha256_hex( $message, $self->secret_key );
+    return 0 unless _timing_safe_compare( $token_signature, $expected_signature );
 
     # Verify call_id
-    return 0 unless _timing_safe_compare($token_call_id, $call_id);
+    return 0 unless _timing_safe_compare( $token_call_id, $call_id );
 
     return 1;
 }
 
 # Alias with different parameter order for backward compat
 sub validate_tool_token {
-    my ($self, $function_name, $token, $call_id) = @_;
-    return $self->validate_token($call_id, $function_name, $token);
+    my ( $self, $function_name, $token, $call_id ) = @_;
+    return $self->validate_token( $call_id, $function_name, $token );
 }
 
 # Legacy methods - no-ops for API compat (mirroring Python's
 # stateless SessionManager.activate_session/end_session/etc. which
 # accept the args, validate they're present, and return success).
 sub activate_session {
-    my ($self, $call_id) = @_;
+    my ( $self, $call_id ) = @_;
     return 1;
 }
 
 sub end_session {
-    my ($self, $call_id) = @_;
+    my ( $self, $call_id ) = @_;
     return 1;
 }
 
 sub get_session_metadata {
-    my ($self, $call_id) = @_;
+    my ( $self, $call_id ) = @_;
     return {};
 }
 
 sub set_session_metadata {
-    my ($self, $call_id, $key, $value) = @_;
+    my ( $self, $call_id, $key, $value ) = @_;
     return 1;
 }
 
 sub debug_token {
-    my ($self, $token) = @_;
+    my ( $self, $token ) = @_;
     return { error => 'debug mode not enabled' } unless $self->_debug_mode;
 
     my $decoded;
     eval { $decoded = MIME::Base64::decode_base64url($token) };
-    if ($@ || !$decoded) {
+    if ( $@ || !$decoded ) {
         return {
             valid_format => JSON::false,
             error        => $@ // 'decode failed',
@@ -158,8 +158,8 @@ sub debug_token {
         };
     }
 
-    my @parts = split(/\./, $decoded);
-    if (@parts != 5) {
+    my @parts = split( /\./, $decoded );
+    if ( @parts != 5 ) {
         return {
             valid_format => JSON::false,
             parts_count  => scalar @parts,
@@ -167,24 +167,24 @@ sub debug_token {
         };
     }
 
-    my ($tc, $tf, $te, $tn, $ts) = @parts;
-    my $current = int(time());
+    my ( $tc, $tf, $te, $tn, $ts ) = @parts;
+    my $current = int( time() );
     my $expiry  = eval { int($te) };
-    my $expired = defined $expiry ? ($expiry < $current ? 1 : 0) : undef;
+    my $expired = defined $expiry ? ( $expiry < $current ? 1 : 0 ) : undef;
 
     return {
         valid_format => JSON::true,
         components   => {
-            call_id   => (length($tc) > 8 ? substr($tc, 0, 8) . '...' : $tc),
+            call_id   => ( length($tc) > 8 ? substr( $tc, 0, 8 ) . '...' : $tc ),
             function  => $tf,
             expiry    => $te,
             nonce     => $tn,
-            signature => (length($ts) > 8 ? substr($ts, 0, 8) . '...' : $ts),
+            signature => ( length($ts) > 8 ? substr( $ts, 0, 8 ) . '...' : $ts ),
         },
         status => {
             current_time       => $current,
             is_expired         => $expired,
-            expires_in_seconds => (defined $expiry && !$expired ? $expiry - $current : 0),
+            expires_in_seconds => ( defined $expiry && !$expired ? $expiry - $current : 0 ),
         },
     };
 }

--- a/lib/SignalWire/Security/WebhookMiddleware.pm
+++ b/lib/SignalWire/Security/WebhookMiddleware.pm
@@ -155,6 +155,10 @@ sub _slurp_body {
         eval { $input->seek( 0, 0 ) };
     }
     if ( $@ || !$input->can('seek') ) {
+
+        # In-memory handle is deliberately handed off as psgi.input for
+        # downstream re-reads; it must NOT be closed here (see RequireBriefOpen
+        # exemption rationale in .perlcriticrc).
         open my $fh, '<', \$body;
         $env->{'psgi.input'}   = $fh;
         $env->{CONTENT_LENGTH} = length($body);

--- a/lib/SignalWire/Security/WebhookMiddleware.pm
+++ b/lib/SignalWire/Security/WebhookMiddleware.pm
@@ -46,7 +46,7 @@ package SignalWire::Security::WebhookMiddleware;
 use strict;
 use warnings;
 
-use Carp qw(croak);
+use Carp                                   qw(croak);
 use SignalWire::Security::WebhookValidator qw(validate_webhook_signature);
 
 # ``wrap`` returns a PSGI app that performs validation and forwards
@@ -61,14 +61,14 @@ use SignalWire::Security::WebhookValidator qw(validate_webhook_signature);
 #   public_url_base => string           (overrides everything; usually for
 #                                        tests)
 sub wrap {
-    my ($class, %opts) = @_;
+    my ( $class, %opts ) = @_;
     my $app = $opts{app} or croak "wrap: 'app' is required";
     croak "wrap: 'app' must be a CODE ref" unless ref($app) eq 'CODE';
 
-    my $signing_key = $opts{signing_key};
-    my $paths       = $opts{paths};                # arrayref or undef
-    my $methods     = $opts{methods} || ['POST'];
-    my $trust_proxy = exists $opts{trust_proxy} ? $opts{trust_proxy} : 1;
+    my $signing_key     = $opts{signing_key};
+    my $paths           = $opts{paths};                                         # arrayref or undef
+    my $methods         = $opts{methods} || ['POST'];
+    my $trust_proxy     = exists $opts{trust_proxy} ? $opts{trust_proxy} : 1;
     my $public_url_base = $opts{public_url_base};
 
     my %method_set = map { uc($_) => 1 } @$methods;
@@ -77,7 +77,7 @@ sub wrap {
 
     # If no signing key, this middleware is a no-op. (AgentBase emits the
     # warning at startup; we don't double-log here.)
-    if (!defined $signing_key || $signing_key eq '') {
+    if ( !defined $signing_key || $signing_key eq '' ) {
         return $app;
     }
 
@@ -85,15 +85,15 @@ sub wrap {
         my $env = shift;
 
         # Method gating: only validate POST (or whichever methods caller asked).
-        my $method = uc($env->{REQUEST_METHOD} || 'GET');
-        if (!$method_set{$method}) {
+        my $method = uc( $env->{REQUEST_METHOD} || 'GET' );
+        if ( !$method_set{$method} ) {
             return $app->($env);
         }
 
         # Path gating: if a whitelist was configured, only those paths
         # require a signature; everything else passes through.
         my $path = $env->{PATH_INFO} || '/';
-        if (%path_set && !$path_set{$path}) {
+        if ( %path_set && !$path_set{$path} ) {
             return $app->($env);
         }
 
@@ -104,21 +104,17 @@ sub wrap {
 
         # Header lookup: prefer X-SignalWire-Signature, fall back to
         # X-Twilio-Signature for cXML compat.
-        my $sig = $env->{HTTP_X_SIGNALWIRE_SIGNATURE}
-               // $env->{HTTP_X_TWILIO_SIGNATURE}
-               // '';
+        my $sig = $env->{HTTP_X_SIGNALWIRE_SIGNATURE} // $env->{HTTP_X_TWILIO_SIGNATURE} // '';
 
-        if ($sig eq '') {
-            return [403, ['Content-Type' => 'text/plain'], ['Forbidden']];
+        if ( $sig eq '' ) {
+            return [ 403, [ 'Content-Type' => 'text/plain' ], ['Forbidden'] ];
         }
 
-        my $url = _reconstruct_url($env, $trust_proxy, $public_url_base);
+        my $url = _reconstruct_url( $env, $trust_proxy, $public_url_base );
 
-        my $ok = eval {
-            validate_webhook_signature($signing_key, $sig, $url, $raw_body);
-        };
-        if ($@ || !$ok) {
-            return [403, ['Content-Type' => 'text/plain'], ['Forbidden']];
+        my $ok = eval { validate_webhook_signature( $signing_key, $sig, $url, $raw_body ); };
+        if ( $@ || !$ok ) {
+            return [ 403, [ 'Content-Type' => 'text/plain' ], ['Forbidden'] ];
         }
 
         return $app->($env);
@@ -134,36 +130,35 @@ sub _slurp_body {
 
     my $body = '';
     my $buf;
+
     # Limit to CONTENT_LENGTH if present so we don't hang on a streaming
     # source, but still allow chunked / unknown-length when not.
     my $cl = $env->{CONTENT_LENGTH};
-    if (defined $cl && $cl =~ /\A\d+\z/) {
+    if ( defined $cl && $cl =~ /\A\d+\z/ ) {
         my $remaining = $cl;
-        while ($remaining > 0) {
+        while ( $remaining > 0 ) {
             my $chunk = $remaining > 8192 ? 8192 : $remaining;
-            my $n = $input->read($buf, $chunk);
+            my $n     = $input->read( $buf, $chunk );
             last unless defined $n && $n > 0;
             $body .= $buf;
             $remaining -= $n;
         }
-    }
-    else {
-        while (my $n = $input->read($buf, 8192)) {
+    } else {
+        while ( my $n = $input->read( $buf, 8192 ) ) {
             $body .= $buf;
         }
     }
 
     # Rewind so downstream code can re-read. If seek isn't supported,
     # swap in a string-handle pointing at the buffered body.
-    if ($input->can('seek')) {
-        eval { $input->seek(0, 0) };
+    if ( $input->can('seek') ) {
+        eval { $input->seek( 0, 0 ) };
     }
-    if ($@ || !$input->can('seek')) {
+    if ( $@ || !$input->can('seek') ) {
         open my $fh, '<', \$body;
-        $env->{'psgi.input'} = $fh;
+        $env->{'psgi.input'}   = $fh;
         $env->{CONTENT_LENGTH} = length($body);
-    }
-    elsif (!defined $cl) {
+    } elsif ( !defined $cl ) {
         $env->{CONTENT_LENGTH} = length($body);
     }
 
@@ -172,40 +167,42 @@ sub _slurp_body {
 
 # Reconstruct the full public URL SignalWire actually POSTed to.
 sub _reconstruct_url {
-    my ($env, $trust_proxy, $public_url_base) = @_;
+    my ( $env, $trust_proxy, $public_url_base ) = @_;
 
     # 1) Explicit override (caller / config / tests).
-    if (defined $public_url_base && $public_url_base ne '') {
-        return _join_base_path($public_url_base, $env);
+    if ( defined $public_url_base && $public_url_base ne '' ) {
+        return _join_base_path( $public_url_base, $env );
     }
 
     # 2) SWML_PROXY_URL_BASE env var (per spec).
-    if (defined $ENV{SWML_PROXY_URL_BASE} && $ENV{SWML_PROXY_URL_BASE} ne '') {
-        return _join_base_path($ENV{SWML_PROXY_URL_BASE}, $env);
+    if ( defined $ENV{SWML_PROXY_URL_BASE} && $ENV{SWML_PROXY_URL_BASE} ne '' ) {
+        return _join_base_path( $ENV{SWML_PROXY_URL_BASE}, $env );
     }
 
     # 3) X-Forwarded-* headers when trust_proxy is on.
-    my ($scheme, $host);
+    my ( $scheme, $host );
     if ($trust_proxy) {
         my $xfp = $env->{HTTP_X_FORWARDED_PROTO};
         my $xfh = $env->{HTTP_X_FORWARDED_HOST};
-        if ($xfp && $xfh) {
-            ($scheme, $host) = ($xfp, $xfh);
+        if ( $xfp && $xfh ) {
+            ( $scheme, $host ) = ( $xfp, $xfh );
         }
     }
 
     # 4) Fallback to raw request fields.
     $scheme //= $env->{'psgi.url_scheme'} // 'http';
     $host   //= $env->{HTTP_HOST}
-              // (($env->{SERVER_NAME} // 'localhost') . ':'
-                  . ($env->{SERVER_PORT} // '80'));
+        // ( ( $env->{SERVER_NAME} // 'localhost' ) . ':' . ( $env->{SERVER_PORT} // '80' ) );
 
-    my $req_uri = defined $env->{REQUEST_URI} && $env->{REQUEST_URI} ne ''
-        ? $env->{REQUEST_URI}
-        : (($env->{PATH_INFO} // '/')
-            . (defined $env->{QUERY_STRING} && $env->{QUERY_STRING} ne ''
-               ? '?' . $env->{QUERY_STRING}
-               : ''));
+    my $req_uri =
+        defined $env->{REQUEST_URI} && $env->{REQUEST_URI} ne '' ? $env->{REQUEST_URI}
+        : (
+        ( $env->{PATH_INFO} // '/' )
+        . (
+            defined $env->{QUERY_STRING} && $env->{QUERY_STRING} ne '' ? '?' . $env->{QUERY_STRING}
+            : ''
+        )
+        );
 
     return "$scheme://$host$req_uri";
 }
@@ -213,14 +210,17 @@ sub _reconstruct_url {
 # Join an external base ("https://foo.ngrok.io") with the path+query
 # from the request env.
 sub _join_base_path {
-    my ($base, $env) = @_;
+    my ( $base, $env ) = @_;
     $base =~ s{/+\z}{};
-    my $req_uri = defined $env->{REQUEST_URI} && $env->{REQUEST_URI} ne ''
-        ? $env->{REQUEST_URI}
-        : (($env->{PATH_INFO} // '/')
-            . (defined $env->{QUERY_STRING} && $env->{QUERY_STRING} ne ''
-               ? '?' . $env->{QUERY_STRING}
-               : ''));
+    my $req_uri =
+        defined $env->{REQUEST_URI} && $env->{REQUEST_URI} ne '' ? $env->{REQUEST_URI}
+        : (
+        ( $env->{PATH_INFO} // '/' )
+        . (
+            defined $env->{QUERY_STRING} && $env->{QUERY_STRING} ne '' ? '?' . $env->{QUERY_STRING}
+            : ''
+        )
+        );
     return $base . $req_uri;
 }
 

--- a/lib/SignalWire/Security/WebhookValidator.pm
+++ b/lib/SignalWire/Security/WebhookValidator.pm
@@ -24,11 +24,11 @@ package SignalWire::Security::WebhookValidator;
 use strict;
 use warnings;
 
-use Carp qw(croak);
-use Digest::SHA qw(hmac_sha1 hmac_sha1_hex sha256_hex);
+use Carp         qw(croak);
+use Digest::SHA  qw(hmac_sha1 hmac_sha1_hex sha256_hex);
 use MIME::Base64 qw(encode_base64);
 use Scalar::Util qw(blessed reftype);
-use URI ();
+use URI          ();
 
 use Exporter qw(import);
 our @EXPORT_OK = qw(validate_webhook_signature validate_request);
@@ -38,13 +38,13 @@ our @EXPORT_OK = qw(validate_webhook_signature validate_request);
 # ---------------------------------------------------------------------------
 
 sub _hex_hmac_sha1 {
-    my ($key, $message) = @_;
-    return hmac_sha1_hex($message, $key);
+    my ( $key, $message ) = @_;
+    return hmac_sha1_hex( $message, $key );
 }
 
 sub _b64_hmac_sha1 {
-    my ($key, $message) = @_;
-    return encode_base64(hmac_sha1($message, $key), '');
+    my ( $key, $message ) = @_;
+    return encode_base64( hmac_sha1( $message, $key ), '' );
 }
 
 # Constant-time string comparison. Both args are stringified. Returns
@@ -54,14 +54,14 @@ sub _b64_hmac_sha1 {
 # Length mismatch returns 0 immediately, which matches what
 # ``hmac.compare_digest`` does in Python (it also requires equal length).
 sub _safe_eq {
-    my ($a, $b) = @_;
+    my ( $a, $b ) = @_;
     return 0 unless defined $a && defined $b;
     $a = "$a";
     $b = "$b";
     return 0 if length($a) != length($b);
     my $diff = 0;
-    for my $i (0 .. length($a) - 1) {
-        $diff |= ord(substr($a, $i, 1)) ^ ord(substr($b, $i, 1));
+    for my $i ( 0 .. length($a) - 1 ) {
+        $diff |= ord( substr( $a, $i, 1 ) ) ^ ord( substr( $b, $i, 1 ) );
     }
     return $diff == 0 ? 1 : 0;
 }
@@ -72,25 +72,28 @@ sub _safe_eq {
 sub _parse_form_body {
     my ($raw_body) = @_;
     return [] unless defined $raw_body && length $raw_body;
+
     # Reject anything with control bytes or things that obviously aren't
     # form data (e.g. JSON starting with { or [) — Scheme B falls back
     # to empty params in that case.
     return [] if $raw_body =~ /\A\s*[\{\[]/;
 
     my @pairs;
-    for my $chunk (split /&/, $raw_body) {
+    for my $chunk ( split /&/, $raw_body ) {
         next if $chunk eq '';
-        my ($k, $v) = split(/=/, $chunk, 2);
+        my ( $k, $v ) = split( /=/, $chunk, 2 );
         $v = '' unless defined $v;
+
         # Percent-decode plus '+' -> ' ' per application/x-www-form-urlencoded.
-        for my $s ($k, $v) {
+        for my $s ( $k, $v ) {
             $s =~ tr/+/ /;
             $s =~ s/%([0-9A-Fa-f]{2})/chr(hex($1))/ge;
         }
+
         # Disqualify the body as form data if any decoded byte is binary
         # garbage; the canonical Scheme A bodies are JSON and shouldn't
         # produce a meaningful pair list anyway.
-        push @pairs, [$k, $v];
+        push @pairs, [ $k, $v ];
     }
     return \@pairs;
 }
@@ -108,28 +111,24 @@ sub _sorted_concat_params {
 
     my @items;
     my $ref = ref($params);
-    if ($ref eq 'HASH') {
-        for my $k (keys %$params) {
+    if ( $ref eq 'HASH' ) {
+        for my $k ( keys %$params ) {
             my $v = $params->{$k};
-            if (ref($v) eq 'ARRAY') {
-                push @items, [$k, defined($_) ? "$_" : ''] for @$v;
-            }
-            else {
-                push @items, [$k, defined($v) ? "$v" : ''];
+            if ( ref($v) eq 'ARRAY' ) {
+                push @items, [ $k, defined($_) ? "$_" : '' ] for @$v;
+            } else {
+                push @items, [ $k, defined($v) ? "$v" : '' ];
             }
         }
-    }
-    elsif ($ref eq 'ARRAY') {
+    } elsif ( $ref eq 'ARRAY' ) {
         for my $pair (@$params) {
-            if (ref($pair) eq 'ARRAY' && @$pair >= 2) {
-                push @items, [$pair->[0], defined($pair->[1]) ? "$pair->[1]" : ''];
-            }
-            elsif (ref($pair) eq 'ARRAY' && @$pair == 1) {
-                push @items, [$pair->[0], ''];
+            if ( ref($pair) eq 'ARRAY' && @$pair >= 2 ) {
+                push @items, [ $pair->[0], defined( $pair->[1] ) ? "$pair->[1]" : '' ];
+            } elsif ( ref($pair) eq 'ARRAY' && @$pair == 1 ) {
+                push @items, [ $pair->[0], '' ];
             }
         }
-    }
-    else {
+    } else {
         return '';
     }
 
@@ -149,23 +148,24 @@ sub _sorted_concat_params {
 
 # Split URL into a hashref with the fields we need. Uses URI for parsing.
 sub _split_url {
-    my ($url) = @_;
-    my $u = URI->new($url);
+    my ($url)  = @_;
+    my $u      = URI->new($url);
     my $scheme = $u->scheme // '';
     my $host   = '';
     my $port   = '';
-    if ($u->can('host')) {
+    if ( $u->can('host') ) {
         $host = $u->host // '';
     }
+
     # URI::http / URI::https sets default_port — distinguish "no explicit
     # port" from "explicit standard port" by checking the raw authority.
-    my $authority = $u->can('authority') ? ($u->authority // '') : '';
-    if ($authority =~ /:(\d+)\z/) {
+    my $authority = $u->can('authority') ? ( $u->authority // '' ) : '';
+    if ( $authority =~ /:(\d+)\z/ ) {
         $port = $1;
     }
-    my $path     = $u->can('path')     ? ($u->path     // '') : '';
-    my $query    = $u->can('query')    ? ($u->query    // '') : '';
-    my $fragment = $u->can('fragment') ? ($u->fragment // '') : '';
+    my $path     = $u->can('path')     ? ( $u->path     // '' ) : '';
+    my $query    = $u->can('query')    ? ( $u->query    // '' ) : '';
+    my $fragment = $u->can('fragment') ? ( $u->fragment // '' ) : '';
     return {
         scheme   => $scheme,
         host     => $host,
@@ -181,7 +181,7 @@ sub _split_url {
 sub _build_url {
     my (%p) = @_;
     my $host = $p{host} // '';
-    if ($host =~ /:/ && $host !~ /^\[/) {
+    if ( $host =~ /:/ && $host !~ /^\[/ ) {
         $host = "[$host]";
     }
     my $netloc = $host;
@@ -190,8 +190,8 @@ sub _build_url {
     my $url = '';
     $url .= $p{scheme} . '://' if $p{scheme} ne '';
     $url .= $netloc;
-    $url .= $p{path} if defined $p{path};
-    $url .= '?' . $p{query} if defined $p{query} && $p{query} ne '';
+    $url .= $p{path}           if defined $p{path};
+    $url .= '?' . $p{query}    if defined $p{query}    && $p{query} ne '';
     $url .= '#' . $p{fragment} if defined $p{fragment} && $p{fragment} ne '';
     return $url;
 }
@@ -208,17 +208,16 @@ sub _candidate_urls {
     my $parts = _split_url($url);
     return [$url] unless $parts->{host};
 
-    my %standard = (http => '80', https => '443');
-    my $std = $standard{ lc($parts->{scheme}) };
-    my @cands = ($url);
+    my %standard = ( http => '80', https => '443' );
+    my $std      = $standard{ lc( $parts->{scheme} ) };
+    my @cands    = ($url);
 
-    if (defined $std) {
-        if ($parts->{port} eq '') {
-            my $with = _build_url(%$parts, port => $std);
+    if ( defined $std ) {
+        if ( $parts->{port} eq '' ) {
+            my $with = _build_url( %$parts, port => $std );
             push @cands, $with if $with ne $url;
-        }
-        elsif ($parts->{port} eq $std) {
-            my $without = _build_url(%$parts, port => '');
+        } elsif ( $parts->{port} eq $std ) {
+            my $without = _build_url( %$parts, port => '' );
             push @cands, $without if $without ne $url;
         }
     }
@@ -229,19 +228,19 @@ sub _candidate_urls {
 # Returns 1 when the param is absent or matches; 0 only when present
 # and mismatches.
 sub _check_body_sha256 {
-    my ($url, $raw_body) = @_;
+    my ( $url, $raw_body ) = @_;
     my $parts = _split_url($url);
     return 1 if $parts->{query} eq '';
     my $expected;
-    for my $pair (split /&/, $parts->{query}) {
-        my ($k, $v) = split(/=/, $pair, 2);
+    for my $pair ( split /&/, $parts->{query} ) {
+        my ( $k, $v ) = split( /=/, $pair, 2 );
         next unless defined $k && $k eq 'bodySHA256';
         $expected = defined $v ? $v : '';
         last;
     }
     return 1 unless defined $expected;
-    my $actual = sha256_hex(defined $raw_body ? $raw_body : '');
-    return _safe_eq($actual, $expected);
+    my $actual = sha256_hex( defined $raw_body ? $raw_body : '' );
+    return _safe_eq( $actual, $expected );
 }
 
 # ---------------------------------------------------------------------------
@@ -258,7 +257,7 @@ sub _check_body_sha256 {
 # Croaks when ``$raw_body`` is a reference (e.g. parsed dict by mistake).
 # Returns 0 when ``$signature`` is missing/empty (never throws).
 sub validate_webhook_signature {
-    my ($signing_key, $signature, $url, $raw_body) = @_;
+    my ( $signing_key, $signature, $url, $raw_body ) = @_;
     croak "signing_key is required"
         unless defined $signing_key && length $signing_key;
     croak "raw_body must be a string -- did you pass a parsed reference by mistake?"
@@ -271,8 +270,8 @@ sub validate_webhook_signature {
     # ------------------------------------------------------------------
     # Scheme A — RELAY/SWML/JSON: hex(HMAC-SHA1(key, url + raw_body))
     # ------------------------------------------------------------------
-    my $expected_a = _hex_hmac_sha1($signing_key, $url . $raw_body);
-    return 1 if _safe_eq($expected_a, $signature);
+    my $expected_a = _hex_hmac_sha1( $signing_key, $url . $raw_body );
+    return 1 if _safe_eq( $expected_a, $signature );
 
     # ------------------------------------------------------------------
     # Scheme B — Compat/cXML form: base64(HMAC-SHA1(key, url + sorted_concat_params))
@@ -280,15 +279,17 @@ sub validate_webhook_signature {
     # Try both with-port and without-port URL variants.
     # ------------------------------------------------------------------
     my $parsed = _parse_form_body($raw_body);
-    my @shapes = ($parsed, []);
+    my @shapes = ( $parsed, [] );
 
-    for my $candidate_url (@{ _candidate_urls($url) }) {
+    for my $candidate_url ( @{ _candidate_urls($url) } ) {
         for my $shape (@shapes) {
             my $concat   = _sorted_concat_params($shape);
-            my $expected = _b64_hmac_sha1($signing_key, $candidate_url . $concat);
-            if (_safe_eq($expected, $signature)) {
+            my $expected = _b64_hmac_sha1( $signing_key, $candidate_url . $concat );
+            if ( _safe_eq( $expected, $signature ) ) {
+
                 # If URL carries bodySHA256, body hash must also match.
-                return 1 if _check_body_sha256($candidate_url, $raw_body);
+                return 1 if _check_body_sha256( $candidate_url, $raw_body );
+
                 # bodySHA256 mismatched; keep trying.
             }
         }
@@ -307,35 +308,35 @@ sub validate_webhook_signature {
 #     and runs Scheme B directly (with URL port normalization).
 #   - Anything else (other ref types): croaks with a clear message.
 sub validate_request {
-    my ($signing_key, $signature, $url, $params_or_raw_body) = @_;
+    my ( $signing_key, $signature, $url, $params_or_raw_body ) = @_;
     croak "signing_key is required"
         unless defined $signing_key && length $signing_key;
     return 0 unless defined $signature && length $signature;
 
     $url = '' unless defined $url;
 
-    if (!defined $params_or_raw_body) {
+    if ( !defined $params_or_raw_body ) {
         $params_or_raw_body = [];
     }
 
     my $ref = ref($params_or_raw_body);
 
-    if (!$ref) {
+    if ( !$ref ) {
+
         # Plain scalar string -> delegate to combined validator.
-        return validate_webhook_signature($signing_key, $signature, $url,
-            $params_or_raw_body);
+        return validate_webhook_signature( $signing_key, $signature, $url, $params_or_raw_body );
     }
 
-    if ($ref ne 'HASH' && $ref ne 'ARRAY') {
+    if ( $ref ne 'HASH' && $ref ne 'ARRAY' ) {
         croak "params_or_raw_body must be a string (raw body) or a "
             . "hashref/arrayref of form params";
     }
 
     # Pre-parsed form params -> Scheme B only, all candidate URLs.
     my $concat = _sorted_concat_params($params_or_raw_body);
-    for my $candidate_url (@{ _candidate_urls($url) }) {
-        my $expected = _b64_hmac_sha1($signing_key, $candidate_url . $concat);
-        return 1 if _safe_eq($expected, $signature);
+    for my $candidate_url ( @{ _candidate_urls($url) } ) {
+        my $expected = _b64_hmac_sha1( $signing_key, $candidate_url . $concat );
+        return 1 if _safe_eq( $expected, $signature );
     }
     return 0;
 }

--- a/lib/SignalWire/Security/WebhookValidator.pm
+++ b/lib/SignalWire/Security/WebhookValidator.pm
@@ -54,14 +54,14 @@ sub _b64_hmac_sha1 {
 # Length mismatch returns 0 immediately, which matches what
 # ``hmac.compare_digest`` does in Python (it also requires equal length).
 sub _safe_eq {
-    my ( $a, $b ) = @_;
-    return 0 unless defined $a && defined $b;
-    $a = "$a";
-    $b = "$b";
-    return 0 if length($a) != length($b);
+    my ( $lhs, $rhs ) = @_;
+    return 0 unless defined $lhs && defined $rhs;
+    $lhs = "$lhs";
+    $rhs = "$rhs";
+    return 0 if length($lhs) != length($rhs);
     my $diff = 0;
-    for my $i ( 0 .. length($a) - 1 ) {
-        $diff |= ord( substr( $a, $i, 1 ) ) ^ ord( substr( $b, $i, 1 ) );
+    for my $i ( 0 .. length($lhs) - 1 ) {
+        $diff |= ord( substr( $lhs, $i, 1 ) ) ^ ord( substr( $rhs, $i, 1 ) );
     }
     return $diff == 0 ? 1 : 0;
 }

--- a/lib/SignalWire/Server/AgentServer.pm
+++ b/lib/SignalWire/Server/AgentServer.pm
@@ -1,4 +1,5 @@
 package SignalWire::Server::AgentServer;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 
@@ -9,26 +10,26 @@ use JSON qw(encode_json decode_json);
 use Carp qw(croak);
 use File::Spec;
 
-has host      => (is => 'rw', default => sub { '0.0.0.0' });
-has port      => (is => 'rw', default => sub { $ENV{PORT} || 3000 });
-has log_level => (is => 'rw', default => sub { 'info' });
-has agents    => (is => 'rw', default => sub { {} });
+has host      => ( is => 'rw', default => sub { '0.0.0.0' } );
+has port      => ( is => 'rw', default => sub { $ENV{PORT} || 3000 } );
+has log_level => ( is => 'rw', default => sub { 'info' } );
+has agents    => ( is => 'rw', default => sub { {} } );
 
 # SIP routing
-has _sip_routing_enabled  => (is => 'rw', default => sub { 0 });
-has _sip_username_mapping => (is => 'rw', default => sub { {} });
+has _sip_routing_enabled  => ( is => 'rw', default => sub { 0 } );
+has _sip_username_mapping => ( is => 'rw', default => sub { {} } );
 
 # Static file routes: { route => directory }
-has _static_routes => (is => 'rw', default => sub { {} });
+has _static_routes => ( is => 'rw', default => sub { {} } );
 
 sub register {
-    my ($self, $agent, $route) = @_;
+    my ( $self, $agent, $route ) = @_;
 
     $route //= $agent->route;
     $route = "/$route" unless $route =~ m{^/};
     $route =~ s{/+$}{} unless $route eq '/';
 
-    if (exists $self->agents->{$route}) {
+    if ( exists $self->agents->{$route} ) {
         croak("Route '$route' is already registered");
     }
 
@@ -38,7 +39,7 @@ sub register {
 }
 
 sub unregister {
-    my ($self, $route) = @_;
+    my ( $self, $route ) = @_;
     $route = "/$route" unless $route =~ m{^/};
     $route =~ s{/+$}{} unless $route eq '/';
     delete $self->agents->{$route};
@@ -51,15 +52,15 @@ sub list_agents {
 }
 
 sub get_agent {
-    my ($self, $route) = @_;
+    my ( $self, $route ) = @_;
     return $self->agents->{$route};
 }
 
 sub serve_static_files {
-    my ($self, $directory, $route) = @_;
+    my ( $self, $directory, $route ) = @_;
 
-    croak("serve_static_files requires a directory") unless defined $directory;
-    croak("serve_static_files requires a route")     unless defined $route;
+    croak("serve_static_files requires a directory")      unless defined $directory;
+    croak("serve_static_files requires a route")          unless defined $route;
     croak("Static directory '$directory' does not exist") unless -d $directory;
 
     $route = "/$route" unless $route =~ m{^/};
@@ -83,95 +84,123 @@ sub _build_psgi_app {
 
     # MIME type mapping for static files
     my %mime_types = (
-        html => 'text/html',
-        htm  => 'text/html',
-        css  => 'text/css',
-        js   => 'application/javascript',
-        json => 'application/json',
-        png  => 'image/png',
-        jpg  => 'image/jpeg',
-        jpeg => 'image/jpeg',
-        gif  => 'image/gif',
-        svg  => 'image/svg+xml',
-        ico  => 'image/x-icon',
-        txt  => 'text/plain',
-        pdf  => 'application/pdf',
-        xml  => 'application/xml',
-        woff => 'font/woff',
+        html  => 'text/html',
+        htm   => 'text/html',
+        css   => 'text/css',
+        js    => 'application/javascript',
+        json  => 'application/json',
+        png   => 'image/png',
+        jpg   => 'image/jpeg',
+        jpeg  => 'image/jpeg',
+        gif   => 'image/gif',
+        svg   => 'image/svg+xml',
+        ico   => 'image/x-icon',
+        txt   => 'text/plain',
+        pdf   => 'application/pdf',
+        xml   => 'application/xml',
+        woff  => 'font/woff',
         woff2 => 'font/woff2',
-        ttf  => 'font/ttf',
-        eot  => 'application/vnd.ms-fontobject',
+        ttf   => 'font/ttf',
+        eot   => 'application/vnd.ms-fontobject',
     );
 
     # Build a plain PSGI app with route dispatch
     my $core_app = sub {
-        my $env = shift;
+        my $env  = shift;
         my $path = $env->{PATH_INFO} // '/';
         $path =~ s{/+$}{} unless $path eq '/';
 
         # Health/ready (no auth)
-        if ($path eq '/health') {
+        if ( $path eq '/health' ) {
             my @agent_names = map { $server->agents->{$_}->name }
-                              sort keys %{ $server->agents };
-            return [200, ['Content-Type' => 'application/json'],
-                [encode_json({ status => 'healthy', agents => \@agent_names })]];
+                sort keys %{ $server->agents };
+            return [
+                200,
+                [ 'Content-Type' => 'application/json' ],
+                [ encode_json( { status => 'healthy', agents => \@agent_names } ) ]
+            ];
         }
-        if ($path eq '/ready') {
-            return [200, ['Content-Type' => 'application/json'],
-                [encode_json({ status => 'ready' })]];
+        if ( $path eq '/ready' ) {
+            return [
+                200,
+                [ 'Content-Type' => 'application/json' ],
+                [ encode_json( { status => 'ready' } ) ]
+            ];
         }
 
         # Check static file routes (longest prefix match)
-        for my $static_route (sort { length($b) <=> length($a) } keys %{ $server->_static_routes }) {
+        for my $static_route (
+            sort { length($b) <=> length($a) }
+            keys %{ $server->_static_routes }
+            )
+        {
             my $prefix = $static_route eq '/' ? '' : $static_route;
-            if ($path eq $static_route || index($path, "$prefix/") == 0 || ($static_route eq '/' && $path =~ m{^/})) {
+            if (   $path eq $static_route
+                || index( $path, "$prefix/" ) == 0
+                || ( $static_route eq '/' && $path =~ m{^/} ) )
+            {
                 next if $static_route eq '/' && $path eq '/';
-                my $rel_path = substr($path, length($prefix));
+                my $rel_path = substr( $path, length($prefix) );
                 $rel_path =~ s{^/}{};
 
                 # Path traversal protection: reject ".." components
-                if ($rel_path =~ m{(?:^|/)\.\.(?:/|$)}) {
-                    return [403, [
-                        'Content-Type'            => 'text/plain',
-                        'X-Content-Type-Options'  => 'nosniff',
-                        'X-Frame-Options'         => 'DENY',
-                        'Cache-Control'           => 'no-store',
-                    ], ['Forbidden']];
+                if ( $rel_path =~ m{(?:^|/)\.\.(?:/|$)} ) {
+                    return [
+                        403,
+                        [
+                            'Content-Type'           => 'text/plain',
+                            'X-Content-Type-Options' => 'nosniff',
+                            'X-Frame-Options'        => 'DENY',
+                            'Cache-Control'          => 'no-store',
+                        ],
+                        ['Forbidden']
+                    ];
                 }
 
-                my $base_dir = $server->_static_routes->{$static_route};
-                my $file_path = File::Spec->catfile($base_dir, split(m{/}, $rel_path));
+                my $base_dir  = $server->_static_routes->{$static_route};
+                my $file_path = File::Spec->catfile( $base_dir, split( m{/}, $rel_path ) );
 
                 # Resolve to absolute and verify it's within the base directory
                 my $abs_path = File::Spec->rel2abs($file_path);
-                unless (index($abs_path, $base_dir) == 0) {
-                    return [403, [
-                        'Content-Type'            => 'text/plain',
-                        'X-Content-Type-Options'  => 'nosniff',
-                        'X-Frame-Options'         => 'DENY',
-                        'Cache-Control'           => 'no-store',
-                    ], ['Forbidden']];
+                unless ( index( $abs_path, $base_dir ) == 0 ) {
+                    return [
+                        403,
+                        [
+                            'Content-Type'           => 'text/plain',
+                            'X-Content-Type-Options' => 'nosniff',
+                            'X-Frame-Options'        => 'DENY',
+                            'Cache-Control'          => 'no-store',
+                        ],
+                        ['Forbidden']
+                    ];
                 }
 
-                if (-f $abs_path && -r $abs_path) {
+                if ( -f $abs_path && -r $abs_path ) {
+
                     # Determine MIME type from extension
-                    my ($ext) = ($abs_path =~ /\.(\w+)$/);
-                    $ext = lc($ext // '');
+                    my ($ext) = ( $abs_path =~ /\.(\w+)$/ );
+                    $ext = lc( $ext // '' );
                     my $content_type = $mime_types{$ext} // 'application/octet-stream';
 
-                    open my $fh, '<:raw', $abs_path or
-                        return [500, ['Content-Type' => 'text/plain'], ['Internal Server Error']];
+                    open my $fh, '<:raw',
+                        $abs_path
+                        or return [ 500, [ 'Content-Type' => 'text/plain' ],
+                        ['Internal Server Error'] ];
                     local $/;
                     my $content = <$fh>;
                     close $fh;
 
-                    return [200, [
-                        'Content-Type'            => $content_type,
-                        'Content-Length'           => length($content),
-                        'X-Content-Type-Options'  => 'nosniff',
-                        'X-Frame-Options'         => 'DENY',
-                        'Cache-Control'           => 'no-store',
-                    ], [$content]];
+                    return [
+                        200,
+                        [
+                            'Content-Type'           => $content_type,
+                            'Content-Length'         => length($content),
+                            'X-Content-Type-Options' => 'nosniff',
+                            'X-Frame-Options'        => 'DENY',
+                            'Cache-Control'          => 'no-store',
+                        ],
+                        [$content]
+                    ];
                 }
 
                 # Static route matched but file not found - fall through
@@ -180,32 +209,35 @@ sub _build_psgi_app {
 
         # Find matching agent by longest prefix
         my $matched_route;
-        for my $route (sort { length($b) <=> length($a) } keys %{ $server->agents }) {
-            if ($route eq '/') {
+        for my $route ( sort { length($b) <=> length($a) } keys %{ $server->agents } ) {
+            if ( $route eq '/' ) {
                 $matched_route = $route;
                 last;
             }
-            if ($path eq $route || index($path, "$route/") == 0) {
+            if ( $path eq $route || index( $path, "$route/" ) == 0 ) {
                 $matched_route = $route;
                 last;
             }
         }
 
-        if (defined $matched_route) {
+        if ( defined $matched_route ) {
             my $agent     = $server->agents->{$matched_route};
             my $agent_app = $agent->psgi_app;
             return $agent_app->($env);
         }
 
-        return [404, ['Content-Type' => 'application/json'],
-            [encode_json({ error => 'Not Found' })]];
+        return [
+            404,
+            [ 'Content-Type' => 'application/json' ],
+            [ encode_json( { error => 'Not Found' } ) ]
+        ];
     };
 
     # Wrap with security headers
     return sub {
         my $env = shift;
         my $res = $core_app->($env);
-        if (ref $res eq 'ARRAY') {
+        if ( ref $res eq 'ARRAY' ) {
             push @{ $res->[1] },
                 'X-Content-Type-Options' => 'nosniff',
                 'X-Frame-Options'        => 'DENY',
@@ -216,7 +248,7 @@ sub _build_psgi_app {
 }
 
 sub run {
-    my ($self, %opts) = @_;
+    my ( $self, %opts ) = @_;
     my $app  = $self->psgi_app;
     my $host = $opts{host} // $self->host;
     my $port = $opts{port} // $self->port;
@@ -229,9 +261,9 @@ sub run {
     #     analogue of Python web_service.start(ssl_cert=, ssl_key=).
     #   * Otherwise the SWML_SSL_* environment variables: TLS only when
     #     SWML_SSL_ENABLED is truthy AND both cert + key paths resolve.
-    my ($cert, $key) = _resolve_tls(\%opts);
-    if (defined $cert && defined $key) {
-        return _run_tls($app, $host, $port, $cert, $key);
+    my ( $cert, $key ) = _resolve_tls( \%opts );
+    if ( defined $cert && defined $key ) {
+        return _run_tls( $app, $host, $port, $cert, $key );
     }
 
     require Plack::Runner;
@@ -250,20 +282,20 @@ sub run {
 # AND both cert + key paths are set), exactly matching the Python reference.
 sub _resolve_tls {
     my ($opts) = @_;
-    my $cert = $opts->{ssl_cert} // $opts->{ssl_cert_path};
-    my $key  = $opts->{ssl_key}  // $opts->{ssl_key_path};
-    if (defined $cert && length $cert && defined $key && length $key) {
-        return ($cert, $key);
+    my $cert   = $opts->{ssl_cert} // $opts->{ssl_cert_path};
+    my $key    = $opts->{ssl_key}  // $opts->{ssl_key_path};
+    if ( defined $cert && length $cert && defined $key && length $key ) {
+        return ( $cert, $key );
     }
-    my $enabled = lc($ENV{SWML_SSL_ENABLED} // '');
-    if ($enabled eq 'true' || $enabled eq '1' || $enabled eq 'yes') {
+    my $enabled = lc( $ENV{SWML_SSL_ENABLED} // '' );
+    if ( $enabled eq 'true' || $enabled eq '1' || $enabled eq 'yes' ) {
         my $ecert = $ENV{SWML_SSL_CERT_PATH};
         my $ekey  = $ENV{SWML_SSL_KEY_PATH};
-        if (defined $ecert && length $ecert && defined $ekey && length $ekey) {
-            return ($ecert, $ekey);
+        if ( defined $ecert && length $ecert && defined $ekey && length $ekey ) {
+            return ( $ecert, $ekey );
         }
     }
-    return (undef, undef);
+    return ( undef, undef );
 }
 
 # Serve $app over HTTPS by building an IO::Socket::SSL listen socket from the
@@ -272,20 +304,21 @@ sub _resolve_tls {
 # from it). IO::Socket::SSL is already a hard dependency (used by the RELAY
 # client), so this adds no new dependency. Blocks like the plaintext path.
 sub _run_tls {
-    my ($app, $host, $port, $cert, $key) = @_;
+    my ( $app, $host, $port, $cert, $key ) = @_;
     require IO::Socket::SSL;
     require HTTP::Server::PSGI;
-    no warnings 'once';  # $IO::Socket::SSL::SSL_ERROR is populated at runtime
+    no warnings 'once';    # $IO::Socket::SSL::SSL_ERROR is populated at runtime
 
     my $ssl = IO::Socket::SSL->new(
-        LocalAddr   => $host,
-        LocalPort   => $port,
-        Listen      => 5,
-        ReuseAddr   => 1,
+        LocalAddr     => $host,
+        LocalPort     => $port,
+        Listen        => 5,
+        ReuseAddr     => 1,
         SSL_cert_file => $cert,
         SSL_key_file  => $key,
-    ) or croak("AgentServer: TLS listen on $host:$port failed: "
-             . ($IO::Socket::SSL::SSL_ERROR // $!));
+        )
+        or croak(
+        "AgentServer: TLS listen on $host:$port failed: " . ( $IO::Socket::SSL::SSL_ERROR // $! ) );
 
     my $srv = HTTP::Server::PSGI->new(
         host        => $host,

--- a/lib/SignalWire/Server/AgentServer.pm
+++ b/lib/SignalWire/Server/AgentServer.pm
@@ -273,7 +273,7 @@ sub run {
         '--port'   => $port,
         '--server' => 'HTTP::Server::PSGI',
     );
-    $runner->run($app);
+    return $runner->run($app);
 }
 
 # _resolve_tls(\%opts) -> ($cert, $key) when TLS should be served, else
@@ -325,7 +325,7 @@ sub _run_tls {
         port        => $port,
         listen_sock => $ssl,
     );
-    $srv->run($app);
+    return $srv->run($app);
 }
 
 1;

--- a/lib/SignalWire/Skills/Builtin/ApiNinjasTrivia.pm
+++ b/lib/SignalWire/Skills/Builtin/ApiNinjasTrivia.pm
@@ -1,4 +1,5 @@
 package SignalWire::Skills::Builtin::ApiNinjasTrivia;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -16,11 +17,11 @@ use JSON ();
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('api_ninjas_trivia', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'api_ninjas_trivia', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'api_ninjas_trivia' });
-has '+skill_description' => (default => sub { 'Get trivia questions from API Ninjas' });
-has '+supports_multiple_instances' => (default => sub { 1 });
+has '+skill_name'                  => ( default => sub { 'api_ninjas_trivia' } );
+has '+skill_description'           => ( default => sub { 'Get trivia questions from API Ninjas' } );
+has '+supports_multiple_instances' => ( default => sub { 1 } );
 
 my @ALL_CATEGORIES = qw(
     artliterature language sciencenature general fooddrink
@@ -46,7 +47,7 @@ sub _trivia_url {
 sub setup { 1 }
 
 sub register_tools {
-    my ($self) = @_;
+    my ($self)     = @_;
     my $tool_name  = $self->params->{tool_name}  // 'get_trivia';
     my $api_key    = $self->params->{api_key}    // '';
     my $categories = $self->params->{categories} // [@ALL_CATEGORIES];
@@ -54,50 +55,53 @@ sub register_tools {
     require SignalWire::SWAIG::FunctionResult;
 
     my $no_results = SignalWire::SWAIG::FunctionResult->new(
-        response => 'Sorry, I cannot get trivia questions right now. Please try again later.',
-    )->to_hash;
+        response => 'Sorry, I cannot get trivia questions right now. Please try again later.', )
+        ->to_hash;
     my $on_success = SignalWire::SWAIG::FunctionResult->new(
-        response => 'Category %{array[0].category} question: %{array[0].question} '
-                  . 'Answer: %{array[0].answer}, be sure to give the user time to answer '
-                  . 'before saying the answer.',
-    )->to_hash;
+              response => 'Category %{array[0].category} question: %{array[0].question} '
+            . 'Answer: %{array[0].answer}, be sure to give the user time to answer '
+            . 'before saying the answer.', )->to_hash;
 
     my $url = _trivia_url();
 
-    $self->agent->register_swaig_function({
-        function    => $tool_name,
-        description => "Get trivia questions for " . ($tool_name =~ s/_/ /gr),
-        parameters  => {
-            type       => 'object',
-            properties => {
-                category => {
-                    type        => 'string',
-                    description => 'Category for trivia question. Options: '
-                                 . join('; ', @$categories),
-                    enum => $categories,
+    $self->agent->register_swaig_function(
+        {
+            function    => $tool_name,
+            description => "Get trivia questions for " . ( $tool_name =~ s/_/ /gr ),
+            parameters  => {
+                type       => 'object',
+                properties => {
+                    category => {
+                        type        => 'string',
+                        description => 'Category for trivia question. Options: '
+                            . join( '; ', @$categories ),
+                        enum => $categories,
+                    },
                 },
+                required => ['category'],
             },
-            required => ['category'],
-        },
-        data_map => {
-            webhooks => [{
-                url     => "$url?category=%{args.category}",
-                method  => 'GET',
-                headers => { 'X-Api-Key' => $api_key },
-                output  => $on_success,
-            }],
-            error_keys => ['error'],
-            output     => $no_results,
-        },
-    });
+            data_map => {
+                webhooks => [
+                    {
+                        url     => "$url?category=%{args.category}",
+                        method  => 'GET',
+                        headers => { 'X-Api-Key' => $api_key },
+                        output  => $on_success,
+                    }
+                ],
+                error_keys => ['error'],
+                output     => $no_results,
+            },
+        }
+    );
 }
 
 sub get_parameter_schema {
     return {
         %{ SignalWire::Skills::SkillBase->get_parameter_schema },
         api_key    => { type => 'string', required => 1, hidden => 1 },
-        categories => { type => 'array',  default => [@ALL_CATEGORIES] },
-        tool_name  => { type => 'string', default => 'get_trivia' },
+        categories => { type => 'array',  default  => [@ALL_CATEGORIES] },
+        tool_name  => { type => 'string', default  => 'get_trivia' },
     };
 }
 

--- a/lib/SignalWire/Skills/Builtin/ApiNinjasTrivia.pm
+++ b/lib/SignalWire/Skills/Builtin/ApiNinjasTrivia.pm
@@ -44,7 +44,7 @@ sub _trivia_url {
     return 'https://api.api-ninjas.com/v1/trivia';
 }
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self)     = @_;
@@ -64,7 +64,7 @@ sub register_tools {
 
     my $url = _trivia_url();
 
-    $self->agent->register_swaig_function(
+    return $self->agent->register_swaig_function(
         {
             function    => $tool_name,
             description => "Get trivia questions for " . ( $tool_name =~ s/_/ /gr ),

--- a/lib/SignalWire/Skills/Builtin/ClaudeSkills.pm
+++ b/lib/SignalWire/Skills/Builtin/ClaudeSkills.pm
@@ -11,7 +11,7 @@ has '+skill_name'        => ( default => sub { 'claude_skills' } );
 has '+skill_description' => ( default => sub { 'Load Claude SKILL.md files as agent tools' } );
 has '+supports_multiple_instances' => ( default => sub { 1 } );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self) = @_;
@@ -19,7 +19,7 @@ sub register_tools {
 
     # In the Perl port, we register a stub tool that represents the skill.
     # Full file-discovery would require YAML parsing (not available in minimal installs).
-    $self->define_tool(
+    return $self->define_tool(
         name        => "${prefix}skill",
         description => "Claude skill tool (stub)",
         parameters  => {

--- a/lib/SignalWire/Skills/Builtin/ClaudeSkills.pm
+++ b/lib/SignalWire/Skills/Builtin/ClaudeSkills.pm
@@ -5,17 +5,18 @@ use Moo;
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('claude_skills', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'claude_skills', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'claude_skills' });
-has '+skill_description' => (default => sub { 'Load Claude SKILL.md files as agent tools' });
-has '+supports_multiple_instances' => (default => sub { 1 });
+has '+skill_name'        => ( default => sub { 'claude_skills' } );
+has '+skill_description' => ( default => sub { 'Load Claude SKILL.md files as agent tools' } );
+has '+supports_multiple_instances' => ( default => sub { 1 } );
 
 sub setup { 1 }
 
 sub register_tools {
     my ($self) = @_;
     my $prefix = $self->params->{tool_prefix} // 'claude_';
+
     # In the Perl port, we register a stub tool that represents the skill.
     # Full file-discovery would require YAML parsing (not available in minimal installs).
     $self->define_tool(
@@ -29,25 +30,24 @@ sub register_tools {
             required => ['arguments'],
         },
         handler => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             return SignalWire::SWAIG::FunctionResult->new(
-                response => "Claude skill invoked with: $args->{arguments}"
-            );
+                response => "Claude skill invoked with: $args->{arguments}" );
         },
     );
 }
 
 sub get_hints {
     my ($self) = @_;
-    return ['claude', 'skill'];
+    return [ 'claude', 'skill' ];
 }
 
 sub get_parameter_schema {
     return {
         %{ SignalWire::Skills::SkillBase->get_parameter_schema },
         skills_path => { type => 'string', required => 1 },
-        tool_prefix => { type => 'string', default => 'claude_' },
+        tool_prefix => { type => 'string', default  => 'claude_' },
     };
 }
 

--- a/lib/SignalWire/Skills/Builtin/CustomSkills.pm
+++ b/lib/SignalWire/Skills/Builtin/CustomSkills.pm
@@ -5,11 +5,11 @@ use Moo;
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('custom_skills', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'custom_skills', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'custom_skills' });
-has '+skill_description' => (default => sub { 'Register user-defined custom tools' });
-has '+supports_multiple_instances' => (default => sub { 1 });
+has '+skill_name'                  => ( default => sub { 'custom_skills' } );
+has '+skill_description'           => ( default => sub { 'Register user-defined custom tools' } );
+has '+supports_multiple_instances' => ( default => sub { 1 } );
 
 sub setup { 1 }
 
@@ -19,9 +19,9 @@ sub register_tools {
 
     for my $tool_def (@$tools) {
         next unless ref $tool_def eq 'HASH';
-        if (exists $tool_def->{function}) {
+        if ( exists $tool_def->{function} ) {
             $self->agent->register_swaig_function($tool_def);
-        } elsif (exists $tool_def->{name}) {
+        } elsif ( exists $tool_def->{name} ) {
             $self->agent->define_tool(%$tool_def);
         }
     }

--- a/lib/SignalWire/Skills/Builtin/CustomSkills.pm
+++ b/lib/SignalWire/Skills/Builtin/CustomSkills.pm
@@ -11,7 +11,7 @@ has '+skill_name'                  => ( default => sub { 'custom_skills' } );
 has '+skill_description'           => ( default => sub { 'Register user-defined custom tools' } );
 has '+supports_multiple_instances' => ( default => sub { 1 } );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self) = @_;
@@ -25,6 +25,7 @@ sub register_tools {
             $self->agent->define_tool(%$tool_def);
         }
     }
+    return;
 }
 
 sub get_parameter_schema {

--- a/lib/SignalWire/Skills/Builtin/Datasphere.pm
+++ b/lib/SignalWire/Skills/Builtin/Datasphere.pm
@@ -71,7 +71,7 @@ sub register_tools {
     require Scalar::Util;
     Scalar::Util::weaken($weak_self);
 
-    $self->define_tool(
+    return $self->define_tool(
         name        => $tool_name,
         description =>
             'Search the knowledge base for information on any topic and return relevant results',

--- a/lib/SignalWire/Skills/Builtin/Datasphere.pm
+++ b/lib/SignalWire/Skills/Builtin/Datasphere.pm
@@ -1,4 +1,5 @@
 package SignalWire::Skills::Builtin::Datasphere;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -11,16 +12,17 @@ use strict;
 use warnings;
 use Moo;
 use HTTP::Tiny;
-use JSON ();
+use JSON         ();
 use MIME::Base64 qw(encode_base64);
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('datasphere', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'datasphere', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'datasphere' });
-has '+skill_description' => (default => sub { 'Search knowledge using SignalWire DataSphere RAG stack' });
-has '+supports_multiple_instances' => (default => sub { 1 });
+has '+skill_name' => ( default => sub { 'datasphere' } );
+has '+skill_description' =>
+    ( default => sub { 'Search knowledge using SignalWire DataSphere RAG stack' } );
+has '+supports_multiple_instances' => ( default => sub { 1 } );
 
 # Honor DATASPHERE_BASE_URL env var so the audit fixture
 # (audit_skills_dispatch.py) can redirect us at a local HTTP server.
@@ -53,6 +55,7 @@ has '_http' => (
 
 sub setup {
     my ($self) = @_;
+
     # Required parameters per Python (skills/datasphere/skill.py:120-127).
     # The audit harness doesn't always set every value, so missing is
     # warned but not fatal — the skill still answers, the API call just
@@ -70,8 +73,9 @@ sub register_tools {
 
     $self->define_tool(
         name        => $tool_name,
-        description => 'Search the knowledge base for information on any topic and return relevant results',
-        parameters  => {
+        description =>
+            'Search the knowledge base for information on any topic and return relevant results',
+        parameters => {
             type       => 'object',
             properties => {
                 query => {
@@ -82,17 +86,16 @@ sub register_tools {
             required => ['query'],
         },
         handler => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             my $query = $args->{query} // '';
             $query =~ s/^\s+|\s+$//g;
-            unless (length $query) {
+            unless ( length $query ) {
                 return SignalWire::SWAIG::FunctionResult->new(
-                    response => 'Please provide a search query.',
-                );
+                    response => 'Please provide a search query.', );
             }
             my $text = $weak_self->search_knowledge($query);
-            return SignalWire::SWAIG::FunctionResult->new(response => $text);
+            return SignalWire::SWAIG::FunctionResult->new( response => $text );
         },
     );
 }
@@ -105,7 +108,7 @@ sub _build_url {
 }
 
 sub search_knowledge {
-    my ($self, $query) = @_;
+    my ( $self, $query ) = @_;
 
     my $project_id  = $self->params->{project_id}  // $ENV{SIGNALWIRE_PROJECT_ID} // '';
     my $token       = $self->params->{token}       // $ENV{DATASPHERE_TOKEN}      // '';
@@ -117,15 +120,16 @@ sub search_knowledge {
         distance     => $self->params->{distance} // 3.0,
         count        => $self->params->{count}    // 1,
     );
-    $payload{tags}          = $self->params->{tags}          if defined $self->params->{tags};
-    $payload{language}      = $self->params->{language}      if defined $self->params->{language};
-    $payload{pos_to_expand} = $self->params->{pos_to_expand} if defined $self->params->{pos_to_expand};
-    $payload{max_synonyms}  = $self->params->{max_synonyms}  if defined $self->params->{max_synonyms};
+    $payload{tags}          = $self->params->{tags}     if defined $self->params->{tags};
+    $payload{language}      = $self->params->{language} if defined $self->params->{language};
+    $payload{pos_to_expand} = $self->params->{pos_to_expand}
+        if defined $self->params->{pos_to_expand};
+    $payload{max_synonyms} = $self->params->{max_synonyms} if defined $self->params->{max_synonyms};
 
-    my $body = JSON::encode_json(\%payload);
-    my $auth = encode_base64("$project_id:$token", '');
+    my $body = JSON::encode_json( \%payload );
+    my $auth = encode_base64( "$project_id:$token", '' );
 
-    my $url = $self->_build_url;
+    my $url  = $self->_build_url;
     my $resp = $self->_http->post(
         $url,
         {
@@ -138,12 +142,12 @@ sub search_knowledge {
         },
     );
 
-    unless ($resp->{success}) {
+    unless ( $resp->{success} ) {
         return "Sorry, there was an error accessing the knowledge base "
             . "($resp->{status} $resp->{reason}). Please try again later.";
     }
 
-    my $data = eval { JSON::decode_json($resp->{content}) };
+    my $data = eval { JSON::decode_json( $resp->{content} ) };
     if ($@) {
         return "Sorry, the knowledge base returned an unparseable response.";
     }
@@ -154,16 +158,17 @@ sub search_knowledge {
     # shape — accept either to keep the parser tolerant of incidental
     # rename without forcing tests through a translation layer.
     my $chunks = $data->{chunks} // $data->{results} // [];
-    unless (ref $chunks eq 'ARRAY' && @$chunks) {
+    unless ( ref $chunks eq 'ARRAY' && @$chunks ) {
         my $msg = $self->params->{no_results_message}
             // "I couldn't find any relevant information for '{query}' in the knowledge base. "
-                . "Try rephrasing your question or asking about a different topic.";
+            . "Try rephrasing your question or asking about a different topic.";
         $msg =~ s/\{query\}/$query/g;
         return $msg;
     }
 
     my $count = scalar @$chunks;
-    my $header = $count == 1
+    my $header =
+        $count == 1
         ? "I found 1 result for '$query':\n\n"
         : "I found $count results for '$query':\n\n";
 
@@ -172,10 +177,10 @@ sub search_knowledge {
     for my $chunk (@$chunks) {
         my $text = $chunk->{text} // $chunk->{content} // $chunk->{chunk};
         $text = JSON::encode_json($chunk) unless defined $text;
-        push @blocks, "=== RESULT $i ===\n$text\n" . ('=' x 50);
+        push @blocks, "=== RESULT $i ===\n$text\n" . ( '=' x 50 );
         $i++;
     }
-    return $header . join("\n\n", @blocks);
+    return $header . join( "\n\n", @blocks );
 }
 
 sub get_hints { return [] }
@@ -190,25 +195,27 @@ sub get_global_data {
 }
 
 sub _get_prompt_sections {
-    return [{
-        title   => 'Knowledge Search Capability',
-        body    => 'You have access to a knowledge base that you can search for information.',
-        bullets => [
-            'Use the search tool to find relevant information',
-            'Provide accurate answers based on search results',
-        ],
-    }];
+    return [
+        {
+            title   => 'Knowledge Search Capability',
+            body    => 'You have access to a knowledge base that you can search for information.',
+            bullets => [
+                'Use the search tool to find relevant information',
+                'Provide accurate answers based on search results',
+            ],
+        }
+    ];
 }
 
 sub get_parameter_schema {
     return {
         %{ SignalWire::Skills::SkillBase->get_parameter_schema },
-        space_name  => { type => 'string', required => 1 },
-        project_id  => { type => 'string', required => 1 },
-        token       => { type => 'string', required => 1 },
-        document_id => { type => 'string', required => 1 },
-        count       => { type => 'integer', default => 1, min => 1, max => 10 },
-        distance    => { type => 'number',  default => 3.0 },
+        space_name  => { type => 'string',  required => 1 },
+        project_id  => { type => 'string',  required => 1 },
+        token       => { type => 'string',  required => 1 },
+        document_id => { type => 'string',  required => 1 },
+        count       => { type => 'integer', default  => 1, min => 1, max => 10 },
+        distance    => { type => 'number',  default  => 3.0 },
     };
 }
 

--- a/lib/SignalWire/Skills/Builtin/Datasphere.pm
+++ b/lib/SignalWire/Skills/Builtin/Datasphere.pm
@@ -83,7 +83,10 @@ sub register_tools {
                     description => 'The search query - what information you are looking for',
                 },
             },
-            required => ['query'],
+
+            # No `required`: the Python reference (skills/datasphere/skill.py)
+            # passes none and the handler guards an empty query. Adding it would
+            # over-constrain the SWAIG schema vs the reference contract.
         },
         handler => sub {
             my ( $args, $raw ) = @_;

--- a/lib/SignalWire/Skills/Builtin/DatasphereServerless.pm
+++ b/lib/SignalWire/Skills/Builtin/DatasphereServerless.pm
@@ -13,14 +13,14 @@ has '+skill_description' => ( default =>
         sub { 'Search knowledge using SignalWire DataSphere with serverless DataMap execution' } );
 has '+supports_multiple_instances' => ( default => sub { 1 } );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self) = @_;
     my $tool_name = $self->params->{tool_name} // 'search_knowledge';
 
     # DataMap-based tool: register as a SWAIG function definition
-    $self->agent->register_swaig_function(
+    return $self->agent->register_swaig_function(
         {
             function    => $tool_name,
             description =>

--- a/lib/SignalWire/Skills/Builtin/DatasphereServerless.pm
+++ b/lib/SignalWire/Skills/Builtin/DatasphereServerless.pm
@@ -6,11 +6,12 @@ use JSON ();
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('datasphere_serverless', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'datasphere_serverless', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'datasphere_serverless' });
-has '+skill_description' => (default => sub { 'Search knowledge using SignalWire DataSphere with serverless DataMap execution' });
-has '+supports_multiple_instances' => (default => sub { 1 });
+has '+skill_name' => ( default => sub { 'datasphere_serverless' } );
+has '+skill_description' => ( default =>
+        sub { 'Search knowledge using SignalWire DataSphere with serverless DataMap execution' } );
+has '+supports_multiple_instances' => ( default => sub { 1 } );
 
 sub setup { 1 }
 
@@ -19,27 +20,35 @@ sub register_tools {
     my $tool_name = $self->params->{tool_name} // 'search_knowledge';
 
     # DataMap-based tool: register as a SWAIG function definition
-    $self->agent->register_swaig_function({
-        function    => $tool_name,
-        description => 'Search the knowledge base for information on any topic and return relevant results',
-        parameters  => {
-            type       => 'object',
-            properties => {
-                query => { type => 'string', description => 'The search query' },
-            },
-            required => ['query'],
-        },
-        data_map => {
-            webhooks => [{
-                method => 'POST',
-                url    => 'https://' . ($self->params->{space_name} // '') . '/api/datasphere/documents/search',
-                output => {
-                    response => 'I found results for "${args.query}":\n\n${formatted_results}',
-                    action   => [{ say => 'Here are the search results.' }],
+    $self->agent->register_swaig_function(
+        {
+            function    => $tool_name,
+            description =>
+'Search the knowledge base for information on any topic and return relevant results',
+            parameters => {
+                type       => 'object',
+                properties => {
+                    query => { type => 'string', description => 'The search query' },
                 },
-            }],
-        },
-    });
+                required => ['query'],
+            },
+            data_map => {
+                webhooks => [
+                    {
+                        method => 'POST',
+                        url    => 'https://'
+                            . ( $self->params->{space_name} // '' )
+                            . '/api/datasphere/documents/search',
+                        output => {
+                            response =>
+                                'I found results for "${args.query}":\n\n${formatted_results}',
+                            action => [ { say => 'Here are the search results.' } ],
+                        },
+                    }
+                ],
+            },
+        }
+    );
 }
 
 sub get_hints { return [] }
@@ -54,25 +63,27 @@ sub get_global_data {
 }
 
 sub _get_prompt_sections {
-    return [{
-        title   => 'Knowledge Search Capability (Serverless)',
-        body    => 'You have access to a serverless knowledge base search.',
-        bullets => [
-            'Use the search tool to find relevant information',
-            'Results are processed server-side for efficiency',
-        ],
-    }];
+    return [
+        {
+            title   => 'Knowledge Search Capability (Serverless)',
+            body    => 'You have access to a serverless knowledge base search.',
+            bullets => [
+                'Use the search tool to find relevant information',
+                'Results are processed server-side for efficiency',
+            ],
+        }
+    ];
 }
 
 sub get_parameter_schema {
     return {
         %{ SignalWire::Skills::SkillBase->get_parameter_schema },
-        space_name  => { type => 'string', required => 1 },
-        project_id  => { type => 'string', required => 1 },
-        token       => { type => 'string', required => 1 },
-        document_id => { type => 'string', required => 1 },
-        count       => { type => 'integer', default => 1, min => 1, max => 10 },
-        distance    => { type => 'number', default => 3.0 },
+        space_name  => { type => 'string',  required => 1 },
+        project_id  => { type => 'string',  required => 1 },
+        token       => { type => 'string',  required => 1 },
+        document_id => { type => 'string',  required => 1 },
+        count       => { type => 'integer', default  => 1, min => 1, max => 10 },
+        distance    => { type => 'number',  default  => 3.0 },
     };
 }
 

--- a/lib/SignalWire/Skills/Builtin/Datetime.pm
+++ b/lib/SignalWire/Skills/Builtin/Datetime.pm
@@ -6,11 +6,12 @@ use POSIX qw(strftime);
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('datetime', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'datetime', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'datetime' });
-has '+skill_description' => (default => sub { 'Get current date, time, and timezone information' });
-has '+supports_multiple_instances' => (default => sub { 0 });
+has '+skill_name' => ( default => sub { 'datetime' } );
+has '+skill_description' =>
+    ( default => sub { 'Get current date, time, and timezone information' } );
+has '+supports_multiple_instances' => ( default => sub { 0 } );
 
 sub setup { 1 }
 
@@ -23,20 +24,23 @@ sub register_tools {
         parameters  => {
             type       => 'object',
             properties => {
-                timezone => { type => 'string', description => 'Timezone (e.g. UTC, US/Eastern)', default => 'UTC' },
+                timezone => {
+                    type        => 'string',
+                    description => 'Timezone (e.g. UTC, US/Eastern)',
+                    default     => 'UTC'
+                },
             },
         },
         handler => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             my $tz = $args->{timezone} // 'UTC';
             local $ENV{TZ} = $tz;
             POSIX::tzset();
-            my $time = strftime('%H:%M:%S %Z', localtime);
-            POSIX::tzset();  # Reset
+            my $time = strftime( '%H:%M:%S %Z', localtime );
+            POSIX::tzset();    # Reset
             require SignalWire::SWAIG::FunctionResult;
             return SignalWire::SWAIG::FunctionResult->new(
-                response => "The current time in $tz is $time"
-            );
+                response => "The current time in $tz is $time" );
         },
     );
 
@@ -46,39 +50,42 @@ sub register_tools {
         parameters  => {
             type       => 'object',
             properties => {
-                timezone => { type => 'string', description => 'Timezone (e.g. UTC, US/Eastern)', default => 'UTC' },
+                timezone => {
+                    type        => 'string',
+                    description => 'Timezone (e.g. UTC, US/Eastern)',
+                    default     => 'UTC'
+                },
             },
         },
         handler => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             my $tz = $args->{timezone} // 'UTC';
             local $ENV{TZ} = $tz;
             POSIX::tzset();
-            my $date = strftime('%Y-%m-%d', localtime);
+            my $date = strftime( '%Y-%m-%d', localtime );
             POSIX::tzset();
             require SignalWire::SWAIG::FunctionResult;
             return SignalWire::SWAIG::FunctionResult->new(
-                response => "The current date in $tz is $date"
-            );
+                response => "The current date in $tz is $date" );
         },
     );
 }
 
 sub _get_prompt_sections {
-    return [{
-        title   => 'Date and Time Information',
-        body    => 'You can get the current date and time in any timezone.',
-        bullets => [
-            'Use get_current_time to get the current time',
-            'Use get_current_date to get the current date',
-        ],
-    }];
+    return [
+        {
+            title   => 'Date and Time Information',
+            body    => 'You can get the current date and time in any timezone.',
+            bullets => [
+                'Use get_current_time to get the current time',
+                'Use get_current_date to get the current date',
+            ],
+        }
+    ];
 }
 
 sub get_parameter_schema {
-    return {
-        %{ SignalWire::Skills::SkillBase->get_parameter_schema },
-    };
+    return { %{ SignalWire::Skills::SkillBase->get_parameter_schema }, };
 }
 
 1;

--- a/lib/SignalWire/Skills/Builtin/Datetime.pm
+++ b/lib/SignalWire/Skills/Builtin/Datetime.pm
@@ -13,7 +13,7 @@ has '+skill_description' =>
     ( default => sub { 'Get current date, time, and timezone information' } );
 has '+supports_multiple_instances' => ( default => sub { 0 } );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self) = @_;
@@ -44,7 +44,7 @@ sub register_tools {
         },
     );
 
-    $self->define_tool(
+    return $self->define_tool(
         name        => 'get_current_date',
         description => 'Get the current date',
         parameters  => {

--- a/lib/SignalWire/Skills/Builtin/GoogleMaps.pm
+++ b/lib/SignalWire/Skills/Builtin/GoogleMaps.pm
@@ -29,13 +29,17 @@ sub register_tools {
                 bias_lat => { type => 'number', description => 'Latitude bias' },
                 bias_lng => { type => 'number', description => 'Longitude bias' },
             },
-            required => ['address'],
+
+            # No `required`: the Python reference (skills/google_maps/skill.py)
+            # passes none on lookup_address. Adding it would over-constrain the
+            # SWAIG schema vs the reference contract.
         },
         handler => sub {
             my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
+            my $address = $args->{address} // '';
             return SignalWire::SWAIG::FunctionResult->new(
-                response => "Address lookup for: $args->{address}" );
+                response => "Address lookup for: $address" );
         },
     );
 
@@ -50,14 +54,19 @@ sub register_tools {
                 dest_lat   => { type => 'number', description => 'Destination latitude' },
                 dest_lng   => { type => 'number', description => 'Destination longitude' },
             },
-            required => [ 'origin_lat', 'origin_lng', 'dest_lat', 'dest_lng' ],
+
+            # No `required`: the Python reference (skills/google_maps/skill.py)
+            # passes none on compute_route (its handler validates the four coords
+            # itself). Adding it would over-constrain the SWAIG schema vs the
+            # reference contract.
         },
         handler => sub {
             my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
-            return SignalWire::SWAIG::FunctionResult->new( response =>
-"Route computed from ($args->{origin_lat},$args->{origin_lng}) to ($args->{dest_lat},$args->{dest_lng})"
-            );
+            my ( $olat, $olng, $dlat, $dlng ) = map { $args->{$_} // '' }
+                qw(origin_lat origin_lng dest_lat dest_lng);
+            return SignalWire::SWAIG::FunctionResult->new(
+                response => "Route computed from ($olat,$olng) to ($dlat,$dlng)" );
         },
     );
 }

--- a/lib/SignalWire/Skills/Builtin/GoogleMaps.pm
+++ b/lib/SignalWire/Skills/Builtin/GoogleMaps.pm
@@ -63,8 +63,8 @@ sub register_tools {
         handler => sub {
             my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
-            my ( $olat, $olng, $dlat, $dlng ) = map { $args->{$_} // '' }
-                qw(origin_lat origin_lng dest_lat dest_lng);
+            my ( $olat, $olng, $dlat, $dlng ) =
+                map { $args->{$_} // '' } qw(origin_lat origin_lng dest_lat dest_lng);
             return SignalWire::SWAIG::FunctionResult->new(
                 response => "Route computed from ($olat,$olng) to ($dlat,$dlng)" );
         },

--- a/lib/SignalWire/Skills/Builtin/GoogleMaps.pm
+++ b/lib/SignalWire/Skills/Builtin/GoogleMaps.pm
@@ -5,16 +5,17 @@ use Moo;
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('google_maps', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'google_maps', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'google_maps' });
-has '+skill_description' => (default => sub { 'Validate addresses and compute driving routes using Google Maps' });
-has '+supports_multiple_instances' => (default => sub { 0 });
+has '+skill_name' => ( default => sub { 'google_maps' } );
+has '+skill_description' =>
+    ( default => sub { 'Validate addresses and compute driving routes using Google Maps' } );
+has '+supports_multiple_instances' => ( default => sub { 0 } );
 
 sub setup { 1 }
 
 sub register_tools {
-    my ($self) = @_;
+    my ($self)      = @_;
     my $lookup_name = $self->params->{lookup_tool_name} // 'lookup_address';
     my $route_name  = $self->params->{route_tool_name}  // 'compute_route';
 
@@ -31,11 +32,10 @@ sub register_tools {
             required => ['address'],
         },
         handler => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             return SignalWire::SWAIG::FunctionResult->new(
-                response => "Address lookup for: $args->{address}"
-            );
+                response => "Address lookup for: $args->{address}" );
         },
     );
 
@@ -50,39 +50,41 @@ sub register_tools {
                 dest_lat   => { type => 'number', description => 'Destination latitude' },
                 dest_lng   => { type => 'number', description => 'Destination longitude' },
             },
-            required => ['origin_lat', 'origin_lng', 'dest_lat', 'dest_lng'],
+            required => [ 'origin_lat', 'origin_lng', 'dest_lat', 'dest_lng' ],
         },
         handler => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
-            return SignalWire::SWAIG::FunctionResult->new(
-                response => "Route computed from ($args->{origin_lat},$args->{origin_lng}) to ($args->{dest_lat},$args->{dest_lng})"
+            return SignalWire::SWAIG::FunctionResult->new( response =>
+"Route computed from ($args->{origin_lat},$args->{origin_lng}) to ($args->{dest_lat},$args->{dest_lng})"
             );
         },
     );
 }
 
 sub get_hints {
-    return ['address', 'location', 'route', 'directions', 'miles', 'distance'];
+    return [ 'address', 'location', 'route', 'directions', 'miles', 'distance' ];
 }
 
 sub _get_prompt_sections {
-    return [{
-        title   => 'Google Maps',
-        body    => '',
-        bullets => [
-            'Use lookup_address to validate and geocode addresses',
-            'Use compute_route to get driving directions between two points',
-        ],
-    }];
+    return [
+        {
+            title   => 'Google Maps',
+            body    => '',
+            bullets => [
+                'Use lookup_address to validate and geocode addresses',
+                'Use compute_route to get driving directions between two points',
+            ],
+        }
+    ];
 }
 
 sub get_parameter_schema {
     return {
         %{ SignalWire::Skills::SkillBase->get_parameter_schema },
         api_key          => { type => 'string', required => 1, hidden => 1 },
-        lookup_tool_name => { type => 'string', default => 'lookup_address' },
-        route_tool_name  => { type => 'string', default => 'compute_route' },
+        lookup_tool_name => { type => 'string', default  => 'lookup_address' },
+        route_tool_name  => { type => 'string', default  => 'compute_route' },
     };
 }
 

--- a/lib/SignalWire/Skills/Builtin/GoogleMaps.pm
+++ b/lib/SignalWire/Skills/Builtin/GoogleMaps.pm
@@ -12,7 +12,7 @@ has '+skill_description' =>
     ( default => sub { 'Validate addresses and compute driving routes using Google Maps' } );
 has '+supports_multiple_instances' => ( default => sub { 0 } );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self)      = @_;
@@ -43,7 +43,7 @@ sub register_tools {
         },
     );
 
-    $self->define_tool(
+    return $self->define_tool(
         name        => $route_name,
         description => 'Compute a driving route between two points',
         parameters  => {

--- a/lib/SignalWire/Skills/Builtin/InfoGatherer.pm
+++ b/lib/SignalWire/Skills/Builtin/InfoGatherer.pm
@@ -44,13 +44,18 @@ sub register_tools {
                 answer            => { type => 'string',  description => 'The answer' },
                 confirmed_by_user => { type => 'boolean', description => 'Whether user confirmed' },
             },
-            required => ['answer'],
+
+            # No `required`: the Python reference (skills/info_gatherer/skill.py)
+            # passes none on submit_answer and the handler reads answer with a
+            # default. Adding it would over-constrain the SWAIG schema vs the
+            # reference contract.
         },
         handler => sub {
             my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
+            my $answer = $args->{answer} // '';
             return SignalWire::SWAIG::FunctionResult->new(
-                response => "Answer recorded: $args->{answer}", );
+                response => "Answer recorded: $answer", );
         },
     );
 }

--- a/lib/SignalWire/Skills/Builtin/InfoGatherer.pm
+++ b/lib/SignalWire/Skills/Builtin/InfoGatherer.pm
@@ -6,17 +6,18 @@ use JSON qw(encode_json);
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('info_gatherer', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'info_gatherer', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'info_gatherer' });
-has '+skill_description' => (default => sub { 'Gather answers to a configurable list of questions' });
-has '+supports_multiple_instances' => (default => sub { 1 });
+has '+skill_name' => ( default => sub { 'info_gatherer' } );
+has '+skill_description' =>
+    ( default => sub { 'Gather answers to a configurable list of questions' } );
+has '+supports_multiple_instances' => ( default => sub { 1 } );
 
 sub setup { 1 }
 
 sub register_tools {
-    my ($self) = @_;
-    my $prefix    = $self->params->{prefix} // '';
+    my ($self)    = @_;
+    my $prefix    = $self->params->{prefix}    // '';
     my $questions = $self->params->{questions} // [];
 
     my $start_name  = $prefix ? "${prefix}_start_questions" : 'start_questions';
@@ -27,12 +28,10 @@ sub register_tools {
         description => 'Start the question-gathering process and return the first question',
         parameters  => { type => 'object', properties => {} },
         handler     => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             my $first = $questions->[0]{question_text} // 'No questions configured';
-            return SignalWire::SWAIG::FunctionResult->new(
-                response => $first,
-            );
+            return SignalWire::SWAIG::FunctionResult->new( response => $first, );
         },
     );
 
@@ -48,11 +47,10 @@ sub register_tools {
             required => ['answer'],
         },
         handler => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             return SignalWire::SWAIG::FunctionResult->new(
-                response => "Answer recorded: $args->{answer}",
-            );
+                response => "Answer recorded: $args->{answer}", );
         },
     );
 }
@@ -72,23 +70,26 @@ sub get_global_data {
 sub _get_prompt_sections {
     my ($self) = @_;
     my $key = $self->params->{prefix} // 'info_gatherer';
-    return [{
-        title => "Info Gatherer ($key)",
-        body  => 'Ask the user a series of questions and collect their answers.',
-        bullets => [
-            'Ask questions one at a time',
-            'Wait for the user to answer before proceeding',
-            'Confirm answers when required',
-        ],
-    }];
+    return [
+        {
+            title   => "Info Gatherer ($key)",
+            body    => 'Ask the user a series of questions and collect their answers.',
+            bullets => [
+                'Ask questions one at a time',
+                'Wait for the user to answer before proceeding',
+                'Confirm answers when required',
+            ],
+        }
+    ];
 }
 
 sub get_parameter_schema {
     return {
         %{ SignalWire::Skills::SkillBase->get_parameter_schema },
-        questions          => { type => 'array',  required => 1, description => 'List of question objects' },
-        prefix             => { type => 'string', description => 'Prefix for tool names' },
-        completion_message => { type => 'string', description => 'Message after all questions answered' },
+        questions => { type => 'array',  required => 1, description => 'List of question objects' },
+        prefix    => { type => 'string', description => 'Prefix for tool names' },
+        completion_message =>
+            { type => 'string', description => 'Message after all questions answered' },
     };
 }
 

--- a/lib/SignalWire/Skills/Builtin/InfoGatherer.pm
+++ b/lib/SignalWire/Skills/Builtin/InfoGatherer.pm
@@ -13,7 +13,7 @@ has '+skill_description' =>
     ( default => sub { 'Gather answers to a configurable list of questions' } );
 has '+supports_multiple_instances' => ( default => sub { 1 } );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self)    = @_;
@@ -35,7 +35,7 @@ sub register_tools {
         },
     );
 
-    $self->define_tool(
+    return $self->define_tool(
         name        => $submit_name,
         description => 'Submit an answer to the current question',
         parameters  => {

--- a/lib/SignalWire/Skills/Builtin/InfoGatherer.pm
+++ b/lib/SignalWire/Skills/Builtin/InfoGatherer.pm
@@ -54,8 +54,8 @@ sub register_tools {
             my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             my $answer = $args->{answer} // '';
-            return SignalWire::SWAIG::FunctionResult->new(
-                response => "Answer recorded: $answer", );
+            return SignalWire::SWAIG::FunctionResult->new( response => "Answer recorded: $answer",
+            );
         },
     );
 }

--- a/lib/SignalWire/Skills/Builtin/Joke.pm
+++ b/lib/SignalWire/Skills/Builtin/Joke.pm
@@ -12,14 +12,14 @@ has '+skill_name'        => ( default => sub { 'joke' } );
 has '+skill_description' => ( default => sub { 'Tell jokes using the API Ninjas joke API' } );
 has '+supports_multiple_instances' => ( default => sub { 0 } );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self) = @_;
     my $tool_name = $self->params->{tool_name} // 'get_joke';
 
     # DataMap-style registration
-    $self->agent->register_swaig_function(
+    return $self->agent->register_swaig_function(
         {
             function    => $tool_name,
             description => 'Get a random joke from API Ninjas',

--- a/lib/SignalWire/Skills/Builtin/Joke.pm
+++ b/lib/SignalWire/Skills/Builtin/Joke.pm
@@ -6,11 +6,11 @@ use JSON ();
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('joke', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'joke', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'joke' });
-has '+skill_description' => (default => sub { 'Tell jokes using the API Ninjas joke API' });
-has '+supports_multiple_instances' => (default => sub { 0 });
+has '+skill_name'        => ( default => sub { 'joke' } );
+has '+skill_description' => ( default => sub { 'Tell jokes using the API Ninjas joke API' } );
+has '+supports_multiple_instances' => ( default => sub { 0 } );
 
 sub setup { 1 }
 
@@ -19,31 +19,35 @@ sub register_tools {
     my $tool_name = $self->params->{tool_name} // 'get_joke';
 
     # DataMap-style registration
-    $self->agent->register_swaig_function({
-        function    => $tool_name,
-        description => 'Get a random joke from API Ninjas',
-        parameters  => {
-            type       => 'object',
-            properties => {
-                type => {
-                    type        => 'string',
-                    description => 'Type of joke',
-                    enum        => ['jokes', 'dadjokes'],
+    $self->agent->register_swaig_function(
+        {
+            function    => $tool_name,
+            description => 'Get a random joke from API Ninjas',
+            parameters  => {
+                type       => 'object',
+                properties => {
+                    type => {
+                        type        => 'string',
+                        description => 'Type of joke',
+                        enum        => [ 'jokes', 'dadjokes' ],
+                    },
                 },
+                required => ['type'],
             },
-            required => ['type'],
-        },
-        data_map => {
-            webhooks => [{
-                method  => 'GET',
-                url     => 'https://api.api-ninjas.com/v1/${args.type}',
-                headers => { 'X-Api-Key' => $self->params->{api_key} // '' },
-                output  => {
-                    response => 'Here\'s a joke: ${array[0].joke}',
-                },
-            }],
-        },
-    });
+            data_map => {
+                webhooks => [
+                    {
+                        method  => 'GET',
+                        url     => 'https://api.api-ninjas.com/v1/${args.type}',
+                        headers => { 'X-Api-Key' => $self->params->{api_key} // '' },
+                        output  => {
+                            response => 'Here\'s a joke: ${array[0].joke}',
+                        },
+                    }
+                ],
+            },
+        }
+    );
 }
 
 sub get_global_data {
@@ -51,21 +55,23 @@ sub get_global_data {
 }
 
 sub _get_prompt_sections {
-    return [{
-        title   => 'Joke Telling',
-        body    => 'You can tell jokes to lighten the mood.',
-        bullets => [
-            'Use the joke tool when the user asks for a joke',
-            'Choose between regular jokes and dad jokes',
-        ],
-    }];
+    return [
+        {
+            title   => 'Joke Telling',
+            body    => 'You can tell jokes to lighten the mood.',
+            bullets => [
+                'Use the joke tool when the user asks for a joke',
+                'Choose between regular jokes and dad jokes',
+            ],
+        }
+    ];
 }
 
 sub get_parameter_schema {
     return {
         %{ SignalWire::Skills::SkillBase->get_parameter_schema },
         api_key   => { type => 'string', required => 1, hidden => 1 },
-        tool_name => { type => 'string', default => 'get_joke' },
+        tool_name => { type => 'string', default  => 'get_joke' },
     };
 }
 

--- a/lib/SignalWire/Skills/Builtin/Math.pm
+++ b/lib/SignalWire/Skills/Builtin/Math.pm
@@ -26,7 +26,10 @@ sub register_tools {
                 expression =>
                     { type => 'string', description => 'Mathematical expression to evaluate' },
             },
-            required => ['expression'],
+
+            # No `required`: the Python reference (skills/math/skill.py) passes
+            # none, and the handler guards an empty/invalid expression. Adding it
+            # would over-constrain the SWAIG schema vs the reference contract.
         },
         handler => sub {
             my ( $args, $raw ) = @_;

--- a/lib/SignalWire/Skills/Builtin/Math.pm
+++ b/lib/SignalWire/Skills/Builtin/Math.pm
@@ -11,12 +11,12 @@ has '+skill_name'        => ( default => sub { 'math' } );
 has '+skill_description' => ( default => sub { 'Perform basic mathematical calculations' } );
 has '+supports_multiple_instances' => ( default => sub { 0 } );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self) = @_;
 
-    $self->define_tool(
+    return $self->define_tool(
         name        => 'calculate',
         description =>
             'Perform a mathematical calculation with basic operations (+, -, *, /, %, **)',

--- a/lib/SignalWire/Skills/Builtin/Math.pm
+++ b/lib/SignalWire/Skills/Builtin/Math.pm
@@ -5,11 +5,11 @@ use Moo;
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('math', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'math', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'math' });
-has '+skill_description' => (default => sub { 'Perform basic mathematical calculations' });
-has '+supports_multiple_instances' => (default => sub { 0 });
+has '+skill_name'        => ( default => sub { 'math' } );
+has '+skill_description' => ( default => sub { 'Perform basic mathematical calculations' } );
+has '+supports_multiple_instances' => ( default => sub { 0 } );
 
 sub setup { 1 }
 
@@ -18,51 +18,51 @@ sub register_tools {
 
     $self->define_tool(
         name        => 'calculate',
-        description => 'Perform a mathematical calculation with basic operations (+, -, *, /, %, **)',
-        parameters  => {
+        description =>
+            'Perform a mathematical calculation with basic operations (+, -, *, /, %, **)',
+        parameters => {
             type       => 'object',
             properties => {
-                expression => { type => 'string', description => 'Mathematical expression to evaluate' },
+                expression =>
+                    { type => 'string', description => 'Mathematical expression to evaluate' },
             },
             required => ['expression'],
         },
         handler => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             my $expr = $args->{expression} // '';
 
             # Safe evaluation: only allow numbers and basic operators
-            if ($expr =~ /^[\d\s\+\-\*\/\%\.\(\)\^]+$/) {
-                $expr =~ s/\^/**/g;  # Convert ^ to **
+            if ( $expr =~ /^[\d\s\+\-\*\/\%\.\(\)\^]+$/ ) {
+                $expr =~ s/\^/**/g;    # Convert ^ to **
                 my $result = eval { no strict; no warnings; eval $expr };
-                if (defined $result && !$@) {
+                if ( defined $result && !$@ ) {
                     return SignalWire::SWAIG::FunctionResult->new(
-                        response => "The result of $args->{expression} is $result"
-                    );
+                        response => "The result of $args->{expression} is $result" );
                 }
             }
             return SignalWire::SWAIG::FunctionResult->new(
-                response => "Could not evaluate expression: $args->{expression}"
-            );
+                response => "Could not evaluate expression: $args->{expression}" );
         },
     );
 }
 
 sub _get_prompt_sections {
-    return [{
-        title   => 'Mathematical Calculations',
-        body    => '',
-        bullets => [
-            'Use the calculate tool for math operations',
-            'Supports +, -, *, /, %, and ** (exponentiation)',
-        ],
-    }];
+    return [
+        {
+            title   => 'Mathematical Calculations',
+            body    => '',
+            bullets => [
+                'Use the calculate tool for math operations',
+                'Supports +, -, *, /, %, and ** (exponentiation)',
+            ],
+        }
+    ];
 }
 
 sub get_parameter_schema {
-    return {
-        %{ SignalWire::Skills::SkillBase->get_parameter_schema },
-    };
+    return { %{ SignalWire::Skills::SkillBase->get_parameter_schema }, };
 }
 
 1;

--- a/lib/SignalWire/Skills/Builtin/Math.pm
+++ b/lib/SignalWire/Skills/Builtin/Math.pm
@@ -33,19 +33,135 @@ sub register_tools {
             require SignalWire::SWAIG::FunctionResult;
             my $expr = $args->{expression} // '';
 
-            # Safe evaluation: only allow numbers and basic operators
-            if ( $expr =~ /^[\d\s\+\-\*\/\%\.\(\)\^]+$/ ) {
-                $expr =~ s/\^/**/g;    # Convert ^ to **
-                my $result = eval { no strict; no warnings; eval $expr };
-                if ( defined $result && !$@ ) {
-                    return SignalWire::SWAIG::FunctionResult->new(
-                        response => "The result of $args->{expression} is $result" );
-                }
+            my $result = eval { _safe_eval($expr) };
+            if ( defined $result && !$@ ) {
+                return SignalWire::SWAIG::FunctionResult->new(
+                    response => "The result of $args->{expression} is $result" );
             }
             return SignalWire::SWAIG::FunctionResult->new(
                 response => "Could not evaluate expression: $args->{expression}" );
         },
     );
+}
+
+# Safe arithmetic evaluator — the Perl analog of the Python reference's
+# ast-based _safe_eval (signalwire/skills/math/skill.py). It replaces the old
+# stringy `eval $expr` (perlcritic ProhibitStringyEval / ProhibitNoStrict) with
+# a small recursive-descent parser over a fixed grammar so NO user input ever
+# reaches the Perl compiler. Supported: integer/decimal literals, unary +/-,
+# the binary operators + - * / % and ** / ^ (exponentiation), and parentheses —
+# exactly the operator set the tool description and prompt advertise. Any
+# unexpected character or malformed expression dies, which the handler's eval
+# turns into the "Could not evaluate" response (matching the old behavior).
+sub _safe_eval {
+    my ($expr) = @_;
+
+    # Tokenize: numbers, the operators (treating ^ as **), and parens. Anything
+    # else is rejected, preserving the old char-class whitelist.
+    my @tokens;
+    while ( length $expr ) {
+        if ( $expr =~ s/^\s+// ) {
+            next;
+        }
+        if ( $expr =~ s/^(\d+(?:\.\d+)?|\.\d+)// ) {
+            push @tokens, [ num => $1 ];
+        } elsif ( $expr =~ s/^(\*\*|\^)// ) {
+            push @tokens, [ op => '**' ];
+        } elsif ( $expr =~ s{^([-+*/%()])}{} ) {
+            push @tokens, [ op => $1 ];
+        } else {
+            die "math: unexpected token near '$expr'\n";
+        }
+    }
+    die "math: empty expression\n" unless @tokens;
+
+    my $pos = 0;
+
+    # expr := term (('+'|'-') term)*
+    my ( $parse_expr, $parse_term, $parse_power, $parse_unary, $parse_atom );
+
+    my $peek = sub { $pos < @tokens ? $tokens[$pos] : undef };
+    my $eat  = sub {
+        my ($op) = @_;
+        my $t = $tokens[$pos];
+        die "math: expected '$op'\n"
+            unless $t && $t->[0] eq 'op' && $t->[1] eq $op;
+        $pos++;
+        return;
+    };
+
+    $parse_atom = sub {
+        my $t = $peek->();
+        die "math: unexpected end of expression\n" unless $t;
+        if ( $t->[0] eq 'num' ) {
+            $pos++;
+            return 0 + $t->[1];
+        }
+        if ( $t->[0] eq 'op' && $t->[1] eq '(' ) {
+            $eat->('(');
+            my $v = $parse_expr->();
+            $eat->(')');
+            return $v;
+        }
+        die "math: unexpected token\n";
+    };
+
+    # unary := ('+'|'-') unary | atom
+    $parse_unary = sub {
+        my $t = $peek->();
+        if ( $t && $t->[0] eq 'op' && ( $t->[1] eq '+' || $t->[1] eq '-' ) ) {
+            my $op = $t->[1];
+            $pos++;
+            my $v = $parse_unary->();
+            return $op eq '-' ? -$v : $v;
+        }
+        return $parse_atom->();
+    };
+
+    # power := unary ('**' power)?   (right-associative, like Perl/Python)
+    $parse_power = sub {
+        my $base = $parse_unary->();
+        my $t    = $peek->();
+        if ( $t && $t->[0] eq 'op' && $t->[1] eq '**' ) {
+            $pos++;
+            my $exp = $parse_power->();
+            die "math: exponent too large\n" if $exp > 1000;
+            return $base**$exp;
+        }
+        return $base;
+    };
+
+    # term := power (('*'|'/'|'%') power)*
+    $parse_term = sub {
+        my $v = $parse_power->();
+        while ( my $t = $peek->() ) {
+            last unless $t->[0] eq 'op' && $t->[1] =~ /^[*\/%]$/;
+            my $op = $t->[1];
+            $pos++;
+            my $rhs = $parse_power->();
+            if    ( $op eq '*' ) { $v *= $rhs }
+            elsif ( $op eq '/' ) { $v /= $rhs }
+            else                 { $v %= $rhs }
+        }
+        return $v;
+    };
+
+    $parse_expr = sub {
+        my $v = $parse_term->();
+        while ( my $t = $peek->() ) {
+            last unless $t->[0] eq 'op' && ( $t->[1] eq '+' || $t->[1] eq '-' );
+            my $op = $t->[1];
+            $pos++;
+            my $rhs = $parse_term->();
+            if   ( $op eq '+' ) { $v += $rhs }
+            else                { $v -= $rhs }
+        }
+        return $v;
+    };
+
+    my $result = $parse_expr->();
+    die "math: trailing tokens\n" if $pos != @tokens;
+    return $result;
 }
 
 sub _get_prompt_sections {

--- a/lib/SignalWire/Skills/Builtin/McpGateway.pm
+++ b/lib/SignalWire/Skills/Builtin/McpGateway.pm
@@ -5,22 +5,22 @@ use Moo;
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('mcp_gateway', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'mcp_gateway', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'mcp_gateway' });
-has '+skill_description' => (default => sub { 'Bridge MCP servers with SWAIG functions' });
-has '+supports_multiple_instances' => (default => sub { 0 });
+has '+skill_name'        => ( default => sub { 'mcp_gateway' } );
+has '+skill_description' => ( default => sub { 'Bridge MCP servers with SWAIG functions' } );
+has '+supports_multiple_instances' => ( default => sub { 0 } );
 
 sub setup { 1 }
 
 sub register_tools {
-    my ($self) = @_;
+    my ($self)   = @_;
     my $prefix   = $self->params->{tool_prefix} // 'mcp_';
-    my $services = $self->params->{services} // [];
+    my $services = $self->params->{services}    // [];
 
     # Register a stub tool for each service
     for my $svc (@$services) {
-        my $svc_name = ref $svc eq 'HASH' ? ($svc->{name} // 'default') : $svc;
+        my $svc_name  = ref $svc eq 'HASH' ? ( $svc->{name} // 'default' ) : $svc;
         my $tool_name = "${prefix}${svc_name}";
         $self->define_tool(
             name        => $tool_name,
@@ -28,15 +28,15 @@ sub register_tools {
             parameters  => {
                 type       => 'object',
                 properties => {
-                    arguments => { type => 'string', description => 'Arguments to pass to MCP service' },
+                    arguments =>
+                        { type => 'string', description => 'Arguments to pass to MCP service' },
                 },
             },
             handler => sub {
-                my ($args, $raw) = @_;
+                my ( $args, $raw ) = @_;
                 require SignalWire::SWAIG::FunctionResult;
                 return SignalWire::SWAIG::FunctionResult->new(
-                    response => "MCP gateway call to $svc_name"
-                );
+                    response => "MCP gateway call to $svc_name" );
             },
         );
     }
@@ -44,9 +44,9 @@ sub register_tools {
 
 sub get_hints {
     my ($self) = @_;
-    my @hints = ('MCP', 'gateway');
-    for my $svc (@{ $self->params->{services} // [] }) {
-        push @hints, ref $svc eq 'HASH' ? ($svc->{name} // ()) : $svc;
+    my @hints = ( 'MCP', 'gateway' );
+    for my $svc ( @{ $self->params->{services} // [] } ) {
+        push @hints, ref $svc eq 'HASH' ? ( $svc->{name} // () ) : $svc;
     }
     return \@hints;
 }
@@ -61,20 +61,22 @@ sub get_global_data {
 }
 
 sub _get_prompt_sections {
-    return [{
-        title   => 'MCP Gateway Integration',
-        body    => 'You have access to MCP gateway services.',
-        bullets => ['Use MCP tools to interact with connected services'],
-    }];
+    return [
+        {
+            title   => 'MCP Gateway Integration',
+            body    => 'You have access to MCP gateway services.',
+            bullets => ['Use MCP tools to interact with connected services'],
+        }
+    ];
 }
 
 sub get_parameter_schema {
     return {
         %{ SignalWire::Skills::SkillBase->get_parameter_schema },
-        gateway_url   => { type => 'string', required => 1 },
-        auth_token    => { type => 'string', hidden => 1 },
-        services      => { type => 'array' },
-        tool_prefix   => { type => 'string', default => 'mcp_' },
+        gateway_url => { type => 'string', required => 1 },
+        auth_token  => { type => 'string', hidden   => 1 },
+        services    => { type => 'array' },
+        tool_prefix => { type => 'string', default => 'mcp_' },
     };
 }
 

--- a/lib/SignalWire/Skills/Builtin/McpGateway.pm
+++ b/lib/SignalWire/Skills/Builtin/McpGateway.pm
@@ -11,7 +11,7 @@ has '+skill_name'        => ( default => sub { 'mcp_gateway' } );
 has '+skill_description' => ( default => sub { 'Bridge MCP servers with SWAIG functions' } );
 has '+supports_multiple_instances' => ( default => sub { 0 } );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self)   = @_;
@@ -40,6 +40,7 @@ sub register_tools {
             },
         );
     }
+    return;
 }
 
 sub get_hints {

--- a/lib/SignalWire/Skills/Builtin/NativeVectorSearch.pm
+++ b/lib/SignalWire/Skills/Builtin/NativeVectorSearch.pm
@@ -15,7 +15,7 @@ has '+skill_description' => (
 );
 has '+supports_multiple_instances' => ( default => sub { 1 } );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self)      = @_;
@@ -23,7 +23,7 @@ sub register_tools {
     my $description = $self->params->{description}
         // 'Search the local knowledge base for information';
 
-    $self->define_tool(
+    return $self->define_tool(
         name        => $tool_name,
         description => $description,
         parameters  => {

--- a/lib/SignalWire/Skills/Builtin/NativeVectorSearch.pm
+++ b/lib/SignalWire/Skills/Builtin/NativeVectorSearch.pm
@@ -5,18 +5,23 @@ use Moo;
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('native_vector_search', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'native_vector_search', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'native_vector_search' });
-has '+skill_description' => (default => sub { 'Search document indexes using vector similarity and keyword search (local or remote)' });
-has '+supports_multiple_instances' => (default => sub { 1 });
+has '+skill_name' => ( default => sub { 'native_vector_search' } );
+has '+skill_description' => (
+    default => sub {
+        'Search document indexes using vector similarity and keyword search (local or remote)';
+    }
+);
+has '+supports_multiple_instances' => ( default => sub { 1 } );
 
 sub setup { 1 }
 
 sub register_tools {
-    my ($self) = @_;
-    my $tool_name   = $self->params->{tool_name}   // 'search_knowledge';
-    my $description = $self->params->{description}  // 'Search the local knowledge base for information';
+    my ($self)      = @_;
+    my $tool_name   = $self->params->{tool_name} // 'search_knowledge';
+    my $description = $self->params->{description}
+        // 'Search the local knowledge base for information';
 
     $self->define_tool(
         name        => $tool_name,
@@ -30,28 +35,29 @@ sub register_tools {
             required => ['query'],
         },
         handler => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             return SignalWire::SWAIG::FunctionResult->new(
-                response => "Vector search for: $args->{query}"
-            );
+                response => "Vector search for: $args->{query}" );
         },
     );
 }
 
 sub get_hints {
     my ($self) = @_;
-    my @base = ('search', 'find', 'look up', 'documentation', 'knowledge base');
+    my @base = ( 'search', 'find', 'look up', 'documentation', 'knowledge base' );
     push @base, @{ $self->params->{hints} // [] };
     return \@base;
 }
 
 sub _get_prompt_sections {
-    return [{
-        title   => 'Knowledge Search',
-        body    => 'You have access to a document search capability.',
-        bullets => ['Use the search tool to find relevant information'],
-    }];
+    return [
+        {
+            title   => 'Knowledge Search',
+            body    => 'You have access to a document search capability.',
+            bullets => ['Use the search tool to find relevant information'],
+        }
+    ];
 }
 
 sub get_parameter_schema {

--- a/lib/SignalWire/Skills/Builtin/PlayBackgroundFile.pm
+++ b/lib/SignalWire/Skills/Builtin/PlayBackgroundFile.pm
@@ -5,18 +5,18 @@ use Moo;
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('play_background_file', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'play_background_file', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'play_background_file' });
-has '+skill_description' => (default => sub { 'Control background file playback' });
-has '+supports_multiple_instances' => (default => sub { 1 });
+has '+skill_name'                  => ( default => sub { 'play_background_file' } );
+has '+skill_description'           => ( default => sub { 'Control background file playback' } );
+has '+supports_multiple_instances' => ( default => sub { 1 } );
 
 sub setup { 1 }
 
 sub register_tools {
-    my ($self) = @_;
+    my ($self)    = @_;
     my $tool_name = $self->params->{tool_name} // 'play_background_file';
-    my $files     = $self->params->{files} // [];
+    my $files     = $self->params->{files}     // [];
 
     # Build action enum from file keys
     my @actions = ('stop');
@@ -25,39 +25,45 @@ sub register_tools {
     }
 
     # DataMap-style registration with expressions
-    $self->agent->register_swaig_function({
-        function    => $tool_name,
-        description => "Control background file playback for $tool_name",
-        parameters  => {
-            type       => 'object',
-            properties => {
-                action => {
-                    type        => 'string',
-                    description => 'Playback action',
-                    enum        => \@actions,
-                },
-            },
-            required => ['action'],
-        },
-        data_map => {
-            expressions => [
-                {
-                    string  => '${args.action}',
-                    pattern => 'stop',
-                    output  => {
-                        response => 'Stopping background playback.',
-                        action   => [{ stop_background_file => {} }],
+    $self->agent->register_swaig_function(
+        {
+            function    => $tool_name,
+            description => "Control background file playback for $tool_name",
+            parameters  => {
+                type       => 'object',
+                properties => {
+                    action => {
+                        type        => 'string',
+                        description => 'Playback action',
+                        enum        => \@actions,
                     },
                 },
-            ],
-        },
-    });
+                required => ['action'],
+            },
+            data_map => {
+                expressions => [
+                    {
+                        string  => '${args.action}',
+                        pattern => 'stop',
+                        output  => {
+                            response => 'Stopping background playback.',
+                            action   => [ { stop_background_file => {} } ],
+                        },
+                    },
+                ],
+            },
+        }
+    );
 }
 
 sub get_parameter_schema {
     return {
         %{ SignalWire::Skills::SkillBase->get_parameter_schema },
-        files     => { type => 'array', required => 1, description => 'Array of file objects with key, description, url' },
+        files => {
+            type        => 'array',
+            required    => 1,
+            description => 'Array of file objects with key, description, url'
+        },
         tool_name => { type => 'string', default => 'play_background_file' },
     };
 }

--- a/lib/SignalWire/Skills/Builtin/PlayBackgroundFile.pm
+++ b/lib/SignalWire/Skills/Builtin/PlayBackgroundFile.pm
@@ -11,7 +11,7 @@ has '+skill_name'                  => ( default => sub { 'play_background_file' 
 has '+skill_description'           => ( default => sub { 'Control background file playback' } );
 has '+supports_multiple_instances' => ( default => sub { 1 } );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self)    = @_;
@@ -25,7 +25,7 @@ sub register_tools {
     }
 
     # DataMap-style registration with expressions
-    $self->agent->register_swaig_function(
+    return $self->agent->register_swaig_function(
         {
             function    => $tool_name,
             description => "Control background file playback for $tool_name",

--- a/lib/SignalWire/Skills/Builtin/Spider.pm
+++ b/lib/SignalWire/Skills/Builtin/Spider.pm
@@ -46,7 +46,7 @@ has '_http' => (
     },
 );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self)      = @_;
@@ -98,7 +98,7 @@ sub register_tools {
         },
     );
 
-    $self->define_tool(
+    return $self->define_tool(
         name        => "${tool_prefix}extract_structured_data",
         description => 'Extract structured data from a URL',
         parameters  => {

--- a/lib/SignalWire/Skills/Builtin/Spider.pm
+++ b/lib/SignalWire/Skills/Builtin/Spider.pm
@@ -1,4 +1,5 @@
 package SignalWire::Skills::Builtin::Spider;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -18,11 +19,11 @@ use JSON ();
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('spider', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'spider', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'spider' });
-has '+skill_description' => (default => sub { 'Fast web scraping and crawling capabilities' });
-has '+supports_multiple_instances' => (default => sub { 1 });
+has '+skill_name'        => ( default => sub { 'spider' } );
+has '+skill_description' => ( default => sub { 'Fast web scraping and crawling capabilities' } );
+has '+supports_multiple_instances' => ( default => sub { 1 } );
 
 # Honor SPIDER_BASE_URL env var. When set, the skill rewrites the
 # user-supplied URL onto the base — useful for the audit fixture
@@ -48,9 +49,9 @@ has '_http' => (
 sub setup { 1 }
 
 sub register_tools {
-    my ($self) = @_;
+    my ($self)      = @_;
     my $tool_prefix = $self->params->{tool_prefix} // '';
-    my $weak_self = $self;
+    my $weak_self   = $self;
     require Scalar::Util;
     Scalar::Util::weaken($weak_self);
 
@@ -65,11 +66,11 @@ sub register_tools {
             required => ['url'],
         },
         handler => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
-            my $url = $args->{url} // '';
+            my $url  = $args->{url} // '';
             my $text = $weak_self->scrape_url($url);
-            return SignalWire::SWAIG::FunctionResult->new(response => $text);
+            return SignalWire::SWAIG::FunctionResult->new( response => $text );
         },
     );
 
@@ -84,15 +85,16 @@ sub register_tools {
             required => ['start_url'],
         },
         handler => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             my $url = $args->{start_url} // '';
+
             # crawl_site is a single-page wrapper around scrape_url here;
             # multi-page crawl + URL frontier is out of scope for the
             # Perl port (Python's lxml-based crawl tree is its own
             # 600-line concern).
             my $text = $weak_self->scrape_url($url);
-            return SignalWire::SWAIG::FunctionResult->new(response => $text);
+            return SignalWire::SWAIG::FunctionResult->new( response => $text );
         },
     );
 
@@ -107,31 +109,32 @@ sub register_tools {
             required => ['url'],
         },
         handler => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
-            my $url = $args->{url} // '';
+            my $url  = $args->{url} // '';
             my $text = $weak_self->scrape_url($url);
-            return SignalWire::SWAIG::FunctionResult->new(response => $text);
+            return SignalWire::SWAIG::FunctionResult->new( response => $text );
         },
     );
 }
 
 sub scrape_url {
-    my ($self, $url) = @_;
+    my ( $self, $url ) = @_;
     my $target = $self->_resolve_url($url);
-    my $resp = $self->_http->get($target);
-    unless ($resp->{success}) {
+    my $resp   = $self->_http->get($target);
+    unless ( $resp->{success} ) {
         return "Spider error: $resp->{status} $resp->{reason} ($target)";
     }
 
     my $body = $resp->{content} // '';
+
     # The audit fixture serves JSON like {"_raw_html": "<html>...</html>"}
     # because http.server can't easily decide between content types.
     # If the response decodes as JSON, lift the embedded HTML out;
     # otherwise treat the body as HTML directly.
-    if ($body =~ /^\s*\{/) {
+    if ( $body =~ /^\s*\{/ ) {
         my $parsed = eval { JSON::decode_json($body) };
-        if (!$@ && ref $parsed eq 'HASH' && exists $parsed->{_raw_html}) {
+        if ( !$@ && ref $parsed eq 'HASH' && exists $parsed->{_raw_html} ) {
             $body = $parsed->{_raw_html};
         }
     }
@@ -140,13 +143,14 @@ sub scrape_url {
 }
 
 sub _resolve_url {
-    my ($self, $url) = @_;
+    my ( $self, $url ) = @_;
     return $url unless $self->base_url;
+
     # When a base URL is configured, route the request through it,
     # preserving the path/query of the requested URL. This mirrors
     # the audit harness contract in SUBAGENT_PLAYBOOK § audit_skills.
     my $path;
-    if ($url =~ m{^https?://[^/]+(/.*)?$}) {
+    if ( $url =~ m{^https?://[^/]+(/.*)?$} ) {
         $path = $1 // '/';
     } else {
         $path = $url;
@@ -164,6 +168,7 @@ sub _extract_text {
     # Strip <script> and <style> blocks entirely.
     $html =~ s{<script\b[^>]*>.*?</script\s*>}{}gisx;
     $html =~ s{<style\b[^>]*>.*?</style\s*>}{}gisx;
+
     # Strip remaining tags, decode common entities, collapse whitespace.
     $html =~ s/<[^>]+>/ /g;
     $html =~ s/&nbsp;/ /gi;
@@ -178,7 +183,7 @@ sub _extract_text {
 }
 
 sub get_hints {
-    return ['scrape', 'crawl', 'extract', 'web page', 'website', 'spider'];
+    return [ 'scrape', 'crawl', 'extract', 'web page', 'website', 'spider' ];
 }
 
 sub get_parameter_schema {

--- a/lib/SignalWire/Skills/Builtin/SwmlTransfer.pm
+++ b/lib/SignalWire/Skills/Builtin/SwmlTransfer.pm
@@ -12,7 +12,7 @@ has '+skill_description' =>
     ( default => sub { 'Transfer calls between agents based on pattern matching' } );
 has '+supports_multiple_instances' => ( default => sub { 1 } );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self)      = @_;
@@ -39,7 +39,7 @@ sub register_tools {
             };
     }
 
-    $self->agent->register_swaig_function(
+    return $self->agent->register_swaig_function(
         {
             function    => $tool_name,
             description => $description,

--- a/lib/SignalWire/Skills/Builtin/SwmlTransfer.pm
+++ b/lib/SignalWire/Skills/Builtin/SwmlTransfer.pm
@@ -5,20 +5,21 @@ use Moo;
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('swml_transfer', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'swml_transfer', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'swml_transfer' });
-has '+skill_description' => (default => sub { 'Transfer calls between agents based on pattern matching' });
-has '+supports_multiple_instances' => (default => sub { 1 });
+has '+skill_name' => ( default => sub { 'swml_transfer' } );
+has '+skill_description' =>
+    ( default => sub { 'Transfer calls between agents based on pattern matching' } );
+has '+supports_multiple_instances' => ( default => sub { 1 } );
 
 sub setup { 1 }
 
 sub register_tools {
-    my ($self) = @_;
-    my $tool_name   = $self->params->{tool_name}   // 'transfer_call';
-    my $description = $self->params->{description}  // 'Transfer call based on pattern matching';
+    my ($self)      = @_;
+    my $tool_name   = $self->params->{tool_name}      // 'transfer_call';
+    my $description = $self->params->{description}    // 'Transfer call based on pattern matching';
     my $param_name  = $self->params->{parameter_name} // 'transfer_type';
-    my $transfers   = $self->params->{transfers}    // {};
+    my $transfers   = $self->params->{transfers}      // {};
 
     my @patterns = keys %$transfers;
 
@@ -27,54 +28,58 @@ sub register_tools {
     for my $pattern (@patterns) {
         my $cfg = $transfers->{$pattern};
         my $url = $cfg->{url} // $cfg->{address} // '';
-        push @expressions, {
+        push @expressions,
+            {
             string  => "\${args.$param_name}",
             pattern => $pattern,
             output  => {
                 response => $cfg->{message} // "Transferring to $pattern",
-                action   => [{ swml_transfer => $url }],
+                action   => [ { swml_transfer => $url } ],
             },
-        };
+            };
     }
 
-    $self->agent->register_swaig_function({
-        function    => $tool_name,
-        description => $description,
-        parameters  => {
-            type       => 'object',
-            properties => {
-                $param_name => {
-                    type        => 'string',
-                    description => $self->params->{parameter_description} // 'The transfer destination',
+    $self->agent->register_swaig_function(
+        {
+            function    => $tool_name,
+            description => $description,
+            parameters  => {
+                type       => 'object',
+                properties => {
+                    $param_name => {
+                        type        => 'string',
+                        description => $self->params->{parameter_description}
+                            // 'The transfer destination',
+                    },
                 },
+                required => [$param_name],
             },
-            required => [$param_name],
-        },
-        data_map => { expressions => \@expressions },
-    });
+            data_map => { expressions => \@expressions },
+        }
+    );
 }
 
 sub get_hints {
     my ($self) = @_;
-    my @hints = ('transfer', 'connect', 'speak to', 'talk to');
-    for my $pattern (keys %{ $self->params->{transfers} // {} }) {
-        push @hints, split(/[\s_-]+/, $pattern);
+    my @hints = ( 'transfer', 'connect', 'speak to', 'talk to' );
+    for my $pattern ( keys %{ $self->params->{transfers} // {} } ) {
+        push @hints, split( /[\s_-]+/, $pattern );
     }
     return \@hints;
 }
 
 sub _get_prompt_sections {
-    my ($self) = @_;
-    my $transfers = $self->params->{transfers} // {};
+    my ($self)       = @_;
+    my $transfers    = $self->params->{transfers} // {};
     my @destinations = map { "- $_" } keys %$transfers;
     return [
         {
-            title   => 'Transferring',
-            body    => "Available transfer destinations:\n" . join("\n", @destinations),
+            title => 'Transferring',
+            body  => "Available transfer destinations:\n" . join( "\n", @destinations ),
         },
         {
-            title   => 'Transfer Instructions',
-            body    => 'When the user wants to be transferred, use the transfer tool.',
+            title => 'Transfer Instructions',
+            body  => 'When the user wants to be transferred, use the transfer tool.',
         },
     ];
 }

--- a/lib/SignalWire/Skills/Builtin/WeatherApi.pm
+++ b/lib/SignalWire/Skills/Builtin/WeatherApi.pm
@@ -5,23 +5,24 @@ use Moo;
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('weather_api', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'weather_api', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'weather_api' });
-has '+skill_description' => (default => sub { 'Get current weather information from WeatherAPI.com' });
-has '+supports_multiple_instances' => (default => sub { 0 });
+has '+skill_name' => ( default => sub { 'weather_api' } );
+has '+skill_description' =>
+    ( default => sub { 'Get current weather information from WeatherAPI.com' } );
+has '+supports_multiple_instances' => ( default => sub { 0 } );
 
 sub setup { 1 }
 
 sub register_tools {
-    my ($self) = @_;
-    my $tool_name = $self->params->{tool_name} // 'get_weather';
-    my $api_key   = $self->params->{api_key}   // '';
+    my ($self)    = @_;
+    my $tool_name = $self->params->{tool_name}        // 'get_weather';
+    my $api_key   = $self->params->{api_key}          // '';
     my $unit      = $self->params->{temperature_unit} // 'fahrenheit';
 
-    my $temp_field = $unit eq 'celsius' ? 'temp_c' : 'temp_f';
+    my $temp_field  = $unit eq 'celsius' ? 'temp_c'      : 'temp_f';
     my $feels_field = $unit eq 'celsius' ? 'feelslike_c' : 'feelslike_f';
-    my $unit_label  = $unit eq 'celsius' ? 'C' : 'F';
+    my $unit_label  = $unit eq 'celsius' ? 'C'           : 'F';
 
     # Honor WEATHER_API_BASE_URL env var so the audit fixture
     # (audit_skills_dispatch.py) can redirect us at a local HTTP server.
@@ -35,41 +36,47 @@ sub register_tools {
         $base =~ s{/+$}{};
         $url = "$base/v1/current.json?key=${api_key}&q=\${lc:enc:args.location}&aqi=no";
     } else {
-        $url = "https://api.weatherapi.com/v1/current.json?key=${api_key}&q=\${lc:enc:args.location}&aqi=no";
+        $url =
+"https://api.weatherapi.com/v1/current.json?key=${api_key}&q=\${lc:enc:args.location}&aqi=no";
     }
 
-    $self->agent->register_swaig_function({
-        function    => $tool_name,
-        description => 'Get current weather information for any location',
-        parameters  => {
-            type       => 'object',
-            properties => {
-                location => { type => 'string', description => 'Location to get weather for' },
-            },
-            required => ['location'],
-        },
-        data_map => {
-            webhooks => [{
-                method => 'GET',
-                url    => $url,
-                output => {
-                    response => "Temperature: \${current.${temp_field}}${unit_label}, "
-                              . "Feels like: \${current.${feels_field}}${unit_label}, "
-                              . "Condition: \${current.condition.text}, "
-                              . "Humidity: \${current.humidity}%, "
-                              . "Wind: \${current.wind_mph} mph",
+    $self->agent->register_swaig_function(
+        {
+            function    => $tool_name,
+            description => 'Get current weather information for any location',
+            parameters  => {
+                type       => 'object',
+                properties => {
+                    location => { type => 'string', description => 'Location to get weather for' },
                 },
-            }],
-        },
-    });
+                required => ['location'],
+            },
+            data_map => {
+                webhooks => [
+                    {
+                        method => 'GET',
+                        url    => $url,
+                        output => {
+                            response => "Temperature: \${current.${temp_field}}${unit_label}, "
+                                . "Feels like: \${current.${feels_field}}${unit_label}, "
+                                . "Condition: \${current.condition.text}, "
+                                . "Humidity: \${current.humidity}%, "
+                                . "Wind: \${current.wind_mph} mph",
+                        },
+                    }
+                ],
+            },
+        }
+    );
 }
 
 sub get_parameter_schema {
     return {
         %{ SignalWire::Skills::SkillBase->get_parameter_schema },
         api_key          => { type => 'string', required => 1, hidden => 1 },
-        tool_name        => { type => 'string', default => 'get_weather' },
-        temperature_unit => { type => 'string', enum => ['fahrenheit', 'celsius'], default => 'fahrenheit' },
+        tool_name        => { type => 'string', default  => 'get_weather' },
+        temperature_unit =>
+            { type => 'string', enum => [ 'fahrenheit', 'celsius' ], default => 'fahrenheit' },
     };
 }
 

--- a/lib/SignalWire/Skills/Builtin/WeatherApi.pm
+++ b/lib/SignalWire/Skills/Builtin/WeatherApi.pm
@@ -12,7 +12,7 @@ has '+skill_description' =>
     ( default => sub { 'Get current weather information from WeatherAPI.com' } );
 has '+supports_multiple_instances' => ( default => sub { 0 } );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 sub register_tools {
     my ($self)    = @_;
@@ -40,7 +40,7 @@ sub register_tools {
 "https://api.weatherapi.com/v1/current.json?key=${api_key}&q=\${lc:enc:args.location}&aqi=no";
     }
 
-    $self->agent->register_swaig_function(
+    return $self->agent->register_swaig_function(
         {
             function    => $tool_name,
             description => 'Get current weather information for any location',

--- a/lib/SignalWire/Skills/Builtin/WebSearch.pm
+++ b/lib/SignalWire/Skills/Builtin/WebSearch.pm
@@ -1,4 +1,5 @@
 package SignalWire::Skills::Builtin::WebSearch;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -18,17 +19,18 @@ use strict;
 use warnings;
 use Moo;
 use HTTP::Tiny;
-use JSON ();
+use JSON        ();
 use URI::Escape qw(uri_escape);
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('web_search', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'web_search', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'web_search' });
-has '+skill_description' => (default => sub { 'Search the web for information using Google Custom Search API' });
-has '+skill_version'     => (default => sub { '2.0.0' });
-has '+supports_multiple_instances' => (default => sub { 1 });
+has '+skill_name' => ( default => sub { 'web_search' } );
+has '+skill_description' =>
+    ( default => sub { 'Search the web for information using Google Custom Search API' } );
+has '+skill_version'               => ( default => sub { '2.0.0' } );
+has '+supports_multiple_instances' => ( default => sub { 1 } );
 
 # Google CSE base URL. Honor WEB_SEARCH_BASE_URL env var so the audit
 # fixture (audit_skills_dispatch.py) can redirect us at a local HTTP
@@ -43,6 +45,7 @@ has 'base_url' => (
     default => sub {
         my $override = $ENV{WEB_SEARCH_BASE_URL};
         return 'https://www.googleapis.com/customsearch/v1' unless $override;
+
         # Strip trailing slash, then append the canonical Google CSE
         # path so callers see the same URL shape as production.
         $override =~ s{/+$}{};
@@ -112,21 +115,21 @@ sub _per_page_timeout {
     my ($self) = @_;
     my $t = $self->params->{per_page_timeout};
     $t = 2.0 unless defined $t;
-    $t += 0;                 # numify
-    return $t > 0 ? $t : 15; # never unbounded
+    $t += 0;                    # numify
+    return $t > 0 ? $t : 15;    # never unbounded
 }
 
 sub _overall_deadline {
     my ($self) = @_;
     my $d = $self->params->{overall_deadline};
     $d = 10.0 unless defined $d;
-    return $d + 0;           # numify
+    return $d + 0;              # numify
 }
 
 sub _parallel_scrape {
     my ($self) = @_;
     my $p = $self->params->{parallel_scrape};
-    return 1 unless defined $p;   # default true
+    return 1 unless defined $p;    # default true
     return $p ? 1 : 0;
 }
 
@@ -145,8 +148,9 @@ sub register_tools {
 
     $self->define_tool(
         name        => $tool_name,
-        description => 'Search the web for high-quality information, automatically filtering low-quality results',
-        parameters  => {
+        description =>
+'Search the web for high-quality information, automatically filtering low-quality results',
+        parameters => {
             type       => 'object',
             properties => {
                 query => { type => 'string', description => 'The search query' },
@@ -154,18 +158,18 @@ sub register_tools {
             required => ['query'],
         },
         handler => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             my $query = $args->{query} // '';
-            my $text = $weak_self->search_web($query);
+            my $text  = $weak_self->search_web($query);
             $text = $weak_self->_wrap_response($text);
-            return SignalWire::SWAIG::FunctionResult->new(response => $text);
+            return SignalWire::SWAIG::FunctionResult->new( response => $text );
         },
     );
 }
 
 sub search_web {
-    my ($self, $query) = @_;
+    my ( $self, $query ) = @_;
 
     # overall_deadline is the wall-clock budget for the WHOLE tool call.
     # Start the clock before the (slowest, non-cancelable) CSE fetch so a
@@ -176,27 +180,29 @@ sub search_web {
     my $deadline_at = $started_at + $self->_overall_deadline;
 
     my $api_key = $self->params->{api_key} || $ENV{GOOGLE_API_KEY} || '';
-    my $cse_id  = $self->params->{search_engine_id}
+    my $cse_id =
+           $self->params->{search_engine_id}
         || $self->params->{cx}
         || $ENV{GOOGLE_CSE_ID}
         || '';
-    my $num     = $self->params->{num_results} // 3;
+    my $num = $self->params->{num_results} // 3;
     $num = 10 if $num > 10;
-    $num = 1 if $num < 1;
+    $num = 1  if $num < 1;
 
-    my $url = $self->base_url
-        . '?key=' . uri_escape($api_key)
-        . '&cx=' . uri_escape($cse_id)
-        . '&q=' . uri_escape($query)
-        . '&num=' . $num;
+    my $url =
+          $self->base_url . '?key='
+        . uri_escape($api_key) . '&cx='
+        . uri_escape($cse_id) . '&q='
+        . uri_escape($query) . '&num='
+        . $num;
 
     # The CSE GET is bounded by per_page_timeout via the _http client's
     # HTTP::Tiny timeout (set from _per_page_timeout in the _http builder).
     my $resp = $self->_http->get($url);
-    unless ($resp->{success}) {
+    unless ( $resp->{success} ) {
         return "Web search error: $resp->{status} $resp->{reason}";
     }
-    my $data = eval { JSON::decode_json($resp->{content}) };
+    my $data = eval { JSON::decode_json( $resp->{content} ) };
     return "Web search parse error: $@" if $@;
 
     my $items = $data->{items} // [];
@@ -216,20 +222,21 @@ sub search_web {
     # fallback immediately so the caller always gets non-empty context
     # before the kernel webhook timeout fires — exactly as Python falls
     # back to _format_snippet_results when time runs out.
-    if ($self->_deadline_exceeded($deadline_at)) {
-        return $self->_format_snippet_results($query, $items, $num);
+    if ( $self->_deadline_exceeded($deadline_at) ) {
+        return $self->_format_snippet_results( $query, $items, $num );
     }
 
     my @lines;
     my $i = 1;
     for my $item (@$items) {
         last if $i > $num;
+
         # Re-check the deadline inside the loop. Formatting is cheap, but
         # the contract is "check before each unit of work and stop once
         # exceeded"; this keeps the guard honest even if a future change
         # makes per-item work expensive.
-        if ($self->_deadline_exceeded($deadline_at)) {
-            return $self->_format_snippet_results($query, $items, $num);
+        if ( $self->_deadline_exceeded($deadline_at) ) {
+            return $self->_format_snippet_results( $query, $items, $num );
         }
         my $title   = $item->{title}   // '';
         my $link    = $item->{link}    // '';
@@ -237,14 +244,14 @@ sub search_web {
         push @lines, "$i. $title\n   $snippet\n   $link";
         $i++;
     }
-    return join("\n\n", @lines);
+    return join( "\n\n", @lines );
 }
 
 # True once the monotonic clock has reached/passed the deadline. Reads the
 # overridable _clock hook so a test can inject elapsed time and drive the
 # deadline path deterministically (no real sleeping).
 sub _deadline_exceeded {
-    my ($self, $deadline_at) = @_;
+    my ( $self, $deadline_at ) = @_;
     return $self->_clock->() >= $deadline_at ? 1 : 0;
 }
 
@@ -257,13 +264,13 @@ sub _deadline_exceeded {
 # title + snippet + url for each item, so downstream sentinel/quality checks
 # still see the same content the happy path would emit.
 sub _format_snippet_results {
-    my ($self, $query, $items, $num) = @_;
+    my ( $self, $query, $items, $num ) = @_;
     $items ||= [];
     return "No results for: $query" unless @$items;
 
-    my $top = $num && $num > 0 ? $num : 1;
-    my @lines = ("Snippet-only results for '$query' (page content not scraped):", "");
-    my $i = 1;
+    my $top   = $num && $num > 0 ? $num : 1;
+    my @lines = ( "Snippet-only results for '$query' (page content not scraped):", "" );
+    my $i     = 1;
     for my $item (@$items) {
         last if $i > $top;
         my $title   = $item->{title}   // '';
@@ -278,7 +285,7 @@ sub _format_snippet_results {
         push @lines, "";
         $i++;
     }
-    my $out = join("\n", @lines);
+    my $out = join( "\n", @lines );
     $out =~ s/\n+$//;
     return $out;
 }
@@ -289,8 +296,9 @@ sub _format_snippet_results {
 # side. Error / no-result branches are passed through unwrapped so the
 # LLM still sees the failure mode verbatim.
 sub _wrap_response {
-    my ($self, $text) = @_;
+    my ( $self, $text ) = @_;
     return $text unless defined $text && length $text;
+
     # Match Python's "errors don't get wrapped" pattern. The Perl
     # search_web returns one of three known failure sentinels; anything
     # else is a real result list.
@@ -313,24 +321,27 @@ sub get_global_data {
 }
 
 sub _get_prompt_sections {
-    return [{
-        title   => 'Web Search Capability (Quality Enhanced)',
-        body    => '',
-        bullets => [
-            'Use web_search to find current information',
-            'Results are quality-filtered automatically',
-        ],
-    }];
+    return [
+        {
+            title   => 'Web Search Capability (Quality Enhanced)',
+            body    => '',
+            bullets => [
+                'Use web_search to find current information',
+                'Results are quality-filtered automatically',
+            ],
+        }
+    ];
 }
 
 sub get_parameter_schema {
     return {
         %{ SignalWire::Skills::SkillBase->get_parameter_schema },
-        api_key           => { type => 'string',  required => 1, hidden => 1 },
-        search_engine_id  => { type => 'string',  required => 1, hidden => 1 },
-        num_results       => { type => 'integer', default  => 3, min => 1, max => 10 },
-        response_prefix   => { type => 'string',  default  => '' },
-        response_postfix  => { type => 'string',  default  => '' },
+        api_key          => { type => 'string',  required => 1, hidden => 1 },
+        search_engine_id => { type => 'string',  required => 1, hidden => 1 },
+        num_results      => { type => 'integer', default  => 3, min    => 1, max => 10 },
+        response_prefix  => { type => 'string',  default  => '' },
+        response_postfix => { type => 'string',  default  => '' },
+
         # Latency-control parameters (Python parity: 51101da + 295745b). The
         # kernel times out webhook responses around 55s; these keep the
         # handler under that. per_page_timeout bounds the CSE HTTP fetch;
@@ -338,31 +349,35 @@ sub get_parameter_schema {
         # parallel_scrape is accepted for API parity (Perl runs sequentially,
         # not contracted); snippets_only returns CSE snippets directly (the
         # Perl skill's default behavior).
-        per_page_timeout  => {
+        per_page_timeout => {
             type        => 'number',
-            description => 'Maximum seconds to wait on a single page fetch (the Google CSE HTTP call for this snippet-only skill).',
-            default     => 2.0,
-            required    => 0,
-            min         => 0.1,
+            description =>
+'Maximum seconds to wait on a single page fetch (the Google CSE HTTP call for this snippet-only skill).',
+            default  => 2.0,
+            required => 0,
+            min      => 0.1,
         },
-        overall_deadline  => {
+        overall_deadline => {
             type        => 'number',
-            description => 'Wall-clock budget in seconds for the whole tool call. Once exceeded, format the CSE snippets we already have so the response beats the kernel webhook timeout.',
-            default     => 10.0,
-            required    => 0,
-            min         => 1.0,
+            description =>
+'Wall-clock budget in seconds for the whole tool call. Once exceeded, format the CSE snippets we already have so the response beats the kernel webhook timeout.',
+            default  => 10.0,
+            required => 0,
+            min      => 1.0,
         },
-        parallel_scrape   => {
+        parallel_scrape => {
             type        => 'boolean',
-            description => 'Accepted for API parity with the scraping ports. The Perl skill is snippet-only and runs sequentially; this flag has no effect.',
-            default     => 1,
-            required    => 0,
+            description =>
+'Accepted for API parity with the scraping ports. The Perl skill is snippet-only and runs sequentially; this flag has no effect.',
+            default  => 1,
+            required => 0,
         },
-        snippets_only     => {
+        snippets_only => {
             type        => 'boolean',
-            description => 'Return Google CSE snippets directly without deep-scraping result pages. This is the Perl skill\'s default behavior.',
-            default     => 0,
-            required    => 0,
+            description =>
+'Return Google CSE snippets directly without deep-scraping result pages. This is the Perl skill\'s default behavior.',
+            default  => 0,
+            required => 0,
         },
     };
 }

--- a/lib/SignalWire/Skills/Builtin/WebSearch.pm
+++ b/lib/SignalWire/Skills/Builtin/WebSearch.pm
@@ -86,7 +86,7 @@ has '_clock' => (
     },
 );
 
-sub setup { 1 }
+sub setup { return 1 }
 
 # --- Latency-control param readers (Python parity: 51101da) -------------
 #
@@ -146,7 +146,7 @@ sub register_tools {
     require Scalar::Util;
     Scalar::Util::weaken($weak_self);
 
-    $self->define_tool(
+    return $self->define_tool(
         name        => $tool_name,
         description =>
 'Search the web for high-quality information, automatically filtering low-quality results',

--- a/lib/SignalWire/Skills/Builtin/WebSearch.pm
+++ b/lib/SignalWire/Skills/Builtin/WebSearch.pm
@@ -155,7 +155,10 @@ sub register_tools {
             properties => {
                 query => { type => 'string', description => 'The search query' },
             },
-            required => ['query'],
+
+            # No `required`: the Python reference (skills/web_search/skill.py)
+            # passes none and the handler guards an empty query. Adding it would
+            # over-constrain the SWAIG schema vs the reference contract.
         },
         handler => sub {
             my ( $args, $raw ) = @_;

--- a/lib/SignalWire/Skills/Builtin/WikipediaSearch.pm
+++ b/lib/SignalWire/Skills/Builtin/WikipediaSearch.pm
@@ -82,7 +82,7 @@ sub register_tools {
     require Scalar::Util;
     Scalar::Util::weaken($weak_self);
 
-    $self->define_tool(
+    return $self->define_tool(
         name        => 'search_wiki',
         description => 'Search Wikipedia for information about a topic and get article summaries',
         parameters  => {

--- a/lib/SignalWire/Skills/Builtin/WikipediaSearch.pm
+++ b/lib/SignalWire/Skills/Builtin/WikipediaSearch.pm
@@ -1,4 +1,5 @@
 package SignalWire::Skills::Builtin::WikipediaSearch;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -12,16 +13,17 @@ use strict;
 use warnings;
 use Moo;
 use HTTP::Tiny;
-use JSON ();
+use JSON        ();
 use URI::Escape qw(uri_escape);
 extends 'SignalWire::Skills::SkillBase';
 
 use SignalWire::Skills::SkillRegistry;
-SignalWire::Skills::SkillRegistry->register_skill('wikipedia_search', __PACKAGE__);
+SignalWire::Skills::SkillRegistry->register_skill( 'wikipedia_search', __PACKAGE__ );
 
-has '+skill_name'        => (default => sub { 'wikipedia_search' });
-has '+skill_description' => (default => sub { 'Search Wikipedia for information about a topic and get article summaries' });
-has '+supports_multiple_instances' => (default => sub { 0 });
+has '+skill_name' => ( default => sub { 'wikipedia_search' } );
+has '+skill_description' => (
+    default => sub { 'Search Wikipedia for information about a topic and get article summaries' } );
+has '+supports_multiple_instances' => ( default => sub { 0 } );
 
 # Default Wikipedia API base. Honor WIKIPEDIA_BASE_URL env var so the
 # audit fixture (audit_skills_dispatch.py) can redirect us at a local
@@ -40,7 +42,7 @@ has 'base_url' => (
     },
 );
 
-has 'num_results' => (is => 'ro', lazy => 1, default => sub { 1 });
+has 'num_results' => ( is => 'ro', lazy => 1, default => sub { 1 } );
 has 'no_results_message' => (
     is      => 'ro',
     lazy    => 1,
@@ -63,12 +65,12 @@ has '_http' => (
 
 sub setup {
     my ($self) = @_;
-    if (defined $self->params->{num_results}) {
+    if ( defined $self->params->{num_results} ) {
         my $n = $self->params->{num_results};
         $n = 1 if $n < 1;
         $self->{num_results} = $n;
     }
-    if (defined $self->params->{no_results_message}) {
+    if ( defined $self->params->{no_results_message} ) {
         $self->{no_results_message} = $self->params->{no_results_message};
     }
     return 1;
@@ -94,36 +96,39 @@ sub register_tools {
             required => ['query'],
         },
         handler => sub {
-            my ($args, $raw) = @_;
+            my ( $args, $raw ) = @_;
             require SignalWire::SWAIG::FunctionResult;
             my $query = $args->{query} // '';
             $query =~ s/^\s+|\s+$//g;
-            unless (length $query) {
+            unless ( length $query ) {
                 return SignalWire::SWAIG::FunctionResult->new(
-                    response => 'Please provide a search query for Wikipedia.',
-                );
+                    response => 'Please provide a search query for Wikipedia.', );
             }
             my $text = $weak_self->search_wiki($query);
-            return SignalWire::SWAIG::FunctionResult->new(response => $text);
+            return SignalWire::SWAIG::FunctionResult->new( response => $text );
         },
     );
 }
 
 sub search_wiki {
-    my ($self, $query) = @_;
+    my ( $self, $query ) = @_;
 
     my $base = $self->base_url;
+
     # Step 1: search.
-    my $search_url = $base
+    my $search_url =
+          $base
         . '?action=query&list=search&format=json'
-        . '&srsearch=' . uri_escape($query)
-        . '&srlimit=' . $self->num_results;
+        . '&srsearch='
+        . uri_escape($query)
+        . '&srlimit='
+        . $self->num_results;
 
     my $resp = $self->_http->get($search_url);
-    unless ($resp->{success}) {
+    unless ( $resp->{success} ) {
         return "Error accessing Wikipedia: $resp->{status} $resp->{reason}";
     }
-    my $data = eval { JSON::decode_json($resp->{content}) };
+    my $data = eval { JSON::decode_json( $resp->{content} ) };
     return "Error parsing Wikipedia response: $@" if $@;
 
     my $hits = $data->{query}{search} // [];
@@ -142,22 +147,25 @@ sub search_wiki {
     my $i = 0;
     for my $hit (@$hits) {
         last if $i++ >= $self->num_results;
-        my $title = $hit->{title} // 'Unknown';
+        my $title   = $hit->{title} // 'Unknown';
         my $snippet = $hit->{snippet};
         my $extract;
 
-        if (defined $snippet && length $snippet) {
+        if ( defined $snippet && length $snippet ) {
+
             # Strip HTML tags Wikipedia includes in the snippet.
             $extract = $snippet;
             $extract =~ s/<[^>]+>//g;
         } else {
-            my $extract_url = $base
+            my $extract_url =
+                  $base
                 . '?action=query&prop=extracts&exintro&explaintext&format=json'
-                . '&titles=' . uri_escape($title);
+                . '&titles='
+                . uri_escape($title);
             my $er = $self->_http->get($extract_url);
-            if ($er->{success}) {
-                my $ed = eval { JSON::decode_json($er->{content}) };
-                if (!$@ && $ed) {
+            if ( $er->{success} ) {
+                my $ed = eval { JSON::decode_json( $er->{content} ) };
+                if ( !$@ && $ed ) {
                     my $pages = $ed->{query}{pages} // {};
                     my ($first) = values %$pages;
                     $extract = $first->{extract} if $first;
@@ -165,25 +173,27 @@ sub search_wiki {
             }
         }
 
-        if (defined $extract && length $extract) {
+        if ( defined $extract && length $extract ) {
             push @articles, "**$title**\n\n$extract";
         } else {
             push @articles, "**$title**\n\nNo summary available for this article.";
         }
     }
 
-    return join("\n\n" . ('=' x 50) . "\n\n", @articles);
+    return join( "\n\n" . ( '=' x 50 ) . "\n\n", @articles );
 }
 
 sub _get_prompt_sections {
-    return [{
-        title   => 'Wikipedia Search',
-        body    => 'You can search Wikipedia for factual information.',
-        bullets => [
-            'Use search_wiki to find information about any topic',
-            'Results include article summaries from Wikipedia',
-        ],
-    }];
+    return [
+        {
+            title   => 'Wikipedia Search',
+            body    => 'You can search Wikipedia for factual information.',
+            bullets => [
+                'Use search_wiki to find information about any topic',
+                'Results include article summaries from Wikipedia',
+            ],
+        }
+    ];
 }
 
 sub get_parameter_schema {

--- a/lib/SignalWire/Skills/Builtin/WikipediaSearch.pm
+++ b/lib/SignalWire/Skills/Builtin/WikipediaSearch.pm
@@ -93,7 +93,10 @@ sub register_tools {
                     description => 'The search term or topic to look up on Wikipedia',
                 },
             },
-            required => ['query'],
+
+            # No `required`: the Python reference (skills/wikipedia_search/skill.py)
+            # passes none and the handler guards an empty query. Adding it would
+            # over-constrain the SWAIG schema vs the reference contract.
         },
         handler => sub {
             my ( $args, $raw ) = @_;

--- a/lib/SignalWire/Skills/SkillBase.pm
+++ b/lib/SignalWire/Skills/SkillBase.pm
@@ -49,6 +49,7 @@ sub BUILD ( $self, @ ) {
     if ( exists $self->params->{swaig_fields} ) {
         $self->swaig_fields( delete $self->params->{swaig_fields} );
     }
+    return;
 }
 
 # --- Abstract interface (subclasses must override) ---

--- a/lib/SignalWire/Skills/SkillBase.pm
+++ b/lib/SignalWire/Skills/SkillBase.pm
@@ -1,13 +1,15 @@
 package SignalWire::Skills::SkillBase;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 
 use strict;
 use warnings;
 use Moo;
+
 # Subroutine signatures (stable since Perl 5.36, the SDK's floor).
 use feature 'signatures';
-use Carp qw(croak);
+use Carp         qw(croak);
 use Scalar::Util ();
 
 # --- isa constraint helpers (coderefs; no extra deps). Each dies on a bad
@@ -17,50 +19,54 @@ my $NonEmptyStr = sub {
         unless defined $_[0] && !ref $_[0] && length $_[0];
 };
 my $ArrayRef = sub { croak("must be an arrayref") unless ref $_[0] eq 'ARRAY' };
-my $HashRef  = sub { croak("must be a hashref")  unless ref $_[0] eq 'HASH'  };
+my $HashRef  = sub { croak("must be a hashref")   unless ref $_[0] eq 'HASH' };
+
 # agent must be a blessed object (the AgentBase the skill is attached to),
 # not a plain string/hashref.
-my $Object   = sub { croak("must be an object") unless Scalar::Util::blessed($_[0]) };
+my $Object = sub { croak("must be an object") unless Scalar::Util::blessed( $_[0] ) };
 
 # Required class-level constants (subclasses override via 'has' or '+')
-has skill_name        => (is => 'ro', required => 1, isa => $NonEmptyStr);
-has skill_description => (is => 'ro', required => 1, isa => $NonEmptyStr);
-has skill_version     => (is => 'ro', default => sub { '1.0.0' }, isa => $NonEmptyStr);
+has skill_name        => ( is => 'ro', required => 1, isa => $NonEmptyStr );
+has skill_description => ( is => 'ro', required => 1, isa => $NonEmptyStr );
+has skill_version     => ( is => 'ro', default  => sub { '1.0.0' }, isa => $NonEmptyStr );
 
-has supports_multiple_instances => (is => 'ro', default => sub { 0 });
-has required_packages           => (is => 'ro', default => sub { [] }, isa => $ArrayRef);
-has required_env_vars           => (is => 'ro', default => sub { [] }, isa => $ArrayRef);
+has supports_multiple_instances => ( is => 'ro', default => sub { 0 } );
+has required_packages           => ( is => 'ro', default => sub { [] }, isa => $ArrayRef );
+has required_env_vars           => ( is => 'ro', default => sub { [] }, isa => $ArrayRef );
 
 # The agent this skill is attached to
-has agent  => (is => 'ro', required => 1, weak_ref => 1, isa => $Object);
+has agent => ( is => 'ro', required => 1, weak_ref => 1, isa => $Object );
+
 # Config params passed at registration
-has params => (is => 'rw', default => sub { {} }, isa => $HashRef);
+has params => ( is => 'rw', default => sub { {} }, isa => $HashRef );
 
 # Extra SWAIG fields to merge into tool definitions
-has swaig_fields => (is => 'rw', default => sub { {} }, isa => $HashRef);
+has swaig_fields => ( is => 'rw', default => sub { {} }, isa => $HashRef );
 
-sub BUILD ($self, @) {
+sub BUILD ( $self, @ ) {
+
     # Extract swaig_fields from params if present
-    if (exists $self->params->{swaig_fields}) {
-        $self->swaig_fields(delete $self->params->{swaig_fields});
+    if ( exists $self->params->{swaig_fields} ) {
+        $self->swaig_fields( delete $self->params->{swaig_fields} );
     }
 }
 
 # --- Abstract interface (subclasses must override) ---
 
 sub setup ($self) {
-    croak(ref($self) . " must implement setup()");
+    croak( ref($self) . " must implement setup()" );
 }
 
 sub register_tools ($self) {
-    croak(ref($self) . " must implement register_tools()");
+    croak( ref($self) . " must implement register_tools()" );
 }
 
 # --- Default implementations ---
 
-sub define_tool ($self, %opts) {
+sub define_tool ( $self, %opts ) {
+
     # Merge swaig_fields into the tool definition
-    my %merged = (%{ $self->swaig_fields }, %opts);
+    my %merged = ( %{ $self->swaig_fields }, %opts );
     return $self->agent->define_tool(%merged);
 }
 
@@ -82,11 +88,12 @@ sub _get_prompt_sections {
 }
 
 sub cleanup {
+
     # no-op by default
 }
 
 sub validate_env_vars ($self) {
-    for my $var (@{ $self->required_env_vars }) {
+    for my $var ( @{ $self->required_env_vars } ) {
         return 0 unless $ENV{$var};
     }
     return 1;
@@ -95,14 +102,15 @@ sub validate_env_vars ($self) {
 sub get_parameter_schema {
     return {
         swaig_fields => { type => 'object', description => 'Additional SWAIG fields' },
-        skip_prompt  => { type => 'boolean', description => 'Skip injecting prompt sections', default => 0 },
-        tool_name    => { type => 'string',  description => 'Override the default tool name' },
+        skip_prompt  =>
+            { type => 'boolean', description => 'Skip injecting prompt sections', default => 0 },
+        tool_name => { type => 'string', description => 'Override the default tool name' },
     };
 }
 
 sub get_instance_key ($self) {
     my $base = $self->skill_name;
-    if ($self->params->{tool_name}) {
+    if ( $self->params->{tool_name} ) {
         return $base . ':' . $self->params->{tool_name};
     }
     return $base;

--- a/lib/SignalWire/Skills/SkillManager.pm
+++ b/lib/SignalWire/Skills/SkillManager.pm
@@ -1,4 +1,5 @@
 package SignalWire::Skills::SkillManager;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 
@@ -7,91 +8,85 @@ use warnings;
 use Moo;
 use Carp qw(croak);
 
-has agent         => (is => 'ro', required => 1, weak_ref => 1);
-has loaded_skills => (is => 'rw', default => sub { {} });
+has agent => ( is => 'ro', required => 1, weak_ref => 1 );
+has loaded_skills => ( is => 'rw', default => sub { {} } );
 
 sub load_skill {
-    my ($self, $skill_name, $skill_class, $params) = @_;
+    my ( $self, $skill_name, $skill_class, $params ) = @_;
     $params //= {};
 
     # Get class from registry if not provided
-    if (!$skill_class) {
+    if ( !$skill_class ) {
         require SignalWire::Skills::SkillRegistry;
         my $factory = SignalWire::Skills::SkillRegistry->get_factory($skill_name);
         unless ($factory) {
-            return (0, "Skill '$skill_name' not found in registry");
+            return ( 0, "Skill '$skill_name' not found in registry" );
         }
         $skill_class = $factory;
     }
 
     # Create instance
-    my $instance = eval {
-        $skill_class->new(
-            agent  => $self->agent,
-            params => { %$params },
-        );
-    };
+    my $instance = eval { $skill_class->new( agent => $self->agent, params => {%$params}, ); };
     if ($@) {
-        return (0, "Failed to create skill '$skill_name': $@");
+        return ( 0, "Failed to create skill '$skill_name': $@" );
     }
 
     my $instance_key = $instance->get_instance_key;
 
     # Check for duplicates
-    if (exists $self->loaded_skills->{$instance_key}) {
-        if (!$instance->supports_multiple_instances) {
-            return (0, "Skill '$skill_name' already loaded and does not support multiple instances");
+    if ( exists $self->loaded_skills->{$instance_key} ) {
+        if ( !$instance->supports_multiple_instances ) {
+            return ( 0,
+                "Skill '$skill_name' already loaded and does not support multiple instances" );
         }
     }
 
     # Validate env vars
-    unless ($instance->validate_env_vars) {
-        return (0, "Skill '$skill_name' missing required environment variables");
+    unless ( $instance->validate_env_vars ) {
+        return ( 0, "Skill '$skill_name' missing required environment variables" );
     }
 
     # Setup
     my $ok = eval { $instance->setup };
-    if ($@ || !$ok) {
+    if ( $@ || !$ok ) {
         my $err = $@ || 'setup() returned false';
-        return (0, "Skill '$skill_name' setup failed: $err");
+        return ( 0, "Skill '$skill_name' setup failed: $err" );
     }
 
     # Register tools
     eval { $instance->register_tools };
     if ($@) {
-        return (0, "Skill '$skill_name' register_tools failed: $@");
+        return ( 0, "Skill '$skill_name' register_tools failed: $@" );
     }
 
     # Merge hints
     my $hints = $instance->get_hints;
-    if ($hints && @$hints) {
+    if ( $hints && @$hints ) {
         $self->agent->add_hints(@$hints);
     }
 
     # Merge global data
     my $gdata = $instance->get_global_data;
-    if ($gdata && %$gdata) {
+    if ( $gdata && %$gdata ) {
         $self->agent->update_global_data($gdata);
     }
 
     # Add prompt sections
     my $sections = $instance->get_prompt_sections;
-    if ($sections && @$sections) {
+    if ( $sections && @$sections ) {
         for my $sec (@$sections) {
-            $self->agent->prompt_add_section(
-                $sec->{title},
-                $sec->{body},
-                ($sec->{bullets} ? (bullets => $sec->{bullets}) : ()),
+            $self->agent->prompt_add_section( $sec->{title}, $sec->{body},
+                ( $sec->{bullets} ? ( bullets => $sec->{bullets} ) : () ),
             );
         }
     }
 
     $self->loaded_skills->{$instance_key} = $instance;
-    return (1, '');
+    return ( 1, '' );
 }
 
 sub unload_skill {
-    my ($self, $key) = @_;
+    my ( $self, $key ) = @_;
     my $instance = delete $self->loaded_skills->{$key};
     if ($instance) {
         eval { $instance->cleanup };
@@ -106,7 +101,7 @@ sub list_skills {
 }
 
 sub has_skill {
-    my ($self, $key) = @_;
+    my ( $self, $key ) = @_;
     return exists $self->loaded_skills->{$key} ? 1 : 0;
 }
 

--- a/lib/SignalWire/Skills/SkillName.pm
+++ b/lib/SignalWire/Skills/SkillName.pm
@@ -1,4 +1,5 @@
 package SignalWire::Skills::SkillName;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 #
@@ -106,7 +107,7 @@ sub all {
 # skills, false for custom / unknown names. Accepts the bareword constant
 # too (it's just the string).
 sub is_builtin {
-    my ($class, $name) = @_;
+    my ( $class, $name ) = @_;
     return 0 unless defined $name;
     return exists $IS_BUILTIN{$name} ? 1 : 0;
 }

--- a/lib/SignalWire/Skills/SkillRegistry.pm
+++ b/lib/SignalWire/Skills/SkillRegistry.pm
@@ -24,9 +24,13 @@ sub get_factory {
     # Return if already registered
     return $REGISTRY{$skill_name} if exists $REGISTRY{$skill_name};
 
-    # Attempt to auto-load from Builtin namespace
+    # Attempt to auto-load from Builtin namespace. Translate the package name to
+    # its .pm path and require THAT (a path string), so we avoid a stringy
+    # `eval "require $module"` (perlcritic ProhibitStringyEval) entirely — no
+    # registry input ever reaches the Perl compiler.
     my $module = 'SignalWire::Skills::Builtin::' . _camelize($skill_name);
-    eval "require $module";    ## no critic
+    ( my $module_path = "$module.pm" ) =~ s{::}{/}g;
+    eval { require $module_path; 1 };
     if ( !$@ ) {
 
         # If the module registered itself, return it
@@ -37,7 +41,7 @@ sub get_factory {
         return $module;
     }
 
-    return undef;
+    return;
 }
 
 sub list_skills {

--- a/lib/SignalWire/Skills/SkillRegistry.pm
+++ b/lib/SignalWire/Skills/SkillRegistry.pm
@@ -1,4 +1,5 @@
 package SignalWire::Skills::SkillRegistry;
+
 # Copyright (c) 2025 SignalWire
 # Licensed under the MIT License.
 
@@ -7,27 +8,30 @@ use warnings;
 
 # Global registry mapping skill name -> class name
 my %REGISTRY;
+
 # External skill directories registered via add_skill_directory.
 # Mirrors Python's SkillRegistry._external_paths.
 my @EXTERNAL_PATHS;
 
 sub register_skill {
-    my ($class, $skill_name, $skill_class) = @_;
+    my ( $class, $skill_name, $skill_class ) = @_;
     $REGISTRY{$skill_name} = $skill_class;
 }
 
 sub get_factory {
-    my ($class, $skill_name) = @_;
+    my ( $class, $skill_name ) = @_;
 
     # Return if already registered
     return $REGISTRY{$skill_name} if exists $REGISTRY{$skill_name};
 
     # Attempt to auto-load from Builtin namespace
     my $module = 'SignalWire::Skills::Builtin::' . _camelize($skill_name);
-    eval "require $module";  ## no critic
-    if (!$@) {
+    eval "require $module";    ## no critic
+    if ( !$@ ) {
+
         # If the module registered itself, return it
         return $REGISTRY{$skill_name} if exists $REGISTRY{$skill_name};
+
         # Otherwise register it
         $REGISTRY{$skill_name} = $module;
         return $module;
@@ -38,6 +42,7 @@ sub get_factory {
 
 sub list_skills {
     my ($class) = @_;
+
     # Make sure all builtins are loaded
     $class->_load_all_builtins;
     return [ sort keys %REGISTRY ];
@@ -53,28 +58,30 @@ sub list_skills {
 # expose ``parameter_schema`` get richer detail.
 sub get_all_skills_schema {
     my ($self) = @_;
+
     # Accept both class-method (SkillRegistry->get_all_skills_schema) and
     # instance-method ($registry->get_all_skills_schema) calls.
     my $class = ref($self) || $self || __PACKAGE__;
     $class->_load_all_builtins;
     my %schema;
-    for my $name (sort keys %REGISTRY) {
+    for my $name ( sort keys %REGISTRY ) {
         my $skill_class = $REGISTRY{$name};
-        my %entry = (name => $name, parameters => {});
-        if (ref($skill_class) eq 'CODE') {
+        my %entry       = ( name => $name, parameters => {} );
+        if ( ref($skill_class) eq 'CODE' ) {
+
             # Factory closure; can't introspect statically
             ;
-        } elsif (defined $skill_class) {
-            if ($skill_class->can('parameter_schema')) {
+        } elsif ( defined $skill_class ) {
+            if ( $skill_class->can('parameter_schema') ) {
                 eval {
                     my $params = $skill_class->parameter_schema;
                     $entry{parameters} = $params if ref($params) eq 'HASH';
                 };
             }
-            if ($skill_class->can('skill_description')) {
+            if ( $skill_class->can('skill_description') ) {
                 eval { $entry{description} = $skill_class->skill_description };
             }
-            if ($skill_class->can('skill_version')) {
+            if ( $skill_class->can('skill_version') ) {
                 eval { $entry{version} = $skill_class->skill_version };
             }
         }
@@ -92,19 +99,20 @@ sub _load_all_builtins {
         weather_api web_search wikipedia_search custom_skills
     );
     for my $name (@names) {
-        $class->get_factory($name);  # triggers auto-load
+        $class->get_factory($name);    # triggers auto-load
     }
 }
 
 sub _camelize {
     my ($name) = @_;
+
     # Convert snake_case to CamelCase: api_ninjas_trivia -> ApiNinjasTrivia
     $name =~ s/_(.)/uc($1)/ge;
     return ucfirst($name);
 }
 
 sub clear_registry {
-    %REGISTRY = ();
+    %REGISTRY       = ();
     @EXTERNAL_PATHS = ();
 }
 
@@ -116,7 +124,7 @@ sub clear_registry {
 # raising ValueError) when the path doesn't exist or isn't a directory,
 # and de-duplicate entries in the external paths list.
 sub add_skill_directory {
-    my ($class, $path) = @_;
+    my ( $class, $path ) = @_;
     die "Skill directory does not exist: $path\n" unless -e $path;
     die "Path is not a directory: $path\n"        unless -d $path;
     return if grep { $_ eq $path } @EXTERNAL_PATHS;

--- a/lib/SignalWire/Skills/SkillRegistry.pm
+++ b/lib/SignalWire/Skills/SkillRegistry.pm
@@ -16,6 +16,7 @@ my @EXTERNAL_PATHS;
 sub register_skill {
     my ( $class, $skill_name, $skill_class ) = @_;
     $REGISTRY{$skill_name} = $skill_class;
+    return;
 }
 
 sub get_factory {
@@ -105,6 +106,7 @@ sub _load_all_builtins {
     for my $name (@names) {
         $class->get_factory($name);    # triggers auto-load
     }
+    return;
 }
 
 sub _camelize {
@@ -118,6 +120,7 @@ sub _camelize {
 sub clear_registry {
     %REGISTRY       = ();
     @EXTERNAL_PATHS = ();
+    return;
 }
 
 # Add a directory to search for skills.

--- a/lib/SignalWire/Utils/UrlValidator.pm
+++ b/lib/SignalWire/Utils/UrlValidator.pm
@@ -32,11 +32,11 @@ our @BLOCKED_NETWORKS = (
     '172.16.0.0/12',
     '192.168.0.0/16',
     '127.0.0.0/8',
-    '169.254.0.0/16',  # link-local / cloud metadata
+    '169.254.0.0/16',    # link-local / cloud metadata
     '0.0.0.0/8',
     '::1/128',
-    'fc00::/7',  # IPv6 private (ULA)
-    'fe80::/10', # IPv6 link-local
+    'fc00::/7',          # IPv6 private (ULA)
+    'fe80::/10',         # IPv6 link-local
 );
 
 # Pluggable resolver. Tests inject a coderef to keep the suite hermetic;
@@ -45,46 +45,47 @@ our @BLOCKED_NETWORKS = (
 our $_RESOLVER;
 
 sub validate_url {
-    my ($url, $allow_private) = @_;
+    my ( $url, $allow_private ) = @_;
     $allow_private //= 0;
 
     my $log = SignalWire::Logging->get_logger('signalwire.url_validator');
 
     my $parsed = eval { URI->new($url) };
-    if (!$parsed || $@) {
+    if ( !$parsed || $@ ) {
         $log->warn("URL validation error: $@");
         return 0;
     }
 
-    my $scheme = lc($parsed->scheme // '');
-    if ($scheme ne 'http' && $scheme ne 'https') {
-        $log->warn("URL rejected: invalid scheme " . ($parsed->scheme // '(none)'));
+    my $scheme = lc( $parsed->scheme // '' );
+    if ( $scheme ne 'http' && $scheme ne 'https' ) {
+        $log->warn( "URL rejected: invalid scheme " . ( $parsed->scheme // '(none)' ) );
         return 0;
     }
 
     my $hostname = $parsed->host // '';
-    if ($hostname eq '') {
+    if ( $hostname eq '' ) {
         $log->warn('URL rejected: no hostname');
         return 0;
     }
+
     # URI keeps brackets in host for IPv6 literals; strip them.
-    if ($hostname =~ /^\[(.+)\]$/) {
+    if ( $hostname =~ /^\[(.+)\]$/ ) {
         $hostname = $1;
     }
 
-    if ($allow_private || _env_allows_private()) {
+    if ( $allow_private || _env_allows_private() ) {
         return 1;
     }
 
     my $ips = _resolve($hostname);
-    if (!$ips || @$ips == 0) {
+    if ( !$ips || @$ips == 0 ) {
         $log->warn("URL rejected: could not resolve hostname $hostname");
         return 0;
     }
 
     foreach my $ip (@$ips) {
         foreach my $cidr (@BLOCKED_NETWORKS) {
-            if (_cidr_contains($cidr, $ip)) {
+            if ( _cidr_contains( $cidr, $ip ) ) {
                 $log->warn("URL rejected: $hostname resolves to blocked IP $ip (in $cidr)");
                 return 0;
             }
@@ -95,8 +96,8 @@ sub validate_url {
 }
 
 sub _env_allows_private {
-    my $v = lc($ENV{SWML_ALLOW_PRIVATE_URLS} // '');
-    return ($v eq '1' || $v eq 'true' || $v eq 'yes') ? 1 : 0;
+    my $v = lc( $ENV{SWML_ALLOW_PRIVATE_URLS} // '' );
+    return ( $v eq '1' || $v eq 'true' || $v eq 'yes' ) ? 1 : 0;
 }
 
 # Resolve a hostname to a list of IP-string addresses, or undef on failure.
@@ -105,20 +106,21 @@ sub _resolve {
     if ($_RESOLVER) {
         return $_RESOLVER->($hostname);
     }
+
     # Literal-IP shortcut.
-    if (_is_ip_literal($hostname)) {
+    if ( _is_ip_literal($hostname) ) {
         return [$hostname];
     }
-    my ($err, @res) = getaddrinfo($hostname, undef, { socktype => 1 });
+    my ( $err, @res ) = getaddrinfo( $hostname, undef, { socktype => 1 } );
     return undef if $err;
     my @ips;
     for my $r (@res) {
         my $fam = $r->{family};
-        if ($fam == AF_INET) {
-            my ($port, $ipv4) = unpack_sockaddr_in($r->{addr});
+        if ( $fam == AF_INET ) {
+            my ( $port, $ipv4 ) = unpack_sockaddr_in( $r->{addr} );
             push @ips, _bytes_to_ipv4($ipv4);
-        } elsif ($fam == AF_INET6) {
-            my ($port, $ipv6) = unpack_sockaddr_in6($r->{addr});
+        } elsif ( $fam == AF_INET6 ) {
+            my ( $port, $ipv6 ) = unpack_sockaddr_in6( $r->{addr} );
             push @ips, _bytes_to_ipv6($ipv6);
         }
     }
@@ -134,19 +136,19 @@ sub _is_ip_literal {
 
 sub _bytes_to_ipv4 {
     my ($bytes) = @_;
-    return join('.', unpack('C4', $bytes));
+    return join( '.', unpack( 'C4', $bytes ) );
 }
 
 sub _bytes_to_ipv6 {
     my ($bytes) = @_;
-    my @parts = unpack('n8', $bytes);
-    return sprintf('%x:%x:%x:%x:%x:%x:%x:%x', @parts);
+    my @parts = unpack( 'n8', $bytes );
+    return sprintf( '%x:%x:%x:%x:%x:%x:%x:%x', @parts );
 }
 
 # CIDR membership test.  Handles both IPv4 and IPv6 input strings.
 sub _cidr_contains {
-    my ($cidr, $ip) = @_;
-    my ($net_str, $prefix) = split('/', $cidr, 2);
+    my ( $cidr,    $ip )     = @_;
+    my ( $net_str, $prefix ) = split( '/', $cidr, 2 );
     return 0 unless defined $prefix;
 
     my $ip_bytes  = _ip_to_bytes($ip);
@@ -156,13 +158,13 @@ sub _cidr_contains {
 
     my $total = length($ip_bytes) * 8;
     return 0 if $prefix < 0 || $prefix > $total;
-    my $full   = int($prefix / 8);
-    my $rem    = $prefix % 8;
-    return 0 if $full > 0 && substr($ip_bytes, 0, $full) ne substr($net_bytes, 0, $full);
-    if ($rem > 0) {
-        my $mask = (0xFF << (8 - $rem)) & 0xFF;
-        my $i = ord(substr($ip_bytes,  $full, 1)) & $mask;
-        my $n = ord(substr($net_bytes, $full, 1)) & $mask;
+    my $full = int( $prefix / 8 );
+    my $rem  = $prefix % 8;
+    return 0 if $full > 0 && substr( $ip_bytes, 0, $full ) ne substr( $net_bytes, 0, $full );
+    if ( $rem > 0 ) {
+        my $mask = ( 0xFF << ( 8 - $rem ) ) & 0xFF;
+        my $i    = ord( substr( $ip_bytes,  $full, 1 ) ) & $mask;
+        my $n    = ord( substr( $net_bytes, $full, 1 ) ) & $mask;
         return 0 if $i != $n;
     }
     return 1;
@@ -171,26 +173,27 @@ sub _cidr_contains {
 sub _ip_to_bytes {
     my ($ip) = @_;
     return undef unless defined $ip;
-    if ($ip =~ /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/) {
-        return pack('C4', $1, $2, $3, $4);
+    if ( $ip =~ /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/ ) {
+        return pack( 'C4', $1, $2, $3, $4 );
     }
-    if ($ip =~ /:/) {
+    if ( $ip =~ /:/ ) {
+
         # IPv6: expand and pack.
         my @groups;
-        if ($ip =~ /::/) {
-            my ($head, $tail) = split('::', $ip, 2);
+        if ( $ip =~ /::/ ) {
+            my ( $head, $tail ) = split( '::', $ip, 2 );
             $head //= '';
             $tail //= '';
-            my @h = $head eq '' ? () : split(':', $head);
-            my @t = $tail eq '' ? () : split(':', $tail);
-            my $missing = 8 - (@h + @t);
+            my @h       = $head eq '' ? () : split( ':', $head );
+            my @t       = $tail eq '' ? () : split( ':', $tail );
+            my $missing = 8 - ( @h + @t );
             return undef if $missing < 0;
-            @groups = (@h, ('0') x $missing, @t);
+            @groups = ( @h, ('0') x $missing, @t );
         } else {
-            @groups = split(':', $ip);
+            @groups = split( ':', $ip );
         }
         return undef if @groups != 8;
-        return pack('n8', map { hex($_) } @groups);
+        return pack( 'n8', map { hex($_) } @groups );
     }
     return undef;
 }

--- a/lib/SignalWire/Utils/UrlValidator.pm
+++ b/lib/SignalWire/Utils/UrlValidator.pm
@@ -112,7 +112,7 @@ sub _resolve {
         return [$hostname];
     }
     my ( $err, @res ) = getaddrinfo( $hostname, undef, { socktype => 1 } );
-    return undef if $err;
+    return if $err;
     my @ips;
     for my $r (@res) {
         my $fam = $r->{family};
@@ -172,7 +172,7 @@ sub _cidr_contains {
 
 sub _ip_to_bytes {
     my ($ip) = @_;
-    return undef unless defined $ip;
+    return unless defined $ip;
     if ( $ip =~ /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/ ) {
         return pack( 'C4', $1, $2, $3, $4 );
     }
@@ -187,15 +187,15 @@ sub _ip_to_bytes {
             my @h       = $head eq '' ? () : split( ':', $head );
             my @t       = $tail eq '' ? () : split( ':', $tail );
             my $missing = 8 - ( @h + @t );
-            return undef if $missing < 0;
+            return if $missing < 0;
             @groups = ( @h, ('0') x $missing, @t );
         } else {
             @groups = split( ':', $ip );
         }
-        return undef if @groups != 8;
+        return if @groups != 8;
         return pack( 'n8', map { hex($_) } @groups );
     }
-    return undef;
+    return;
 }
 
 1;

--- a/scripts/enumerate_surface.pl
+++ b/scripts/enumerate_surface.pl
@@ -1042,6 +1042,10 @@ my %SKIP_FILE = ();
 # -------------------------------------------------------------------------
 sub parse_file {
     my ($path) = @_;
+
+    # Whole-file line-by-line parse; the handle is read across the loop below
+    # and explicitly closed once the file is consumed (close $fh, ~45 lines on).
+    # See RequireBriefOpen exemption rationale in .perlcriticrc.
     open my $fh, '<', $path or die "open $path: $!";
     my @packages;    # list of { name => ..., subs => [...], _seen => {...} }
     my $current;

--- a/scripts/enumerate_surface.pl
+++ b/scripts/enumerate_surface.pl
@@ -24,20 +24,20 @@
 #   perl scripts/enumerate_surface.pl --stdout             # dump to stdout
 use strict;
 use warnings;
-use JSON ();
-use File::Find ();
-use File::Spec ();
+use JSON         ();
+use File::Find   ();
+use File::Spec   ();
 use Getopt::Long ();
-use FindBin ();
+use FindBin      ();
 
 # -------------------------------------------------------------------------
 # Configuration
 # -------------------------------------------------------------------------
 
-my $REPO_ROOT = File::Spec->rel2abs(File::Spec->catdir($FindBin::Bin, '..'));
-my $LIB_ROOT  = File::Spec->catdir($REPO_ROOT, 'lib', 'SignalWire');
+my $REPO_ROOT = File::Spec->rel2abs( File::Spec->catdir( $FindBin::Bin, '..' ) );
+my $LIB_ROOT  = File::Spec->catdir( $REPO_ROOT, 'lib', 'SignalWire' );
 
-my $output_path = File::Spec->catfile($REPO_ROOT, 'port_surface.json');
+my $output_path = File::Spec->catfile( $REPO_ROOT, 'port_surface.json' );
 my $to_stdout   = 0;
 Getopt::Long::GetOptions(
     'output=s' => \$output_path,
@@ -53,208 +53,360 @@ Getopt::Long::GetOptions(
 # mixins) the mapping is per-method and handled below.
 #
 my %PACKAGE_TO_PY = (
+
     # Entry point (SignalWire.pm acts as the package-level loader)
     'SignalWire' => { module => 'signalwire', class => undef },
 
     # Core orchestration
-    'SignalWire::Agent::AgentBase'         => { module => 'signalwire.core.agent_base',      class => 'AgentBase'    },
-    'SignalWire::SWML::Service'            => { module => 'signalwire.core.swml_service',    class => 'SWMLService'  },
-    'SignalWire::SWAIG::FunctionResult'    => { module => 'signalwire.core.function_result', class => 'FunctionResult' },
-    'SignalWire::DataMap'                  => { module => 'signalwire.core.data_map',        class => 'DataMap'      },
-    'SignalWire::Security::SessionManager'      => { module => 'signalwire.core.security.session_manager',   class => 'SessionManager' },
-    'SignalWire::Security::WebhookValidator'    => { module => 'signalwire.core.security.webhook_validator', class => undef },
-    'SignalWire::Security::WebhookMiddleware'   => { module => 'signalwire.core.security.webhook_middleware', class => undef },
-    'SignalWire::Server::AgentServer'      => { module => 'signalwire.agent_server',         class => 'AgentServer'  },
-    'SignalWire::Logging'                  => { module => 'signalwire.core.logging_config',  class => undef          },
-    'SignalWire::Core::LoggingConfig'      => { module => 'signalwire.core.logging_config',  class => undef          },
-    'SignalWire::Utils'                    => { module => 'signalwire.utils',                 class => undef          },
-    'SignalWire::Utils::UrlValidator'      => { module => 'signalwire.utils.url_validator',    class => undef          },
+    'SignalWire::Agent::AgentBase' =>
+        { module => 'signalwire.core.agent_base', class => 'AgentBase' },
+    'SignalWire::SWML::Service' =>
+        { module => 'signalwire.core.swml_service', class => 'SWMLService' },
+    'SignalWire::SWAIG::FunctionResult' =>
+        { module => 'signalwire.core.function_result', class => 'FunctionResult' },
+    'SignalWire::DataMap' => { module => 'signalwire.core.data_map', class => 'DataMap' },
+    'SignalWire::Security::SessionManager' =>
+        { module => 'signalwire.core.security.session_manager', class => 'SessionManager' },
+    'SignalWire::Security::WebhookValidator' =>
+        { module => 'signalwire.core.security.webhook_validator', class => undef },
+    'SignalWire::Security::WebhookMiddleware' =>
+        { module => 'signalwire.core.security.webhook_middleware', class => undef },
+    'SignalWire::Server::AgentServer' =>
+        { module => 'signalwire.agent_server', class => 'AgentServer' },
+    'SignalWire::Logging' => { module => 'signalwire.core.logging_config', class => undef },
+    'SignalWire::Core::LoggingConfig' =>
+        { module => 'signalwire.core.logging_config', class => undef },
+    'SignalWire::Utils'               => { module => 'signalwire.utils', class => undef },
+    'SignalWire::Utils::UrlValidator' =>
+        { module => 'signalwire.utils.url_validator', class => undef },
 
     # Contexts (multiple classes in one .pm)
-    'SignalWire::Contexts'                 => { module => 'signalwire.core.contexts',        class => undef          },
-    'SignalWire::Contexts::Context'        => { module => 'signalwire.core.contexts',        class => 'Context'      },
-    'SignalWire::Contexts::ContextBuilder' => { module => 'signalwire.core.contexts',        class => 'ContextBuilder' },
-    'SignalWire::Contexts::GatherInfo'     => { module => 'signalwire.core.contexts',        class => 'GatherInfo'   },
-    'SignalWire::Contexts::GatherQuestion' => { module => 'signalwire.core.contexts',        class => 'GatherQuestion' },
-    'SignalWire::Contexts::Step'           => { module => 'signalwire.core.contexts',        class => 'Step'         },
+    'SignalWire::Contexts'          => { module => 'signalwire.core.contexts', class => undef },
+    'SignalWire::Contexts::Context' => { module => 'signalwire.core.contexts', class => 'Context' },
+    'SignalWire::Contexts::ContextBuilder' =>
+        { module => 'signalwire.core.contexts', class => 'ContextBuilder' },
+    'SignalWire::Contexts::GatherInfo' =>
+        { module => 'signalwire.core.contexts', class => 'GatherInfo' },
+    'SignalWire::Contexts::GatherQuestion' =>
+        { module => 'signalwire.core.contexts', class => 'GatherQuestion' },
+    'SignalWire::Contexts::Step' => { module => 'signalwire.core.contexts', class => 'Step' },
 
     # Skills
-    'SignalWire::Skills::SkillBase'        => { module => 'signalwire.core.skill_base',    class => 'SkillBase'     },
-    'SignalWire::Skills::SkillManager'     => { module => 'signalwire.core.skill_manager', class => 'SkillManager'  },
-    'SignalWire::Skills::SkillRegistry'    => { module => 'signalwire.skills.registry',    class => 'SkillRegistry' },
+    'SignalWire::Skills::SkillBase' =>
+        { module => 'signalwire.core.skill_base', class => 'SkillBase' },
+    'SignalWire::Skills::SkillManager' =>
+        { module => 'signalwire.core.skill_manager', class => 'SkillManager' },
+    'SignalWire::Skills::SkillRegistry' =>
+        { module => 'signalwire.skills.registry', class => 'SkillRegistry' },
 
     # Built-in skills: each Perl package maps to the equivalent
     # signalwire.skills.<name>.skill module + Skill class.
-    'SignalWire::Skills::Builtin::Datetime'             => { module => 'signalwire.skills.datetime.skill',             class => 'DateTimeSkill' },
-    'SignalWire::Skills::Builtin::Math'                 => { module => 'signalwire.skills.math.skill',                 class => 'MathSkill' },
-    'SignalWire::Skills::Builtin::WebSearch'            => { module => 'signalwire.skills.web_search.skill',           class => 'WebSearchSkill' },
-    'SignalWire::Skills::Builtin::WikipediaSearch'      => { module => 'signalwire.skills.wikipedia_search.skill',     class => 'WikipediaSearchSkill' },
-    'SignalWire::Skills::Builtin::WeatherApi'           => { module => 'signalwire.skills.weather_api.skill',          class => 'WeatherApiSkill' },
-    'SignalWire::Skills::Builtin::Joke'                 => { module => 'signalwire.skills.joke.skill',                 class => 'JokeSkill' },
-    'SignalWire::Skills::Builtin::Spider'               => { module => 'signalwire.skills.spider.skill',               class => 'SpiderSkill' },
-    'SignalWire::Skills::Builtin::Datasphere'           => { module => 'signalwire.skills.datasphere.skill',           class => 'DataSphereSkill' },
-    'SignalWire::Skills::Builtin::DatasphereServerless' => { module => 'signalwire.skills.datasphere_serverless.skill', class => 'DataSphereServerlessSkill' },
-    'SignalWire::Skills::Builtin::NativeVectorSearch'   => { module => 'signalwire.skills.native_vector_search.skill', class => 'NativeVectorSearchSkill' },
-    'SignalWire::Skills::Builtin::ApiNinjasTrivia'      => { module => 'signalwire.skills.api_ninjas_trivia.skill',    class => 'ApiNinjasTriviaSkill' },
-    'SignalWire::Skills::Builtin::SwmlTransfer'         => { module => 'signalwire.skills.swml_transfer.skill',        class => 'SWMLTransferSkill' },
-    'SignalWire::Skills::Builtin::GoogleMaps'           => { module => 'signalwire.skills.google_maps.skill',          class => 'GoogleMapsSkill' },
-    'SignalWire::Skills::Builtin::PlayBackgroundFile'   => { module => 'signalwire.skills.play_background_file.skill', class => 'PlayBackgroundFileSkill' },
-    'SignalWire::Skills::Builtin::InfoGatherer'         => { module => 'signalwire.skills.info_gatherer.skill',        class => 'InfoGathererSkill' },
-    'SignalWire::Skills::Builtin::McpGateway'           => { module => 'signalwire.skills.mcp_gateway.skill',          class => 'MCPGatewaySkill' },
-    'SignalWire::Skills::Builtin::ClaudeSkills'         => { module => 'signalwire.skills.claude_skills.skill',        class => 'ClaudeSkillsSkill' },
+    'SignalWire::Skills::Builtin::Datetime' =>
+        { module => 'signalwire.skills.datetime.skill', class => 'DateTimeSkill' },
+    'SignalWire::Skills::Builtin::Math' =>
+        { module => 'signalwire.skills.math.skill', class => 'MathSkill' },
+    'SignalWire::Skills::Builtin::WebSearch' =>
+        { module => 'signalwire.skills.web_search.skill', class => 'WebSearchSkill' },
+    'SignalWire::Skills::Builtin::WikipediaSearch' =>
+        { module => 'signalwire.skills.wikipedia_search.skill', class => 'WikipediaSearchSkill' },
+    'SignalWire::Skills::Builtin::WeatherApi' =>
+        { module => 'signalwire.skills.weather_api.skill', class => 'WeatherApiSkill' },
+    'SignalWire::Skills::Builtin::Joke' =>
+        { module => 'signalwire.skills.joke.skill', class => 'JokeSkill' },
+    'SignalWire::Skills::Builtin::Spider' =>
+        { module => 'signalwire.skills.spider.skill', class => 'SpiderSkill' },
+    'SignalWire::Skills::Builtin::Datasphere' =>
+        { module => 'signalwire.skills.datasphere.skill', class => 'DataSphereSkill' },
+    'SignalWire::Skills::Builtin::DatasphereServerless' => {
+        module => 'signalwire.skills.datasphere_serverless.skill',
+        class  => 'DataSphereServerlessSkill'
+    },
+    'SignalWire::Skills::Builtin::NativeVectorSearch' => {
+        module => 'signalwire.skills.native_vector_search.skill',
+        class  => 'NativeVectorSearchSkill'
+    },
+    'SignalWire::Skills::Builtin::ApiNinjasTrivia' =>
+        { module => 'signalwire.skills.api_ninjas_trivia.skill', class => 'ApiNinjasTriviaSkill' },
+    'SignalWire::Skills::Builtin::SwmlTransfer' =>
+        { module => 'signalwire.skills.swml_transfer.skill', class => 'SWMLTransferSkill' },
+    'SignalWire::Skills::Builtin::GoogleMaps' =>
+        { module => 'signalwire.skills.google_maps.skill', class => 'GoogleMapsSkill' },
+    'SignalWire::Skills::Builtin::PlayBackgroundFile' => {
+        module => 'signalwire.skills.play_background_file.skill',
+        class  => 'PlayBackgroundFileSkill'
+    },
+    'SignalWire::Skills::Builtin::InfoGatherer' =>
+        { module => 'signalwire.skills.info_gatherer.skill', class => 'InfoGathererSkill' },
+    'SignalWire::Skills::Builtin::McpGateway' =>
+        { module => 'signalwire.skills.mcp_gateway.skill', class => 'MCPGatewaySkill' },
+    'SignalWire::Skills::Builtin::ClaudeSkills' =>
+        { module => 'signalwire.skills.claude_skills.skill', class => 'ClaudeSkillsSkill' },
+
     # CustomSkills has no direct Python equivalent — it's a Perl-only harness
     # for loading user-supplied skill packages. Report it under the registry
     # namespace with a port-only class; it will surface in PORT_ADDITIONS.md.
-    'SignalWire::Skills::Builtin::CustomSkills'         => { module => 'signalwire.skills.registry', class => 'CustomSkills' },
+    'SignalWire::Skills::Builtin::CustomSkills' =>
+        { module => 'signalwire.skills.registry', class => 'CustomSkills' },
 
     # Prefabs
-    'SignalWire::Prefabs::Concierge'    => { module => 'signalwire.prefabs.concierge',     class => 'ConciergeAgent'    },
-    'SignalWire::Prefabs::FAQBot'       => { module => 'signalwire.prefabs.faq_bot',       class => 'FAQBotAgent'       },
-    'SignalWire::Prefabs::InfoGatherer' => { module => 'signalwire.prefabs.info_gatherer', class => 'InfoGathererAgent' },
-    'SignalWire::Prefabs::Receptionist' => { module => 'signalwire.prefabs.receptionist',  class => 'ReceptionistAgent' },
-    'SignalWire::Prefabs::Survey'       => { module => 'signalwire.prefabs.survey',        class => 'SurveyAgent'       },
+    'SignalWire::Prefabs::Concierge' =>
+        { module => 'signalwire.prefabs.concierge', class => 'ConciergeAgent' },
+    'SignalWire::Prefabs::FAQBot' =>
+        { module => 'signalwire.prefabs.faq_bot', class => 'FAQBotAgent' },
+    'SignalWire::Prefabs::InfoGatherer' =>
+        { module => 'signalwire.prefabs.info_gatherer', class => 'InfoGathererAgent' },
+    'SignalWire::Prefabs::Receptionist' =>
+        { module => 'signalwire.prefabs.receptionist', class => 'ReceptionistAgent' },
+    'SignalWire::Prefabs::Survey' =>
+        { module => 'signalwire.prefabs.survey', class => 'SurveyAgent' },
 
     # RELAY client
-    'SignalWire::Relay::Client'    => { module => 'signalwire.relay.client',  class => 'RelayClient' },
-    'SignalWire::Relay::Call'      => { module => 'signalwire.relay.call',    class => 'Call'        },
-    'SignalWire::Relay::Message'   => { module => 'signalwire.relay.message', class => 'Message'     },
-    'SignalWire::Relay::Action'    => { module => 'signalwire.relay.call',    class => 'Action'      },
-    'SignalWire::Relay::Action::AI'         => { module => 'signalwire.relay.call', class => 'AIAction'         },
-    'SignalWire::Relay::Action::Collect'    => { module => 'signalwire.relay.call', class => 'CollectAction'    },
-    'SignalWire::Relay::Action::StandaloneCollect' => { module => 'signalwire.relay.call', class => 'StandaloneCollectAction' },
-    'SignalWire::Relay::Action::Detect'     => { module => 'signalwire.relay.call', class => 'DetectAction'     },
-    'SignalWire::Relay::Action::Fax'        => { module => 'signalwire.relay.call', class => 'FaxAction'        },
-    'SignalWire::Relay::Action::Pay'        => { module => 'signalwire.relay.call', class => 'PayAction'        },
-    'SignalWire::Relay::Action::Play'       => { module => 'signalwire.relay.call', class => 'PlayAction'       },
-    'SignalWire::Relay::Action::Record'     => { module => 'signalwire.relay.call', class => 'RecordAction'     },
-    'SignalWire::Relay::Action::Stream'     => { module => 'signalwire.relay.call', class => 'StreamAction'     },
-    'SignalWire::Relay::Action::Tap'        => { module => 'signalwire.relay.call', class => 'TapAction'        },
-    'SignalWire::Relay::Action::Transcribe' => { module => 'signalwire.relay.call', class => 'TranscribeAction' },
-    'SignalWire::Relay::Event'                     => { module => 'signalwire.relay.event', class => 'RelayEvent'         },
-    'SignalWire::Relay::Event::CallState'          => { module => 'signalwire.relay.event', class => 'CallStateEvent'     },
-    'SignalWire::Relay::Event::CallReceive'        => { module => 'signalwire.relay.event', class => 'CallReceiveEvent'   },
-    'SignalWire::Relay::Event::CallDial'           => { module => 'signalwire.relay.event', class => 'DialEvent'          },
-    'SignalWire::Relay::Event::CallConnect'        => { module => 'signalwire.relay.event', class => 'ConnectEvent'       },
-    'SignalWire::Relay::Event::CallPlay'           => { module => 'signalwire.relay.event', class => 'PlayEvent'          },
-    'SignalWire::Relay::Event::CallRecord'         => { module => 'signalwire.relay.event', class => 'RecordEvent'        },
-    'SignalWire::Relay::Event::CallCollect'        => { module => 'signalwire.relay.event', class => 'CollectEvent'       },
-    'SignalWire::Relay::Event::CallDetect'         => { module => 'signalwire.relay.event', class => 'DetectEvent'        },
-    'SignalWire::Relay::Event::CallFax'            => { module => 'signalwire.relay.event', class => 'FaxEvent'           },
-    'SignalWire::Relay::Event::CallTap'            => { module => 'signalwire.relay.event', class => 'TapEvent'           },
-    'SignalWire::Relay::Event::CallStream'         => { module => 'signalwire.relay.event', class => 'StreamEvent'        },
-    'SignalWire::Relay::Event::CallTranscribe'     => { module => 'signalwire.relay.event', class => 'TranscribeEvent'    },
-    'SignalWire::Relay::Event::CallPay'            => { module => 'signalwire.relay.event', class => 'PayEvent'           },
-    'SignalWire::Relay::Event::CallSendDigits'     => { module => 'signalwire.relay.event', class => 'SendDigitsEvent'    },
-    'SignalWire::Relay::Event::CallRefer'          => { module => 'signalwire.relay.event', class => 'ReferEvent'         },
-    'SignalWire::Relay::Event::Conference'         => { module => 'signalwire.relay.event', class => 'ConferenceEvent'    },
-    'SignalWire::Relay::Event::CallAI'             => { module => 'signalwire.relay.event', class => 'CallingErrorEvent'  },
-    'SignalWire::Relay::Event::MessageReceive'     => { module => 'signalwire.relay.event', class => 'MessageReceiveEvent' },
-    'SignalWire::Relay::Event::MessageState'       => { module => 'signalwire.relay.event', class => 'MessageStateEvent'  },
+    'SignalWire::Relay::Client'  => { module => 'signalwire.relay.client', class => 'RelayClient' },
+    'SignalWire::Relay::Call'    => { module => 'signalwire.relay.call',   class => 'Call' },
+    'SignalWire::Relay::Message' => { module => 'signalwire.relay.message', class => 'Message' },
+    'SignalWire::Relay::Action'  => { module => 'signalwire.relay.call',    class => 'Action' },
+    'SignalWire::Relay::Action::AI' => { module => 'signalwire.relay.call', class => 'AIAction' },
+    'SignalWire::Relay::Action::Collect' =>
+        { module => 'signalwire.relay.call', class => 'CollectAction' },
+    'SignalWire::Relay::Action::StandaloneCollect' =>
+        { module => 'signalwire.relay.call', class => 'StandaloneCollectAction' },
+    'SignalWire::Relay::Action::Detect' =>
+        { module => 'signalwire.relay.call', class => 'DetectAction' },
+    'SignalWire::Relay::Action::Fax' => { module => 'signalwire.relay.call', class => 'FaxAction' },
+    'SignalWire::Relay::Action::Pay' => { module => 'signalwire.relay.call', class => 'PayAction' },
+    'SignalWire::Relay::Action::Play' =>
+        { module => 'signalwire.relay.call', class => 'PlayAction' },
+    'SignalWire::Relay::Action::Record' =>
+        { module => 'signalwire.relay.call', class => 'RecordAction' },
+    'SignalWire::Relay::Action::Stream' =>
+        { module => 'signalwire.relay.call', class => 'StreamAction' },
+    'SignalWire::Relay::Action::Tap' => { module => 'signalwire.relay.call', class => 'TapAction' },
+    'SignalWire::Relay::Action::Transcribe' =>
+        { module => 'signalwire.relay.call', class => 'TranscribeAction' },
+    'SignalWire::Relay::Event' => { module => 'signalwire.relay.event', class => 'RelayEvent' },
+    'SignalWire::Relay::Event::CallState' =>
+        { module => 'signalwire.relay.event', class => 'CallStateEvent' },
+    'SignalWire::Relay::Event::CallReceive' =>
+        { module => 'signalwire.relay.event', class => 'CallReceiveEvent' },
+    'SignalWire::Relay::Event::CallDial' =>
+        { module => 'signalwire.relay.event', class => 'DialEvent' },
+    'SignalWire::Relay::Event::CallConnect' =>
+        { module => 'signalwire.relay.event', class => 'ConnectEvent' },
+    'SignalWire::Relay::Event::CallPlay' =>
+        { module => 'signalwire.relay.event', class => 'PlayEvent' },
+    'SignalWire::Relay::Event::CallRecord' =>
+        { module => 'signalwire.relay.event', class => 'RecordEvent' },
+    'SignalWire::Relay::Event::CallCollect' =>
+        { module => 'signalwire.relay.event', class => 'CollectEvent' },
+    'SignalWire::Relay::Event::CallDetect' =>
+        { module => 'signalwire.relay.event', class => 'DetectEvent' },
+    'SignalWire::Relay::Event::CallFax' =>
+        { module => 'signalwire.relay.event', class => 'FaxEvent' },
+    'SignalWire::Relay::Event::CallTap' =>
+        { module => 'signalwire.relay.event', class => 'TapEvent' },
+    'SignalWire::Relay::Event::CallStream' =>
+        { module => 'signalwire.relay.event', class => 'StreamEvent' },
+    'SignalWire::Relay::Event::CallTranscribe' =>
+        { module => 'signalwire.relay.event', class => 'TranscribeEvent' },
+    'SignalWire::Relay::Event::CallPay' =>
+        { module => 'signalwire.relay.event', class => 'PayEvent' },
+    'SignalWire::Relay::Event::CallSendDigits' =>
+        { module => 'signalwire.relay.event', class => 'SendDigitsEvent' },
+    'SignalWire::Relay::Event::CallRefer' =>
+        { module => 'signalwire.relay.event', class => 'ReferEvent' },
+    'SignalWire::Relay::Event::Conference' =>
+        { module => 'signalwire.relay.event', class => 'ConferenceEvent' },
+    'SignalWire::Relay::Event::CallAI' =>
+        { module => 'signalwire.relay.event', class => 'CallingErrorEvent' },
+    'SignalWire::Relay::Event::MessageReceive' =>
+        { module => 'signalwire.relay.event', class => 'MessageReceiveEvent' },
+    'SignalWire::Relay::Event::MessageState' =>
+        { module => 'signalwire.relay.event', class => 'MessageStateEvent' },
+
     # Perl-only events: CallDisconnect, Conference subtypes, Authorization,
     # plain Disconnect. Routed to relay.event so they surface in PORT_ADDITIONS.
-    'SignalWire::Relay::Event::CallDisconnect'     => { module => 'signalwire.relay.event', class => 'CallDisconnectEvent' },
-    'SignalWire::Relay::Event::AuthorizationState' => { module => 'signalwire.relay.event', class => 'AuthorizationStateEvent' },
-    'SignalWire::Relay::Event::Disconnect'         => { module => 'signalwire.relay.event', class => 'DisconnectEvent' },
-    'SignalWire::Relay::Constants'                 => { module => 'signalwire.relay.client', class => 'Constants' },
+    'SignalWire::Relay::Event::CallDisconnect' =>
+        { module => 'signalwire.relay.event', class => 'CallDisconnectEvent' },
+    'SignalWire::Relay::Event::AuthorizationState' =>
+        { module => 'signalwire.relay.event', class => 'AuthorizationStateEvent' },
+    'SignalWire::Relay::Event::Disconnect' =>
+        { module => 'signalwire.relay.event', class => 'DisconnectEvent' },
+    'SignalWire::Relay::Constants' => { module => 'signalwire.relay.client', class => 'Constants' },
 
     # REST client
-    'SignalWire::REST::RestClient'  => { module => 'signalwire.rest.client',  class => 'RestClient' },
-    'SignalWire::REST::HttpClient'        => { module => 'signalwire.rest._base', class => 'HttpClient' },
-    'SignalWire::REST::HttpClient::Error' => { module => 'signalwire.rest._base', class => 'SignalWireRestError' },
-    'SignalWire::REST::Namespaces::Base'          => { module => 'signalwire.rest._base', class => 'BaseResource' },
-    'SignalWire::REST::Namespaces::CrudResource'  => { module => 'signalwire.rest._base', class => 'CrudResource' },
-    'SignalWire::REST::PhoneCallHandler'          => { module => 'signalwire.rest.call_handler', class => 'PhoneCallHandler' },
-    'SignalWire::REST::Pagination'                => { module => 'signalwire.rest._pagination', class => undef },
-    'SignalWire::REST::Pagination::PaginatedIterator' => { module => 'signalwire.rest._pagination', class => 'PaginatedIterator' },
+    'SignalWire::REST::RestClient' => { module => 'signalwire.rest.client', class => 'RestClient' },
+    'SignalWire::REST::HttpClient' => { module => 'signalwire.rest._base',  class => 'HttpClient' },
+    'SignalWire::REST::HttpClient::Error' =>
+        { module => 'signalwire.rest._base', class => 'SignalWireRestError' },
+    'SignalWire::REST::Namespaces::Base' =>
+        { module => 'signalwire.rest._base', class => 'BaseResource' },
+    'SignalWire::REST::Namespaces::CrudResource' =>
+        { module => 'signalwire.rest._base', class => 'CrudResource' },
+    'SignalWire::REST::PhoneCallHandler' =>
+        { module => 'signalwire.rest.call_handler', class => 'PhoneCallHandler' },
+    'SignalWire::REST::Pagination' => { module => 'signalwire.rest._pagination', class => undef },
+    'SignalWire::REST::Pagination::PaginatedIterator' =>
+        { module => 'signalwire.rest._pagination', class => 'PaginatedIterator' },
 
     # REST: simple namespaces
-    'SignalWire::REST::Namespaces::Calling'       => { module => 'signalwire.rest.namespaces.calling',    class => 'CallingNamespace' },
-    'SignalWire::REST::Namespaces::Chat'          => { module => 'signalwire.rest.namespaces.chat',       class => 'ChatResource' },
-    'SignalWire::REST::Namespaces::PubSub'        => { module => 'signalwire.rest.namespaces.pubsub',     class => 'PubSubResource' },
-    'SignalWire::REST::Namespaces::PhoneNumbers'  => { module => 'signalwire.rest.namespaces.phone_numbers', class => 'PhoneNumbersResource' },
-    'SignalWire::REST::Namespaces::Datasphere'    => { module => 'signalwire.rest.namespaces.datasphere', class => 'DatasphereNamespace' },
-    'SignalWire::REST::Namespaces::Datasphere::Documents' => { module => 'signalwire.rest.namespaces.datasphere', class => 'DatasphereDocuments' },
-    'SignalWire::REST::Namespaces::Project'       => { module => 'signalwire.rest.namespaces.project',    class => 'ProjectNamespace' },
-    'SignalWire::REST::Namespaces::Project::Tokens' => { module => 'signalwire.rest.namespaces.project',  class => 'ProjectTokens' },
+    'SignalWire::REST::Namespaces::Calling' =>
+        { module => 'signalwire.rest.namespaces.calling', class => 'CallingNamespace' },
+    'SignalWire::REST::Namespaces::Chat' =>
+        { module => 'signalwire.rest.namespaces.chat', class => 'ChatResource' },
+    'SignalWire::REST::Namespaces::PubSub' =>
+        { module => 'signalwire.rest.namespaces.pubsub', class => 'PubSubResource' },
+    'SignalWire::REST::Namespaces::PhoneNumbers' =>
+        { module => 'signalwire.rest.namespaces.phone_numbers', class => 'PhoneNumbersResource' },
+    'SignalWire::REST::Namespaces::Datasphere' =>
+        { module => 'signalwire.rest.namespaces.datasphere', class => 'DatasphereNamespace' },
+    'SignalWire::REST::Namespaces::Datasphere::Documents' =>
+        { module => 'signalwire.rest.namespaces.datasphere', class => 'DatasphereDocuments' },
+    'SignalWire::REST::Namespaces::Project' =>
+        { module => 'signalwire.rest.namespaces.project', class => 'ProjectNamespace' },
+    'SignalWire::REST::Namespaces::Project::Tokens' =>
+        { module => 'signalwire.rest.namespaces.project', class => 'ProjectTokens' },
 
     # REST: multi-package Resources.pm splits into several namespaces
-    'SignalWire::REST::Namespaces::Resources'         => { module => 'signalwire.rest._base',         class => undef },
-    'SignalWire::REST::Namespaces::Addresses'         => { module => 'signalwire.rest.namespaces.addresses',         class => 'AddressesResource' },
-    'SignalWire::REST::Namespaces::Queues'            => { module => 'signalwire.rest.namespaces.queues',            class => 'QueuesResource' },
-    'SignalWire::REST::Namespaces::Recordings'        => { module => 'signalwire.rest.namespaces.recordings',        class => 'RecordingsResource' },
-    'SignalWire::REST::Namespaces::NumberGroups'      => { module => 'signalwire.rest.namespaces.number_groups',     class => 'NumberGroupsResource' },
-    'SignalWire::REST::Namespaces::VerifiedCallers'   => { module => 'signalwire.rest.namespaces.verified_callers',  class => 'VerifiedCallersResource' },
-    'SignalWire::REST::Namespaces::SipProfile'        => { module => 'signalwire.rest.namespaces.sip_profile',       class => 'SipProfileResource' },
-    'SignalWire::REST::Namespaces::Lookup'            => { module => 'signalwire.rest.namespaces.lookup',            class => 'LookupResource' },
-    'SignalWire::REST::Namespaces::ShortCodes'        => { module => 'signalwire.rest.namespaces.short_codes',       class => 'ShortCodesResource' },
-    'SignalWire::REST::Namespaces::ImportedNumbers'   => { module => 'signalwire.rest.namespaces.imported_numbers',  class => 'ImportedNumbersResource' },
-    'SignalWire::REST::Namespaces::MFA'               => { module => 'signalwire.rest.namespaces.mfa',               class => 'MfaResource' },
+    'SignalWire::REST::Namespaces::Resources' =>
+        { module => 'signalwire.rest._base', class => undef },
+    'SignalWire::REST::Namespaces::Addresses' =>
+        { module => 'signalwire.rest.namespaces.addresses', class => 'AddressesResource' },
+    'SignalWire::REST::Namespaces::Queues' =>
+        { module => 'signalwire.rest.namespaces.queues', class => 'QueuesResource' },
+    'SignalWire::REST::Namespaces::Recordings' =>
+        { module => 'signalwire.rest.namespaces.recordings', class => 'RecordingsResource' },
+    'SignalWire::REST::Namespaces::NumberGroups' =>
+        { module => 'signalwire.rest.namespaces.number_groups', class => 'NumberGroupsResource' },
+    'SignalWire::REST::Namespaces::VerifiedCallers' => {
+        module => 'signalwire.rest.namespaces.verified_callers',
+        class  => 'VerifiedCallersResource'
+    },
+    'SignalWire::REST::Namespaces::SipProfile' =>
+        { module => 'signalwire.rest.namespaces.sip_profile', class => 'SipProfileResource' },
+    'SignalWire::REST::Namespaces::Lookup' =>
+        { module => 'signalwire.rest.namespaces.lookup', class => 'LookupResource' },
+    'SignalWire::REST::Namespaces::ShortCodes' =>
+        { module => 'signalwire.rest.namespaces.short_codes', class => 'ShortCodesResource' },
+    'SignalWire::REST::Namespaces::ImportedNumbers' => {
+        module => 'signalwire.rest.namespaces.imported_numbers',
+        class  => 'ImportedNumbersResource'
+    },
+    'SignalWire::REST::Namespaces::MFA' =>
+        { module => 'signalwire.rest.namespaces.mfa', class => 'MfaResource' },
 
     # REST: Logs.pm — multi-package
-    'SignalWire::REST::Namespaces::Logs'              => { module => 'signalwire.rest.namespaces.logs', class => 'LogsNamespace' },
-    'SignalWire::REST::Namespaces::Logs::Messages'    => { module => 'signalwire.rest.namespaces.logs', class => 'MessageLogs' },
-    'SignalWire::REST::Namespaces::Logs::Voice'       => { module => 'signalwire.rest.namespaces.logs', class => 'VoiceLogs' },
-    'SignalWire::REST::Namespaces::Logs::Fax'         => { module => 'signalwire.rest.namespaces.logs', class => 'FaxLogs' },
-    'SignalWire::REST::Namespaces::Logs::Conferences' => { module => 'signalwire.rest.namespaces.logs', class => 'ConferenceLogs' },
+    'SignalWire::REST::Namespaces::Logs' =>
+        { module => 'signalwire.rest.namespaces.logs', class => 'LogsNamespace' },
+    'SignalWire::REST::Namespaces::Logs::Messages' =>
+        { module => 'signalwire.rest.namespaces.logs', class => 'MessageLogs' },
+    'SignalWire::REST::Namespaces::Logs::Voice' =>
+        { module => 'signalwire.rest.namespaces.logs', class => 'VoiceLogs' },
+    'SignalWire::REST::Namespaces::Logs::Fax' =>
+        { module => 'signalwire.rest.namespaces.logs', class => 'FaxLogs' },
+    'SignalWire::REST::Namespaces::Logs::Conferences' =>
+        { module => 'signalwire.rest.namespaces.logs', class => 'ConferenceLogs' },
 
     # REST: Registry.pm — multi-package
-    'SignalWire::REST::Namespaces::Registry'              => { module => 'signalwire.rest.namespaces.registry', class => 'RegistryNamespace' },
-    'SignalWire::REST::Namespaces::Registry::Brands'      => { module => 'signalwire.rest.namespaces.registry', class => 'RegistryBrands' },
-    'SignalWire::REST::Namespaces::Registry::Campaigns'   => { module => 'signalwire.rest.namespaces.registry', class => 'RegistryCampaigns' },
-    'SignalWire::REST::Namespaces::Registry::Orders'      => { module => 'signalwire.rest.namespaces.registry', class => 'RegistryOrders' },
-    'SignalWire::REST::Namespaces::Registry::Numbers'     => { module => 'signalwire.rest.namespaces.registry', class => 'RegistryNumbers' },
+    'SignalWire::REST::Namespaces::Registry' =>
+        { module => 'signalwire.rest.namespaces.registry', class => 'RegistryNamespace' },
+    'SignalWire::REST::Namespaces::Registry::Brands' =>
+        { module => 'signalwire.rest.namespaces.registry', class => 'RegistryBrands' },
+    'SignalWire::REST::Namespaces::Registry::Campaigns' =>
+        { module => 'signalwire.rest.namespaces.registry', class => 'RegistryCampaigns' },
+    'SignalWire::REST::Namespaces::Registry::Orders' =>
+        { module => 'signalwire.rest.namespaces.registry', class => 'RegistryOrders' },
+    'SignalWire::REST::Namespaces::Registry::Numbers' =>
+        { module => 'signalwire.rest.namespaces.registry', class => 'RegistryNumbers' },
 
     # REST: Compat.pm — multi-package
-    'SignalWire::REST::Namespaces::Compat'               => { module => 'signalwire.rest.namespaces.compat', class => 'CompatNamespace' },
-    'SignalWire::REST::Namespaces::Compat::Accounts'     => { module => 'signalwire.rest.namespaces.compat', class => 'CompatAccounts' },
-    'SignalWire::REST::Namespaces::Compat::Calls'        => { module => 'signalwire.rest.namespaces.compat', class => 'CompatCalls' },
-    'SignalWire::REST::Namespaces::Compat::Messages'     => { module => 'signalwire.rest.namespaces.compat', class => 'CompatMessages' },
-    'SignalWire::REST::Namespaces::Compat::Faxes'        => { module => 'signalwire.rest.namespaces.compat', class => 'CompatFaxes' },
-    'SignalWire::REST::Namespaces::Compat::Conferences'  => { module => 'signalwire.rest.namespaces.compat', class => 'CompatConferences' },
-    'SignalWire::REST::Namespaces::Compat::PhoneNumbers' => { module => 'signalwire.rest.namespaces.compat', class => 'CompatPhoneNumbers' },
-    'SignalWire::REST::Namespaces::Compat::Applications' => { module => 'signalwire.rest.namespaces.compat', class => 'CompatApplications' },
-    'SignalWire::REST::Namespaces::Compat::LamlBins'     => { module => 'signalwire.rest.namespaces.compat', class => 'CompatLamlBins' },
-    'SignalWire::REST::Namespaces::Compat::Queues'       => { module => 'signalwire.rest.namespaces.compat', class => 'CompatQueues' },
-    'SignalWire::REST::Namespaces::Compat::Recordings'   => { module => 'signalwire.rest.namespaces.compat', class => 'CompatRecordings' },
-    'SignalWire::REST::Namespaces::Compat::Transcriptions' => { module => 'signalwire.rest.namespaces.compat', class => 'CompatTranscriptions' },
-    'SignalWire::REST::Namespaces::Compat::Tokens'       => { module => 'signalwire.rest.namespaces.compat', class => 'CompatTokens' },
+    'SignalWire::REST::Namespaces::Compat' =>
+        { module => 'signalwire.rest.namespaces.compat', class => 'CompatNamespace' },
+    'SignalWire::REST::Namespaces::Compat::Accounts' =>
+        { module => 'signalwire.rest.namespaces.compat', class => 'CompatAccounts' },
+    'SignalWire::REST::Namespaces::Compat::Calls' =>
+        { module => 'signalwire.rest.namespaces.compat', class => 'CompatCalls' },
+    'SignalWire::REST::Namespaces::Compat::Messages' =>
+        { module => 'signalwire.rest.namespaces.compat', class => 'CompatMessages' },
+    'SignalWire::REST::Namespaces::Compat::Faxes' =>
+        { module => 'signalwire.rest.namespaces.compat', class => 'CompatFaxes' },
+    'SignalWire::REST::Namespaces::Compat::Conferences' =>
+        { module => 'signalwire.rest.namespaces.compat', class => 'CompatConferences' },
+    'SignalWire::REST::Namespaces::Compat::PhoneNumbers' =>
+        { module => 'signalwire.rest.namespaces.compat', class => 'CompatPhoneNumbers' },
+    'SignalWire::REST::Namespaces::Compat::Applications' =>
+        { module => 'signalwire.rest.namespaces.compat', class => 'CompatApplications' },
+    'SignalWire::REST::Namespaces::Compat::LamlBins' =>
+        { module => 'signalwire.rest.namespaces.compat', class => 'CompatLamlBins' },
+    'SignalWire::REST::Namespaces::Compat::Queues' =>
+        { module => 'signalwire.rest.namespaces.compat', class => 'CompatQueues' },
+    'SignalWire::REST::Namespaces::Compat::Recordings' =>
+        { module => 'signalwire.rest.namespaces.compat', class => 'CompatRecordings' },
+    'SignalWire::REST::Namespaces::Compat::Transcriptions' =>
+        { module => 'signalwire.rest.namespaces.compat', class => 'CompatTranscriptions' },
+    'SignalWire::REST::Namespaces::Compat::Tokens' =>
+        { module => 'signalwire.rest.namespaces.compat', class => 'CompatTokens' },
 
     # REST: Fabric.pm — multi-package (Python surface under rest.namespaces.fabric)
-    'SignalWire::REST::Namespaces::Fabric'                     => { module => 'signalwire.rest.namespaces.fabric', class => 'FabricNamespace' },
-    'SignalWire::REST::Namespaces::Fabric::Addresses'          => { module => 'signalwire.rest.namespaces.fabric', class => 'FabricAddresses' },
-    'SignalWire::REST::Namespaces::Fabric::Subscribers'        => { module => 'signalwire.rest.namespaces.fabric', class => 'SubscribersResource' },
-    'SignalWire::REST::Namespaces::Fabric::Tokens'             => { module => 'signalwire.rest.namespaces.fabric', class => 'FabricTokens' },
-    'SignalWire::REST::Namespaces::Fabric::GenericResources'   => { module => 'signalwire.rest.namespaces.fabric', class => 'GenericResources' },
-    'SignalWire::REST::Namespaces::Fabric::SwmlWebhooks'       => { module => 'signalwire.rest.namespaces.fabric', class => 'SwmlWebhooksResource' },
+    'SignalWire::REST::Namespaces::Fabric' =>
+        { module => 'signalwire.rest.namespaces.fabric', class => 'FabricNamespace' },
+    'SignalWire::REST::Namespaces::Fabric::Addresses' =>
+        { module => 'signalwire.rest.namespaces.fabric', class => 'FabricAddresses' },
+    'SignalWire::REST::Namespaces::Fabric::Subscribers' =>
+        { module => 'signalwire.rest.namespaces.fabric', class => 'SubscribersResource' },
+    'SignalWire::REST::Namespaces::Fabric::Tokens' =>
+        { module => 'signalwire.rest.namespaces.fabric', class => 'FabricTokens' },
+    'SignalWire::REST::Namespaces::Fabric::GenericResources' =>
+        { module => 'signalwire.rest.namespaces.fabric', class => 'GenericResources' },
+    'SignalWire::REST::Namespaces::Fabric::SwmlWebhooks' =>
+        { module => 'signalwire.rest.namespaces.fabric', class => 'SwmlWebhooksResource' },
+
     # Other Fabric::* subpackages are helpers that have no 1:1 Python
     # equivalent; they'll land in PORT_ADDITIONS.md under rest.namespaces.fabric.
-    'SignalWire::REST::Namespaces::Fabric::Resource'              => { module => 'signalwire.rest.namespaces.fabric', class => 'FabricResource' },
-    'SignalWire::REST::Namespaces::Fabric::AutoMaterializedWebhook' => { module => 'signalwire.rest.namespaces.fabric', class => 'AutoMaterializedWebhook' },
-    'SignalWire::REST::Namespaces::Fabric::CxmlWebhooks'          => { module => 'signalwire.rest.namespaces.fabric', class => 'CxmlWebhooksResource' },
-    'SignalWire::REST::Namespaces::Fabric::ResourcePUT'           => { module => 'signalwire.rest.namespaces.fabric', class => 'FabricResourcePUT' },
-    'SignalWire::REST::Namespaces::Fabric::CallFlows'             => { module => 'signalwire.rest.namespaces.fabric', class => 'CallFlowsResource' },
-    'SignalWire::REST::Namespaces::Fabric::ConferenceRooms'       => { module => 'signalwire.rest.namespaces.fabric', class => 'ConferenceRoomsResource' },
-    'SignalWire::REST::Namespaces::Fabric::CxmlApplications'      => { module => 'signalwire.rest.namespaces.fabric', class => 'CxmlApplicationsResource' },
+    'SignalWire::REST::Namespaces::Fabric::Resource' =>
+        { module => 'signalwire.rest.namespaces.fabric', class => 'FabricResource' },
+    'SignalWire::REST::Namespaces::Fabric::AutoMaterializedWebhook' =>
+        { module => 'signalwire.rest.namespaces.fabric', class => 'AutoMaterializedWebhook' },
+    'SignalWire::REST::Namespaces::Fabric::CxmlWebhooks' =>
+        { module => 'signalwire.rest.namespaces.fabric', class => 'CxmlWebhooksResource' },
+    'SignalWire::REST::Namespaces::Fabric::ResourcePUT' =>
+        { module => 'signalwire.rest.namespaces.fabric', class => 'FabricResourcePUT' },
+    'SignalWire::REST::Namespaces::Fabric::CallFlows' =>
+        { module => 'signalwire.rest.namespaces.fabric', class => 'CallFlowsResource' },
+    'SignalWire::REST::Namespaces::Fabric::ConferenceRooms' =>
+        { module => 'signalwire.rest.namespaces.fabric', class => 'ConferenceRoomsResource' },
+    'SignalWire::REST::Namespaces::Fabric::CxmlApplications' =>
+        { module => 'signalwire.rest.namespaces.fabric', class => 'CxmlApplicationsResource' },
 
     # REST: Video.pm — multi-package
-    'SignalWire::REST::Namespaces::Video'                    => { module => 'signalwire.rest.namespaces.video', class => 'VideoNamespace' },
-    'SignalWire::REST::Namespaces::Video::Rooms'             => { module => 'signalwire.rest.namespaces.video', class => 'VideoRooms' },
-    'SignalWire::REST::Namespaces::Video::RoomTokens'        => { module => 'signalwire.rest.namespaces.video', class => 'VideoRoomTokens' },
-    'SignalWire::REST::Namespaces::Video::RoomSessions'      => { module => 'signalwire.rest.namespaces.video', class => 'VideoRoomSessions' },
-    'SignalWire::REST::Namespaces::Video::RoomRecordings'    => { module => 'signalwire.rest.namespaces.video', class => 'VideoRoomRecordings' },
-    'SignalWire::REST::Namespaces::Video::Conferences'       => { module => 'signalwire.rest.namespaces.video', class => 'VideoConferences' },
-    'SignalWire::REST::Namespaces::Video::ConferenceTokens'  => { module => 'signalwire.rest.namespaces.video', class => 'VideoConferenceTokens' },
-    'SignalWire::REST::Namespaces::Video::Streams'           => { module => 'signalwire.rest.namespaces.video', class => 'VideoStreams' },
+    'SignalWire::REST::Namespaces::Video' =>
+        { module => 'signalwire.rest.namespaces.video', class => 'VideoNamespace' },
+    'SignalWire::REST::Namespaces::Video::Rooms' =>
+        { module => 'signalwire.rest.namespaces.video', class => 'VideoRooms' },
+    'SignalWire::REST::Namespaces::Video::RoomTokens' =>
+        { module => 'signalwire.rest.namespaces.video', class => 'VideoRoomTokens' },
+    'SignalWire::REST::Namespaces::Video::RoomSessions' =>
+        { module => 'signalwire.rest.namespaces.video', class => 'VideoRoomSessions' },
+    'SignalWire::REST::Namespaces::Video::RoomRecordings' =>
+        { module => 'signalwire.rest.namespaces.video', class => 'VideoRoomRecordings' },
+    'SignalWire::REST::Namespaces::Video::Conferences' =>
+        { module => 'signalwire.rest.namespaces.video', class => 'VideoConferences' },
+    'SignalWire::REST::Namespaces::Video::ConferenceTokens' =>
+        { module => 'signalwire.rest.namespaces.video', class => 'VideoConferenceTokens' },
+    'SignalWire::REST::Namespaces::Video::Streams' =>
+        { module => 'signalwire.rest.namespaces.video', class => 'VideoStreams' },
 
     # SWML
-    'SignalWire::SWML::Document' => { module => 'signalwire.core.swml_builder',  class => 'SWMLBuilder' },
-    'SignalWire::SWML::Schema'   => { module => 'signalwire.utils.schema_utils', class => 'SchemaUtils' },
+    'SignalWire::SWML::Document' =>
+        { module => 'signalwire.core.swml_builder', class => 'SWMLBuilder' },
+    'SignalWire::SWML::Schema' =>
+        { module => 'signalwire.utils.schema_utils', class => 'SchemaUtils' },
 
     # POM — typed Prompt Object Model. Python lives in ``signalwire.pom.pom``;
     # Perl mirrors the same shape under ``SignalWire::POM::*`` and projects
     # both classes back to the canonical Python paths.
-    'SignalWire::POM::PromptObjectModel' => { module => 'signalwire.pom.pom', class => 'PromptObjectModel' },
-    'SignalWire::POM::Section'           => { module => 'signalwire.pom.pom', class => 'Section' },
+    'SignalWire::POM::PromptObjectModel' =>
+        { module => 'signalwire.pom.pom', class => 'PromptObjectModel' },
+    'SignalWire::POM::Section' => { module => 'signalwire.pom.pom', class => 'Section' },
 );
 
 # -------------------------------------------------------------------------
@@ -267,90 +419,341 @@ my %PACKAGE_TO_PY = (
 # diff tool can reason about surface parity.
 # -------------------------------------------------------------------------
 my %AGENTBASE_METHOD_TO_PY = (
+
     # Stays on AgentBase itself
-    'new'                      => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => '__init__' },
-    'get_name'                 => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'get_name' },
-    'get_full_url'             => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'get_full_url' },
-    'set_web_hook_url'         => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'set_web_hook_url' },
-    'set_post_prompt_url'      => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'set_post_prompt_url' },
-    'add_pre_answer_verb'      => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'add_pre_answer_verb' },
-    'add_post_answer_verb'     => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'add_post_answer_verb' },
-    'add_post_ai_verb'         => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'add_post_ai_verb' },
-    'clear_pre_answer_verbs'   => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'clear_pre_answer_verbs' },
-    'clear_post_answer_verbs'  => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'clear_post_answer_verbs' },
-    'clear_post_ai_verbs'      => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'clear_post_ai_verbs' },
-    'add_swaig_query_params'   => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'add_swaig_query_params' },
-    'clear_swaig_query_params' => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'clear_swaig_query_params' },
-    'on_summary'               => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'on_summary' },
-    'on_debug_event'           => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'on_debug_event' },
-    'enable_sip_routing'       => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'enable_sip_routing' },
-    'register_sip_username'    => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'register_sip_username' },
-    'auto_map_sip_usernames'   => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'auto_map_sip_usernames' },
-    'add_answer_verb'          => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'add_answer_verb' },
+    'new' => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => '__init__' },
+    'get_name' =>
+        { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'get_name' },
+    'get_full_url' =>
+        { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'get_full_url' },
+    'set_web_hook_url' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'set_web_hook_url'
+    },
+    'set_post_prompt_url' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'set_post_prompt_url'
+    },
+    'add_pre_answer_verb' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'add_pre_answer_verb'
+    },
+    'add_post_answer_verb' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'add_post_answer_verb'
+    },
+    'add_post_ai_verb' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'add_post_ai_verb'
+    },
+    'clear_pre_answer_verbs' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'clear_pre_answer_verbs'
+    },
+    'clear_post_answer_verbs' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'clear_post_answer_verbs'
+    },
+    'clear_post_ai_verbs' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'clear_post_ai_verbs'
+    },
+    'add_swaig_query_params' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'add_swaig_query_params'
+    },
+    'clear_swaig_query_params' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'clear_swaig_query_params'
+    },
+    'on_summary' =>
+        { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'on_summary' },
+    'on_debug_event' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'on_debug_event'
+    },
+    'enable_sip_routing' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'enable_sip_routing'
+    },
+    'register_sip_username' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'register_sip_username'
+    },
+    'auto_map_sip_usernames' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'auto_map_sip_usernames'
+    },
+    'add_answer_verb' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'add_answer_verb'
+    },
 
     # PromptMixin
-    'set_prompt_text'      => { module => 'signalwire.core.mixins.prompt_mixin', class => 'PromptMixin', method => 'set_prompt_text' },
-    'set_post_prompt'      => { module => 'signalwire.core.mixins.prompt_mixin', class => 'PromptMixin', method => 'set_post_prompt' },
-    'prompt_add_section'   => { module => 'signalwire.core.mixins.prompt_mixin', class => 'PromptMixin', method => 'prompt_add_section' },
-    'prompt_add_subsection' => { module => 'signalwire.core.mixins.prompt_mixin', class => 'PromptMixin', method => 'prompt_add_subsection' },
-    'prompt_add_to_section'=> { module => 'signalwire.core.mixins.prompt_mixin', class => 'PromptMixin', method => 'prompt_add_to_section' },
-    'prompt_has_section'   => { module => 'signalwire.core.mixins.prompt_mixin', class => 'PromptMixin', method => 'prompt_has_section' },
-    'get_prompt'           => { module => 'signalwire.core.mixins.prompt_mixin', class => 'PromptMixin', method => 'get_prompt' },
-    'define_contexts'      => { module => 'signalwire.core.mixins.prompt_mixin', class => 'PromptMixin', method => 'define_contexts' },
-    'reset_contexts'       => { module => 'signalwire.core.mixins.prompt_mixin', class => 'PromptMixin', method => 'reset_contexts' },
-    'contexts'             => { module => 'signalwire.core.mixins.prompt_mixin', class => 'PromptMixin', method => 'contexts' },
+    'set_prompt_text' => {
+        module => 'signalwire.core.mixins.prompt_mixin',
+        class  => 'PromptMixin',
+        method => 'set_prompt_text'
+    },
+    'set_post_prompt' => {
+        module => 'signalwire.core.mixins.prompt_mixin',
+        class  => 'PromptMixin',
+        method => 'set_post_prompt'
+    },
+    'prompt_add_section' => {
+        module => 'signalwire.core.mixins.prompt_mixin',
+        class  => 'PromptMixin',
+        method => 'prompt_add_section'
+    },
+    'prompt_add_subsection' => {
+        module => 'signalwire.core.mixins.prompt_mixin',
+        class  => 'PromptMixin',
+        method => 'prompt_add_subsection'
+    },
+    'prompt_add_to_section' => {
+        module => 'signalwire.core.mixins.prompt_mixin',
+        class  => 'PromptMixin',
+        method => 'prompt_add_to_section'
+    },
+    'prompt_has_section' => {
+        module => 'signalwire.core.mixins.prompt_mixin',
+        class  => 'PromptMixin',
+        method => 'prompt_has_section'
+    },
+    'get_prompt' => {
+        module => 'signalwire.core.mixins.prompt_mixin',
+        class  => 'PromptMixin',
+        method => 'get_prompt'
+    },
+    'define_contexts' => {
+        module => 'signalwire.core.mixins.prompt_mixin',
+        class  => 'PromptMixin',
+        method => 'define_contexts'
+    },
+    'reset_contexts' => {
+        module => 'signalwire.core.mixins.prompt_mixin',
+        class  => 'PromptMixin',
+        method => 'reset_contexts'
+    },
+    'contexts' => {
+        module => 'signalwire.core.mixins.prompt_mixin',
+        class  => 'PromptMixin',
+        method => 'contexts'
+    },
 
     # ToolMixin
-    'define_tool'            => { module => 'signalwire.core.mixins.tool_mixin', class => 'ToolMixin', method => 'define_tool' },
-    'register_swaig_function' => { module => 'signalwire.core.mixins.tool_mixin', class => 'ToolMixin', method => 'register_swaig_function' },
-    'define_tools'           => { module => 'signalwire.core.mixins.tool_mixin', class => 'ToolMixin', method => 'define_tools' },
-    'on_function_call'       => { module => 'signalwire.core.mixins.tool_mixin', class => 'ToolMixin', method => 'on_function_call' },
+    'define_tool' => {
+        module => 'signalwire.core.mixins.tool_mixin',
+        class  => 'ToolMixin',
+        method => 'define_tool'
+    },
+    'register_swaig_function' => {
+        module => 'signalwire.core.mixins.tool_mixin',
+        class  => 'ToolMixin',
+        method => 'register_swaig_function'
+    },
+    'define_tools' => {
+        module => 'signalwire.core.mixins.tool_mixin',
+        class  => 'ToolMixin',
+        method => 'define_tools'
+    },
+    'on_function_call' => {
+        module => 'signalwire.core.mixins.tool_mixin',
+        class  => 'ToolMixin',
+        method => 'on_function_call'
+    },
 
     # AIConfigMixin
-    'add_hint'                 => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'add_hint' },
-    'add_hints'                => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'add_hints' },
-    'add_pattern_hint'         => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'add_pattern_hint' },
-    'add_language'             => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'add_language' },
-    'set_languages'            => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'set_languages' },
-    'get_language_params'      => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'get_language_params' },
-    'set_language_params'      => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'set_language_params' },
-    'add_pronunciation'        => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'add_pronunciation' },
-    'set_pronunciations'       => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'set_pronunciations' },
-    'set_param'                => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'set_param' },
-    'set_params'               => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'set_params' },
-    'set_global_data'          => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'set_global_data' },
-    'update_global_data'       => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'update_global_data' },
-    'set_native_functions'     => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'set_native_functions' },
-    'set_internal_fillers'     => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'set_internal_fillers' },
-    'add_internal_filler'      => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'add_internal_filler' },
-    'enable_debug_events'      => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'enable_debug_events' },
-    'add_function_include'     => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'add_function_include' },
-    'set_function_includes'    => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'set_function_includes' },
-    'set_prompt_llm_params'    => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'set_prompt_llm_params' },
-    'set_post_prompt_llm_params' => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'set_post_prompt_llm_params' },
-    'add_mcp_server'           => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'add_mcp_server' },
-    'enable_mcp_server'        => { module => 'signalwire.core.mixins.ai_config_mixin', class => 'AIConfigMixin', method => 'enable_mcp_server' },
+    'add_hint' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'add_hint'
+    },
+    'add_hints' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'add_hints'
+    },
+    'add_pattern_hint' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'add_pattern_hint'
+    },
+    'add_language' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'add_language'
+    },
+    'set_languages' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'set_languages'
+    },
+    'get_language_params' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'get_language_params'
+    },
+    'set_language_params' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'set_language_params'
+    },
+    'add_pronunciation' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'add_pronunciation'
+    },
+    'set_pronunciations' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'set_pronunciations'
+    },
+    'set_param' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'set_param'
+    },
+    'set_params' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'set_params'
+    },
+    'set_global_data' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'set_global_data'
+    },
+    'update_global_data' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'update_global_data'
+    },
+    'set_native_functions' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'set_native_functions'
+    },
+    'set_internal_fillers' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'set_internal_fillers'
+    },
+    'add_internal_filler' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'add_internal_filler'
+    },
+    'enable_debug_events' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'enable_debug_events'
+    },
+    'add_function_include' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'add_function_include'
+    },
+    'set_function_includes' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'set_function_includes'
+    },
+    'set_prompt_llm_params' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'set_prompt_llm_params'
+    },
+    'set_post_prompt_llm_params' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'set_post_prompt_llm_params'
+    },
+    'add_mcp_server' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'add_mcp_server'
+    },
+    'enable_mcp_server' => {
+        module => 'signalwire.core.mixins.ai_config_mixin',
+        class  => 'AIConfigMixin',
+        method => 'enable_mcp_server'
+    },
 
     # SkillMixin
-    'add_skill'    => { module => 'signalwire.core.mixins.skill_mixin', class => 'SkillMixin', method => 'add_skill' },
-    'remove_skill' => { module => 'signalwire.core.mixins.skill_mixin', class => 'SkillMixin', method => 'remove_skill' },
-    'list_skills'  => { module => 'signalwire.core.mixins.skill_mixin', class => 'SkillMixin', method => 'list_skills' },
-    'has_skill'    => { module => 'signalwire.core.mixins.skill_mixin', class => 'SkillMixin', method => 'has_skill' },
+    'add_skill' => {
+        module => 'signalwire.core.mixins.skill_mixin',
+        class  => 'SkillMixin',
+        method => 'add_skill'
+    },
+    'remove_skill' => {
+        module => 'signalwire.core.mixins.skill_mixin',
+        class  => 'SkillMixin',
+        method => 'remove_skill'
+    },
+    'list_skills' => {
+        module => 'signalwire.core.mixins.skill_mixin',
+        class  => 'SkillMixin',
+        method => 'list_skills'
+    },
+    'has_skill' => {
+        module => 'signalwire.core.mixins.skill_mixin',
+        class  => 'SkillMixin',
+        method => 'has_skill'
+    },
 
     # WebMixin
-    'run'                         => { module => 'signalwire.core.mixins.web_mixin', class => 'WebMixin', method => 'run' },
-    'serve'                       => { module => 'signalwire.core.mixins.web_mixin', class => 'WebMixin', method => 'serve' },
-    'manual_set_proxy_url'        => { module => 'signalwire.core.mixins.web_mixin', class => 'WebMixin', method => 'manual_set_proxy_url' },
-    'set_dynamic_config_callback' => { module => 'signalwire.core.mixins.web_mixin', class => 'WebMixin', method => 'set_dynamic_config_callback' },
+    'run' => { module => 'signalwire.core.mixins.web_mixin', class => 'WebMixin', method => 'run' },
+    'serve' =>
+        { module => 'signalwire.core.mixins.web_mixin', class => 'WebMixin', method => 'serve' },
+    'manual_set_proxy_url' => {
+        module => 'signalwire.core.mixins.web_mixin',
+        class  => 'WebMixin',
+        method => 'manual_set_proxy_url'
+    },
+    'set_dynamic_config_callback' => {
+        module => 'signalwire.core.mixins.web_mixin',
+        class  => 'WebMixin',
+        method => 'set_dynamic_config_callback'
+    },
 
     # SWMLService (extract_sip_username lives here in Python)
-    'extract_sip_username' => { module => 'signalwire.core.swml_service', class => 'SWMLService', method => 'extract_sip_username' },
+    'extract_sip_username' => {
+        module => 'signalwire.core.swml_service',
+        class  => 'SWMLService',
+        method => 'extract_sip_username'
+    },
 
     # Port-only on AgentBase — will land in PORT_ADDITIONS.md
-    'render_swml'          => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'render_swml' },
-    'psgi_app'             => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'psgi_app' },
-    'set_answer_config'    => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'set_answer_config' },
-    'list_tool_names'      => { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'list_tool_names' },
+    'render_swml' =>
+        { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'render_swml' },
+    'psgi_app' =>
+        { module => 'signalwire.core.agent_base', class => 'AgentBase', method => 'psgi_app' },
+    'set_answer_config' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'set_answer_config'
+    },
+    'list_tool_names' => {
+        module => 'signalwire.core.agent_base',
+        class  => 'AgentBase',
+        method => 'list_tool_names'
+    },
 );
 
 # Package-scoped overrides for specific (package, sub) → (module, class, method)
@@ -358,73 +761,140 @@ my %AGENTBASE_METHOD_TO_PY = (
 # membership) needs to be rerouted, e.g. Perl helpers that live in a different
 # Python home, or when Perl had to rename to avoid a builtin.
 my %METHOD_OVERRIDES = (
+
     # SWMLService auth methods come from AuthMixin in Python.
     'SignalWire::SWML::Service' => {
-        'validate_basic_auth'         => { module => 'signalwire.core.mixins.auth_mixin', class => 'AuthMixin', method => 'validate_basic_auth' },
-        'get_basic_auth_credentials'  => { module => 'signalwire.core.mixins.auth_mixin', class => 'AuthMixin', method => 'get_basic_auth_credentials' },
+        'validate_basic_auth' => {
+            module => 'signalwire.core.mixins.auth_mixin',
+            class  => 'AuthMixin',
+            method => 'validate_basic_auth'
+        },
+        'get_basic_auth_credentials' => {
+            module => 'signalwire.core.mixins.auth_mixin',
+            class  => 'AuthMixin',
+            method => 'get_basic_auth_credentials'
+        },
     },
 
     # Perl renamed `delete` to `delete_<resource>` because `delete` is a
     # core builtin keyword. Translate back to the Python name `delete`.
     'SignalWire::REST::Namespaces::Recordings' => {
-        'delete_recording' => { module => 'signalwire.rest.namespaces.recordings', class => 'RecordingsResource', method => 'delete' },
+        'delete_recording' => {
+            module => 'signalwire.rest.namespaces.recordings',
+            class  => 'RecordingsResource',
+            method => 'delete'
+        },
     },
     'SignalWire::REST::Namespaces::Fabric::GenericResources' => {
-        'delete_resource' => { module => 'signalwire.rest.namespaces.fabric', class => 'GenericResources', method => 'delete' },
+        'delete_resource' => {
+            module => 'signalwire.rest.namespaces.fabric',
+            class  => 'GenericResources',
+            method => 'delete'
+        },
     },
     'SignalWire::REST::Namespaces::Compat::PhoneNumbers' => {
-        'delete_number' => { module => 'signalwire.rest.namespaces.compat', class => 'CompatPhoneNumbers', method => 'delete' },
+        'delete_number' => {
+            module => 'signalwire.rest.namespaces.compat',
+            class  => 'CompatPhoneNumbers',
+            method => 'delete'
+        },
     },
     'SignalWire::REST::Namespaces::Compat::Recordings' => {
-        'delete_recording' => { module => 'signalwire.rest.namespaces.compat', class => 'CompatRecordings', method => 'delete' },
+        'delete_recording' => {
+            module => 'signalwire.rest.namespaces.compat',
+            class  => 'CompatRecordings',
+            method => 'delete'
+        },
     },
     'SignalWire::REST::Namespaces::Compat::Tokens' => {
-        'delete_token' => { module => 'signalwire.rest.namespaces.compat', class => 'CompatTokens', method => 'delete' },
+        'delete_token' => {
+            module => 'signalwire.rest.namespaces.compat',
+            class  => 'CompatTokens',
+            method => 'delete'
+        },
     },
     'SignalWire::REST::Namespaces::Compat::Transcriptions' => {
-        'delete_transcription' => { module => 'signalwire.rest.namespaces.compat', class => 'CompatTranscriptions', method => 'delete' },
+        'delete_transcription' => {
+            module => 'signalwire.rest.namespaces.compat',
+            class  => 'CompatTranscriptions',
+            method => 'delete'
+        },
     },
     'SignalWire::REST::Namespaces::Project::Tokens' => {
-        'delete_token' => { module => 'signalwire.rest.namespaces.project', class => 'ProjectTokens', method => 'delete' },
+        'delete_token' => {
+            module => 'signalwire.rest.namespaces.project',
+            class  => 'ProjectTokens',
+            method => 'delete'
+        },
     },
     'SignalWire::REST::Namespaces::Registry::Numbers' => {
-        'delete_number' => { module => 'signalwire.rest.namespaces.registry', class => 'RegistryNumbers', method => 'delete' },
+        'delete_number' => {
+            module => 'signalwire.rest.namespaces.registry',
+            class  => 'RegistryNumbers',
+            method => 'delete'
+        },
     },
     'SignalWire::REST::Namespaces::Video::RoomRecordings' => {
-        'delete_recording' => { module => 'signalwire.rest.namespaces.video', class => 'VideoRoomRecordings', method => 'delete' },
+        'delete_recording' => {
+            module => 'signalwire.rest.namespaces.video',
+            class  => 'VideoRoomRecordings',
+            method => 'delete'
+        },
     },
     'SignalWire::REST::Namespaces::Video::Streams' => {
-        'delete_stream' => { module => 'signalwire.rest.namespaces.video', class => 'VideoStreams', method => 'delete' },
+        'delete_stream' => {
+            module => 'signalwire.rest.namespaces.video',
+            class  => 'VideoStreams',
+            method => 'delete'
+        },
     },
+
     # CrudResource base class's delete_resource maps to the Python `delete`.
     'SignalWire::REST::Namespaces::CrudResource' => {
-        'delete_resource' => { module => 'signalwire.rest._base', class => 'CrudResource', method => 'delete' },
+        'delete_resource' =>
+            { module => 'signalwire.rest._base', class => 'CrudResource', method => 'delete' },
     },
     'SignalWire::REST::HttpClient' => {
-        'delete_request' => { module => 'signalwire.rest._base', class => 'HttpClient', method => 'delete' },
+        'delete_request' =>
+            { module => 'signalwire.rest._base', class => 'HttpClient', method => 'delete' },
     },
 
     # Perl uses `to_hash` where Python uses `to_dict`. Python hash-like
     # APIs are dicts; the Perl convention is hashref, hence the name. For
     # surface parity, translate back to the Python name.
     'SignalWire::Contexts::Context' => {
-        'to_hash' => { module => 'signalwire.core.contexts', class => 'Context', method => 'to_dict' },
+        'to_hash' =>
+            { module => 'signalwire.core.contexts', class => 'Context', method => 'to_dict' },
     },
     'SignalWire::Contexts::ContextBuilder' => {
-        'to_hash' => { module => 'signalwire.core.contexts', class => 'ContextBuilder', method => 'to_dict' },
+        'to_hash' => {
+            module => 'signalwire.core.contexts',
+            class  => 'ContextBuilder',
+            method => 'to_dict'
+        },
     },
     'SignalWire::Contexts::GatherInfo' => {
-        'to_hash' => { module => 'signalwire.core.contexts', class => 'GatherInfo', method => 'to_dict' },
+        'to_hash' =>
+            { module => 'signalwire.core.contexts', class => 'GatherInfo', method => 'to_dict' },
     },
     'SignalWire::Contexts::GatherQuestion' => {
-        'to_hash' => { module => 'signalwire.core.contexts', class => 'GatherQuestion', method => 'to_dict' },
+        'to_hash' => {
+            module => 'signalwire.core.contexts',
+            class  => 'GatherQuestion',
+            method => 'to_dict'
+        },
     },
     'SignalWire::Contexts::Step' => {
         'to_hash' => { module => 'signalwire.core.contexts', class => 'Step', method => 'to_dict' },
     },
     'SignalWire::SWAIG::FunctionResult' => {
-        'to_hash' => { module => 'signalwire.core.function_result', class => 'FunctionResult', method => 'to_dict' },
+        'to_hash' => {
+            module => 'signalwire.core.function_result',
+            class  => 'FunctionResult',
+            method => 'to_dict'
+        },
     },
+
     # POM Section/PromptObjectModel: same to_hash -> to_dict rename as the
     # Contexts/FunctionResult families above; the underlying serialised
     # shape is identical between languages.
@@ -432,7 +902,8 @@ my %METHOD_OVERRIDES = (
         'to_hash' => { module => 'signalwire.pom.pom', class => 'Section', method => 'to_dict' },
     },
     'SignalWire::POM::PromptObjectModel' => {
-        'to_hash' => { module => 'signalwire.pom.pom', class => 'PromptObjectModel', method => 'to_dict' },
+        'to_hash' =>
+            { module => 'signalwire.pom.pom', class => 'PromptObjectModel', method => 'to_dict' },
     },
 
     # SWML::Service auth methods come from AuthMixin in Python (declared
@@ -452,6 +923,7 @@ my %METHOD_OVERRIDES = (
 # doesn't flag them. This list was derived from which Python classes
 # expose __init__ in python_surface.json.
 my %FORCE_IMPLICIT_INIT = map { $_ => 1 } (
+
     # REST core
     'SignalWire::REST::RestClient',
     'SignalWire::REST::HttpClient',
@@ -497,9 +969,9 @@ my %FORCE_IMPLICIT_INIT = map { $_ => 1 } (
     'SignalWire::Skills::SkillRegistry',
 
     # SWML
-    'SignalWire::SWML::Document',   # SWMLBuilder in Python
+    'SignalWire::SWML::Document',    # SWMLBuilder in Python
     'SignalWire::SWML::Service',
-    'SignalWire::SWML::Schema',     # SchemaUtils in Python
+    'SignalWire::SWML::Schema',      # SchemaUtils in Python
 
     # Prefabs (Python records __init__ on each prefab agent)
     'SignalWire::Prefabs::Concierge',
@@ -522,6 +994,7 @@ my %FORCE_IMPLICIT_INIT = map { $_ => 1 } (
 # as a public method. Matching that keeps the diff meaningful.
 my %SKIP_IMPLICIT_INIT = map { $_ => 1 } (
     'SignalWire::Relay::Constants',
+
     # Relay::Event and every Relay::Event::Foo subclass
     'SignalWire::Relay::Event',
     'SignalWire::Relay::Event::CallState',
@@ -570,43 +1043,47 @@ my %SKIP_FILE = ();
 sub parse_file {
     my ($path) = @_;
     open my $fh, '<', $path or die "open $path: $!";
-    my @packages;        # list of { name => ..., subs => [...], _seen => {...} }
+    my @packages;    # list of { name => ..., subs => [...], _seen => {...} }
     my $current;
-    while (my $line = <$fh>) {
-        if ($line =~ /^\s*package\s+([A-Za-z_][\w:]*)\s*;/) {
+    while ( my $line = <$fh> ) {
+        if ( $line =~ /^\s*package\s+([A-Za-z_][\w:]*)\s*;/ ) {
             my $pkg = $1;
             $current = {
-                name         => $pkg,
-                subs         => [],
-                _seen        => {},
-                uses_moo     => 0,
-                has_extends  => 0,
+                name        => $pkg,
+                subs        => [],
+                _seen       => {},
+                uses_moo    => 0,
+                has_extends => 0,
             };
             push @packages, $current;
             next;
         }
+
         # Detect `use Moo;` / `use Moo::Role;`
-        if ($line =~ /^\s*use\s+Moo(?:::Role)?\b/) {
+        if ( $line =~ /^\s*use\s+Moo(?:::Role)?\b/ ) {
             $current->{uses_moo} = 1 if $current;
             next;
         }
+
         # Detect `extends 'Foo';` (Moo inheritance)
-        if ($line =~ /^\s*extends\s+['"\(]/) {
+        if ( $line =~ /^\s*extends\s+['"\(]/ ) {
             $current->{has_extends} = 1 if $current;
+
             # fall through — no 'next' needed, but nothing else to match
         }
+
         # Only match sub definitions at column 0. Indented subs are almost
         # always inside string heredocs/POD examples or nested coderefs, not
         # package-level public API. This keeps false positives out.
-        if ($line =~ /^sub\s+([A-Za-z_]\w*)\b/) {
+        if ( $line =~ /^sub\s+([A-Za-z_]\w*)\b/ ) {
             my $sub_name = $1;
-            next unless $current;   # sub before any package — ignore
-            # Perl convention: leading underscore = private. Dunder
-            # methods (e.g. __iter__, __next__, __init__) are public
-            # protocol hooks and should be emitted.
-            next if $sub_name =~ /^_/ && !($sub_name =~ /^__\w+__$/);
+            next unless $current;    # sub before any package — ignore
+                                     # Perl convention: leading underscore = private. Dunder
+                                     # methods (e.g. __iter__, __next__, __init__) are public
+                                     # protocol hooks and should be emitted.
+            next if $sub_name =~ /^_/ && !( $sub_name =~ /^__\w+__$/ );
             next if $SKIP_SUB{$sub_name};
-            next if $current->{_seen}{$sub_name}++;  # de-dup overloaded defs
+            next if $current->{_seen}{$sub_name}++;                       # de-dup overloaded defs
             push @{ $current->{subs} }, $sub_name;
         }
     }
@@ -616,7 +1093,7 @@ sub parse_file {
     # own their own __init__ and should emit it; subclasses/roles inherit it
     # and shouldn't repeat it in the surface.
     for my $p (@packages) {
-        $p->{is_moo_root} = ($p->{uses_moo} && !$p->{has_extends}) ? 1 : 0;
+        $p->{is_moo_root} = ( $p->{uses_moo} && !$p->{has_extends} ) ? 1 : 0;
     }
     return \@packages;
 }
@@ -627,7 +1104,7 @@ sub parse_file {
 # -------------------------------------------------------------------------
 sub collect_surface {
     my ($lib_root) = @_;
-    my %modules;   # module => { classes => { CLS => [...] }, functions => [...] }
+    my %modules;    # module => { classes => { CLS => [...] }, functions => [...] }
 
     my $ensure = sub {
         my ($mod) = @_;
@@ -635,40 +1112,44 @@ sub collect_surface {
         return $modules{$mod};
     };
     my $record_class_method = sub {
-        my ($mod, $class, $method) = @_;
+        my ( $mod, $class, $method ) = @_;
         my $bucket = $ensure->($mod);
         $bucket->{classes}{$class} //= [];
         my %seen = map { $_ => 1 } @{ $bucket->{classes}{$class} };
         push @{ $bucket->{classes}{$class} }, $method unless $seen{$method};
     };
     my $record_function = sub {
-        my ($mod, $fn) = @_;
+        my ( $mod, $fn ) = @_;
         my $bucket = $ensure->($mod);
-        my %seen = map { $_ => 1 } @{ $bucket->{functions} };
+        my %seen   = map { $_ => 1 } @{ $bucket->{functions} };
         push @{ $bucket->{functions} }, $fn unless $seen{$fn};
     };
     my $record_class_only = sub {
-        my ($mod, $class) = @_;
+        my ( $mod, $class ) = @_;
         my $bucket = $ensure->($mod);
         $bucket->{classes}{$class} //= [];
     };
 
     my @pm_files;
-    File::Find::find({
-        wanted => sub { push @pm_files, $File::Find::name if /\.pm$/ },
-        no_chdir => 1,
-    }, $lib_root);
+    File::Find::find(
+        {
+            wanted   => sub { push @pm_files, $File::Find::name if /\.pm$/ },
+            no_chdir => 1,
+        },
+        $lib_root
+    );
+
     # SignalWire.pm at the lib root
-    my $top = File::Spec->catfile(File::Spec->catdir($lib_root, '..'), 'SignalWire.pm');
+    my $top = File::Spec->catfile( File::Spec->catdir( $lib_root, '..' ), 'SignalWire.pm' );
     push @pm_files, $top if -f $top;
 
-    for my $file (sort @pm_files) {
+    for my $file ( sort @pm_files ) {
         next if $SKIP_FILE{$file};
         my $packages = parse_file($file);
         for my $pkg (@$packages) {
             my $pkg_name = $pkg->{name};
-            my $info = $PACKAGE_TO_PY{$pkg_name};
-            if (!$info) {
+            my $info     = $PACKAGE_TO_PY{$pkg_name};
+            if ( !$info ) {
                 warn "enumerate_surface: package $pkg_name not in translation map (file: $file)\n";
                 next;
             }
@@ -677,68 +1158,73 @@ sub collect_surface {
 
             # Record the class even if there are no subs, to keep the shape
             # consistent with Python's output for empty-class definitions.
-            $record_class_only->($mod, $class) if defined $class;
+            $record_class_only->( $mod, $class ) if defined $class;
 
             # Emit implicit `__init__` only when the Perl class is a Moo root
             # (use Moo; with no extends) — that matches Python's AST-based
             # enumerator which records `__init__` on the class that defines
             # it, not on subclasses that inherit it. Packages opting in via
             # %FORCE_IMPLICIT_INIT get one too.
-            if (defined $class && !$SKIP_IMPLICIT_INIT{$pkg_name}) {
+            if ( defined $class && !$SKIP_IMPLICIT_INIT{$pkg_name} ) {
                 my $has_explicit_new = grep { $_ eq 'new' } @{ $pkg->{subs} };
                 my $should_emit_init = 0;
-                if (!$has_explicit_new) {
-                    if ($FORCE_IMPLICIT_INIT{$pkg_name}) {
+                if ( !$has_explicit_new ) {
+                    if ( $FORCE_IMPLICIT_INIT{$pkg_name} ) {
                         $should_emit_init = 1;
-                    } elsif ($pkg->{is_moo_root}) {
+                    } elsif ( $pkg->{is_moo_root} ) {
                         $should_emit_init = 1;
                     }
                 }
                 if ($should_emit_init) {
-                    if ($pkg_name eq 'SignalWire::Agent::AgentBase') {
+                    if ( $pkg_name eq 'SignalWire::Agent::AgentBase' ) {
                         my $r = $AGENTBASE_METHOD_TO_PY{new};
-                        $record_class_method->($r->{module}, $r->{class}, $r->{method}) if $r;
+                        $record_class_method->( $r->{module}, $r->{class}, $r->{method} ) if $r;
                     } else {
-                        $record_class_method->($mod, $class, '__init__');
+                        $record_class_method->( $mod, $class, '__init__' );
                     }
                 }
             }
 
-            for my $sub (@{ $pkg->{subs} }) {
+            for my $sub ( @{ $pkg->{subs} } ) {
+
                 # Special-case routing for AgentBase flat class.
-                if ($pkg_name eq 'SignalWire::Agent::AgentBase') {
+                if ( $pkg_name eq 'SignalWire::Agent::AgentBase' ) {
                     my $route = $AGENTBASE_METHOD_TO_PY{$sub};
                     if ($route) {
-                        $record_class_method->($route->{module}, $route->{class}, $route->{method});
+                        $record_class_method->(
+                            $route->{module}, $route->{class}, $route->{method}
+                        );
                     } else {
-                        warn "enumerate_surface: AgentBase sub '$sub' has no routing entry; recording on AgentBase\n";
-                        $record_class_method->('signalwire.core.agent_base', 'AgentBase', $sub);
+                        warn
+"enumerate_surface: AgentBase sub '$sub' has no routing entry; recording on AgentBase\n";
+                        $record_class_method->( 'signalwire.core.agent_base', 'AgentBase', $sub );
                     }
                     next;
                 }
 
                 # Per-package overrides
-                if (my $ov = $METHOD_OVERRIDES{$pkg_name}{$sub}) {
-                    $record_class_method->($ov->{module}, $ov->{class}, $ov->{method});
+                if ( my $ov = $METHOD_OVERRIDES{$pkg_name}{$sub} ) {
+                    $record_class_method->( $ov->{module}, $ov->{class}, $ov->{method} );
                     next;
                 }
 
                 # Default: project onto declared (module, class)
-                my $method = ($sub eq 'new') ? '__init__' : $sub;
-                if (defined $class) {
-                    $record_class_method->($mod, $class, $method);
+                my $method = ( $sub eq 'new' ) ? '__init__' : $sub;
+                if ( defined $class ) {
+                    $record_class_method->( $mod, $class, $method );
                 } else {
+
                     # Module-level (no class)
-                    $record_function->($mod, $method);
+                    $record_function->( $mod, $method );
                 }
             }
         }
     }
 
     # Normalise: sort method arrays and function arrays.
-    for my $mod (keys %modules) {
+    for my $mod ( keys %modules ) {
         my $bucket = $modules{$mod};
-        for my $c (keys %{ $bucket->{classes} }) {
+        for my $c ( keys %{ $bucket->{classes} } ) {
             my @m = sort @{ $bucket->{classes}{$c} };
             $bucket->{classes}{$c} = \@m;
         }
@@ -767,7 +1253,7 @@ my $modules = collect_surface($LIB_ROOT);
 my $snapshot = {
     version        => '1',
     generated_from => 'signalwire-perl @ ' . git_sha(),
-    perl_version   => sprintf('%vd', $^V),
+    perl_version   => sprintf( '%vd', $^V ),
     modules        => $modules,
 };
 

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -20,6 +20,11 @@
 #                                           FunctionResult serialisation vs
 #                                           Python's to_dict() over the shared
 #                                           81-entry corpus; no mocks/network)
+#   7. fmt gate                           — Perl::Tidy (local: apply; CI: --assert-tidy)
+#   8. lint gate                          — Perl::Critic severity 5, zero findings
+#   9. doc-audit gate                     — porting-sdk audit_docs.py
+#  10. surface-diff gate                  — porting-sdk diff_port_surface.py
+#  11. skill-contract gate                — porting-sdk diff_skill_contracts.py
 
 set -u
 set -o pipefail
@@ -83,6 +88,17 @@ if [ -d "$LOCAL_LIB_DIR" ]; then
     export PERL5LIB="$LOCAL_LIB_DIR${PERL5LIB:+:$PERL5LIB}"
 fi
 
+# Same local::lib, same reason — but for the FMT/LINT gate EXECUTABLES. The
+# perltidy / perlcritic scripts (CPAN develop-deps) install into the local::lib's
+# bin/ alongside the modules above; that dir is NOT on the default PATH, so a
+# LOCAL run would hit `perltidy: command not found` even though it's installed.
+# Prepend it when it exists — same $HOME keying + existence guard as PERL5LIB, so
+# CI (deps on the system perl, already on PATH) is unaffected.
+LOCAL_LIB_BIN="${PERL_LOCAL_LIB_ROOT:-$HOME/perl5}/bin"
+if [ -d "$LOCAL_LIB_BIN" ]; then
+    export PATH="$LOCAL_LIB_BIN:$PATH"
+fi
+
 echo "==> running CI gates for $PORT_NAME (porting-sdk at $PORTING_SDK_DIR)"
 
 # Gate 1: prove
@@ -139,6 +155,133 @@ run_gate "NO-CHEAT" "audit_no_cheat_tests" \
 run_gate "EMISSION" "diff_port_emission vs python to_dict()" \
     python3 "$PORTING_SDK_DIR/scripts/diff_port_emission.py" \
         --dump-cmd "perl bin/emit-corpus.pl" \
+        --port-repo "$PORT_ROOT"
+
+# The set of Perl source files the FMT + LINT gates police: every module under
+# lib/ plus the repo's hand-written Perl tooling (bin/ + scripts/). Kept in one
+# place so FMT and LINT police exactly the same files. enumerate_signatures.py
+# is Python (skipped); enumerate_surface.pl / signature_dump.pl are Perl.
+perl_source_files() {
+    find lib -type f -name '*.pm'
+    echo bin/emit-corpus.pl
+    echo bin/emit-skills.pl
+    echo bin/swaig-test
+    echo scripts/enumerate_surface.pl
+    echo scripts/signature_dump.pl
+}
+
+# Gate 7: FMT — the language format gate (perl: Perl::Tidy). perltidy is the
+# Perl analog of gofmt / rustfmt / google-java-format: SOURCE-STYLE ONLY and
+# proven wire-/surface-neutral (a full reformat leaves port_signatures.json +
+# port_surface.json byte-identical and EMISSION 81/81 — verified in the FMT
+# rollout). Config is the committed .perltidyrc. Mirrors the go/ruby/java FMT
+# shape:
+#   * LOCAL ($CI unset)  → `perltidy -b`: reformats your working tree in place
+#     (deleting the .bak via -bext='/') so you never hand-run it; notes if it
+#     changed files. A residual non-tidy file then still fails the --assert-tidy
+#     check below.
+#   * CI ($CI=true)      → `perltidy --assert-tidy` (read-only, output to
+#     /dev/null): FAILS if any source file is not already tidy.
+fmt_gate() {
+    local f rc=0
+    if [ -n "${CI:-}" ]; then
+        while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            perltidy --profile="$PORT_ROOT/.perltidyrc" --assert-tidy \
+                -nst -se --outfile=/dev/null "$f" || rc=1
+        done < <(perl_source_files)
+    else
+        while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            perltidy --profile="$PORT_ROOT/.perltidyrc" -b -bext='/' "$f"
+        done < <(perl_source_files)
+        if ! git diff --quiet 2>/dev/null; then
+            echo "    (FMT auto-applied formatting to your working tree — review & stage)"
+        fi
+        # A residual issue perltidy can't fix must still fail the gate.
+        while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            perltidy --profile="$PORT_ROOT/.perltidyrc" --assert-tidy \
+                -nst -se --outfile=/dev/null "$f" || rc=1
+        done < <(perl_source_files)
+    fi
+    return $rc
+}
+run_gate "FMT" "perltidy (local: apply; CI: --assert-tidy)" fmt_gate
+
+# Gate 8: LINT — the language lint gate (perl: Perl::Critic at severity 5,
+# burned to ZERO). This is the blocking quality floor: the severity-5 policy set
+# (.perlcriticrc) is held at zero by FIXING source idiomatically — there are NO
+# `## no critic` annotations in lib/ and NO disabled policies. severity is pinned
+# both in .perlcriticrc and on the command line so the gate reproduces a bare
+# `perlcritic lib/`. Mirrors the go vet+golangci / ruby rubocop blocking-lint
+# gate.
+lint_gate() {
+    local f rc=0
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        perlcritic --profile "$PORT_ROOT/.perlcriticrc" --severity 5 "$f" || rc=1
+    done < <(perl_source_files)
+    return $rc
+}
+run_gate "LINT" "perlcritic severity 5, zero findings" lint_gate
+
+# Gate 9: DOC-AUDIT — every method/class referenced in docs/ + examples/ fenced
+# code blocks must resolve to a real symbol in the port surface (catches
+# phantom-API doc promises). Uses the committed port_surface.json (the
+# SURFACE-FRESH gate above already proved it is fresh) + DOC_AUDIT_IGNORE.md for
+# intentional non-symbol references. Mirrors .github/workflows/doc-audit.yml.
+run_gate "DOC-AUDIT" "audit_docs vs port_surface.json" \
+    python3 "$PORTING_SDK_DIR/scripts/audit_docs.py" \
+        --root "$PORT_ROOT" \
+        --surface "$PORT_ROOT/port_surface.json" \
+        --ignore "$PORT_ROOT/DOC_AUDIT_IGNORE.md"
+
+# Gate 10: SURFACE-DIFF — diff the port's public surface against the Python
+# reference (omissions + additions). The signature DRIFT gate (Layer A) checks
+# method *signatures*; this checks surface *membership* — public symbols the
+# port has that Python doesn't and vice-versa. Mirrors
+# .github/workflows/surface-audit.yml. Regenerate the surface in place via the
+# Perl enumerator, diff, then restore the committed copy unconditionally so the
+# gate is side-effect free.
+surface_diff_gate() {
+    local committed="/tmp/committed_surface_diff_${PORT_NAME}.$$"
+    git show HEAD:port_surface.json >"$committed" 2>/dev/null \
+        || cp port_surface.json "$committed"
+    perl scripts/enumerate_surface.pl --output port_surface.json
+    local regen_rc=$?
+    if [ "$regen_rc" -ne 0 ]; then
+        git checkout -- port_surface.json 2>/dev/null || true
+        rm -f "$committed"
+        echo "surface regen failed (exit $regen_rc)" >&2
+        return "$regen_rc"
+    fi
+    python3 "$PORTING_SDK_DIR/scripts/diff_port_surface.py" \
+        --reference "$PORTING_SDK_DIR/python_surface.json" \
+        --port-surface port_surface.json \
+        --omissions "$PORT_ROOT/PORT_OMISSIONS.md" \
+        --additions "$PORT_ROOT/PORT_ADDITIONS.md"
+    local rc=$?
+    git checkout -- port_surface.json 2>/dev/null || true
+    rm -f "$committed"
+    return $rc
+}
+run_gate "SURFACE-DIFF" "diff_port_surface vs python reference" \
+    surface_diff_gate
+
+# Gate 11: SKILL-CONTRACT — the surface/drift/emission gates see signatures +
+# symbol names + FunctionResult serialisation; NONE sees a built-in skill's
+# SWAIG tool contract ({name, parameters, required, enum} each skill registers).
+# This differ closes that gap: it builds the Python oracle by instantiating each
+# covered reference skill, runs the Perl skill-dump program (bin/emit-skills.pl,
+# which reads the SAME shared corpus), and structurally compares the two.
+# DESCRIPTIONS + implementation (handler vs DataMap) are not compared — only
+# name/param-name/param-type/enum/required. Mirrors the go/ruby/java SKILL-
+# CONTRACT gate. Same prereqs as EMISSION (signalwire-python adjacent; no
+# network).
+run_gate "SKILL-CONTRACT" "diff_skill_contracts vs python reference" \
+    python3 "$PORTING_SDK_DIR/scripts/diff_skill_contracts.py" \
+        --dump-cmd "perl bin/emit-skills.pl" \
         --port-repo "$PORT_ROOT"
 
 if [ -z "$FAILED_GATES" ]; then

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -21,7 +21,7 @@
 #                                           Python's to_dict() over the shared
 #                                           81-entry corpus; no mocks/network)
 #   7. fmt gate                           — Perl::Tidy (local: apply; CI: --assert-tidy)
-#   8. lint gate                          — Perl::Critic severity 5, zero findings
+#   8. lint gate                          — Perl::Critic severity 4, zero findings
 #   9. doc-audit gate                     — porting-sdk audit_docs.py
 #  10. surface-diff gate                  — porting-sdk diff_port_surface.py
 #  11. skill-contract gate                — porting-sdk diff_skill_contracts.py
@@ -209,22 +209,25 @@ fmt_gate() {
 }
 run_gate "FMT" "perltidy (local: apply; CI: --assert-tidy)" fmt_gate
 
-# Gate 8: LINT — the language lint gate (perl: Perl::Critic at severity 5,
-# burned to ZERO). This is the blocking quality floor: the severity-5 policy set
-# (.perlcriticrc) is held at zero by FIXING source idiomatically — there are NO
-# `## no critic` annotations in lib/ and NO disabled policies. severity is pinned
-# both in .perlcriticrc and on the command line so the gate reproduces a bare
-# `perlcritic lib/`. Mirrors the go vet+golangci / ruby rubocop blocking-lint
-# gate.
+# Gate 8: LINT — the language lint gate (perl: Perl::Critic at severity 4,
+# burned to ZERO). This is the blocking quality floor, ratcheted from the
+# original severity-5 floor to 4 by FIXING source idiomatically
+# (RequireFinalReturn / RequireArgUnpacking / RequireLocalizedPunctuationVars).
+# The only disabled policies (.perlcriticrc) are the handful justified by
+# wire/surface parity or a heuristic that does not fit the code — never style,
+# never to hide a finding (each carries a one-line rationale; see the file).
+# severity is pinned both in .perlcriticrc and on the command line so the gate
+# reproduces a bare `perlcritic lib/`. Mirrors the go vet+golangci / ruby
+# rubocop blocking-lint gate.
 lint_gate() {
     local f rc=0
     while IFS= read -r f; do
         [ -n "$f" ] || continue
-        perlcritic --profile "$PORT_ROOT/.perlcriticrc" --severity 5 "$f" || rc=1
+        perlcritic --profile "$PORT_ROOT/.perlcriticrc" --severity 4 "$f" || rc=1
     done < <(perl_source_files)
     return $rc
 }
-run_gate "LINT" "perlcritic severity 5, zero findings" lint_gate
+run_gate "LINT" "perlcritic severity 4, zero findings" lint_gate
 
 # Gate 9: DOC-AUDIT — every method/class referenced in docs/ + examples/ fenced
 # code blocks must resolve to a real symbol in the port surface (catches

--- a/scripts/signature_dump.pl
+++ b/scripts/signature_dump.pl
@@ -28,7 +28,7 @@ my $lib_root = $ARGV[0] // 'lib';
 die "lib directory not found: $lib_root\n" unless -d $lib_root;
 
 my @files;
-find(sub { push @files, $File::Find::name if /\.pm$/ }, $lib_root);
+find( sub { push @files, $File::Find::name if /\.pm$/ }, $lib_root );
 @files = sort @files;
 
 my @types;
@@ -36,13 +36,13 @@ for my $file (@files) {
     open my $fh, '<', $file or next;
     my @lines = <$fh>;
     close $fh;
-    push @types, parse_file($file, \@lines);
+    push @types, parse_file( $file, \@lines );
 }
 
-print JSON::PP->new->pretty->canonical->encode({ types => \@types });
+print JSON::PP->new->pretty->canonical->encode( { types => \@types } );
 
 sub parse_file {
-    my ($file, $lines) = @_;
+    my ( $file, $lines ) = @_;
     my @entries;
     my $cur_pkg;
     my @methods;
@@ -50,30 +50,32 @@ sub parse_file {
     my @extends;
 
     my $i = 0;
-    while ($i < @$lines) {
+    while ( $i < @$lines ) {
         my $line = $lines->[$i];
 
-        if ($line =~ /^\s*package\s+([\w:]+)\s*;/) {
+        if ( $line =~ /^\s*package\s+([\w:]+)\s*;/ ) {
+
             # Flush previous package
-            if (defined $cur_pkg && (@methods || @attrs || @extends)) {
-                push @entries, {
-                    full_name => $cur_pkg,
-                    methods => [@methods],
+            if ( defined $cur_pkg && ( @methods || @attrs || @extends ) ) {
+                push @entries,
+                    {
+                    full_name  => $cur_pkg,
+                    methods    => [@methods],
                     attributes => [@attrs],
-                    extends => [@extends],
-                };
+                    extends    => [@extends],
+                    };
             }
             $cur_pkg = $1;
             @methods = ();
-            @attrs = ();
+            @attrs   = ();
             @extends = ();
             $i++;
             next;
         }
 
         # ``extends 'Parent';`` — single arg
-        if ($line =~ /^\s*extends\s+(?:'([^']+)'|"([^"]+)")/) {
-            push @extends, ($1 // $2);
+        if ( $line =~ /^\s*extends\s+(?:'([^']+)'|"([^"]+)")/ ) {
+            push @extends, ( $1 // $2 );
             $i++;
             next;
         }
@@ -87,51 +89,53 @@ sub parse_file {
         #   sub foo { my ($self, $alpha, $beta, %opts) = @_; ... }
         # form. Without this, a port-side switch to signatures would drop
         # every parameter and surface as spurious arity drift.
-        my ($name, $sig);
-        if ($line =~ /^\s*sub\s+([A-Za-z_][\w]*)\s*(\([^)]*\))?\s*\{/) {
-            ($name, $sig) = ($1, $2);
-        }
-        elsif ($line =~ /^\s*sub\s+([A-Za-z_][\w]*)\s*(\([^)]*\))?\s*$/) {
+        my ( $name, $sig );
+        if ( $line =~ /^\s*sub\s+([A-Za-z_][\w]*)\s*(\([^)]*\))?\s*\{/ ) {
+            ( $name, $sig ) = ( $1, $2 );
+        } elsif ( $line =~ /^\s*sub\s+([A-Za-z_][\w]*)\s*(\([^)]*\))?\s*$/ ) {
+
             # Declaration with no opening brace on this line (brace on the
             # next line). The signature, if any, is still on this line.
-            ($name, $sig) = ($1, $2);
+            ( $name, $sig ) = ( $1, $2 );
         }
-        if (defined $name) {
+        if ( defined $name ) {
+
             # Collect body lines. Always include the sub-declaration line
             # itself so single-line definitions like
             #   sub play_pause { my ($s, $id, %p) = @_; ... }
             # have their params parsed (depth becomes 0 immediately and
             # the j-loop below skips body collection).
-            my @body = ($line);
-            my $depth = ($line =~ tr/\{// ) - ($line =~ tr/\}//);
-            my $j = $i + 1;
-            while ($j < @$lines && $depth > 0 && $j - $i < 30) {
+            my @body  = ($line);
+            my $depth = ( $line =~ tr/\{// ) - ( $line =~ tr/\}// );
+            my $j     = $i + 1;
+            while ( $j < @$lines && $depth > 0 && $j - $i < 30 ) {
                 push @body, $lines->[$j];
-                $depth += ($lines->[$j] =~ tr/\{//) - ($lines->[$j] =~ tr/\}//);
+                $depth += ( $lines->[$j] =~ tr/\{// ) - ( $lines->[$j] =~ tr/\}// );
                 $j++;
             }
+
             # A non-empty signature parenthetical is authoritative: parse
             # the names straight from it. An empty signature ``()`` means a
             # genuinely zero-parameter sub (e.g. a classmethod-free helper).
             # When there's no signature at all, fall back to scanning the
             # body for ``my (...) = @_`` / ``my $x = shift``.
             my @params;
-            if (defined $sig) {
+            if ( defined $sig ) {
                 @params = parse_signature($sig);
+            } else {
+                @params = parse_params( \@body );
             }
-            else {
-                @params = parse_params(\@body);
-            }
-            push @methods, {
-                name => $name,
+            push @methods,
+                {
+                name       => $name,
                 parameters => \@params,
-            };
+                };
             $i++;
             next;
         }
 
         # Moo/Moose attribute: has 'name' => ( ... );
-        if ($line =~ /^\s*has\s+(?:'([^']+)'|"([^"]+)")\s*=>/) {
+        if ( $line =~ /^\s*has\s+(?:'([^']+)'|"([^"]+)")\s*=>/ ) {
             my $attr = $1 // $2;
             push @attrs, { name => $attr };
             $i++;
@@ -141,13 +145,14 @@ sub parse_file {
         $i++;
     }
 
-    if (defined $cur_pkg && (@methods || @attrs || @extends)) {
-        push @entries, {
-            full_name => $cur_pkg,
-            methods => [@methods],
+    if ( defined $cur_pkg && ( @methods || @attrs || @extends ) ) {
+        push @entries,
+            {
+            full_name  => $cur_pkg,
+            methods    => [@methods],
             attributes => [@attrs],
-            extends => [@extends],
-        };
+            extends    => [@extends],
+            };
     }
     return @entries;
 }
@@ -163,24 +168,28 @@ sub parse_file {
 # downstream from the Python reference, not from the Perl default here.
 sub parse_signature {
     my ($sig) = @_;
+
     # Strip the surrounding parens.
     $sig =~ s/^\s*\(//;
     $sig =~ s/\)\s*$//;
     my @params;
+
     # Split on top-level commas. Signature defaults in this SDK are simple
     # scalars/strings without nested commas, so a plain comma split is
     # sufficient (and the parser is best-effort by design).
-    for my $part (split /,/, $sig) {
+    for my $part ( split /,/, $sig ) {
+
         # Drop any default: ``$beta = 5`` / ``$x //= 'foo'`` -> ``$beta``.
         $part =~ s/(?:\/\/=|=).*$//s;
         $part =~ s/^\s+//;
         $part =~ s/\s+$//;
         next if $part eq '';
+
         # A bare sigil placeholder (``$``, ``@``, ``%`` with no name) is a
         # signature's way of accepting-and-ignoring an argument; skip it
         # since it has no name to record.
         my $sigil = '';
-        if ($part =~ /^([\@\%])/) {
+        if ( $part =~ /^([\@\%])/ ) {
             $sigil = $1;
         }
         $part =~ s/^[\$\@\%]//;
@@ -196,18 +205,31 @@ sub parse_params {
     my @params;
 
     for my $bline (@$body) {
+
         # ``my ($self, $a, $b, $c) = @_;`` — also handles ``my (@args) = @_;``
         # and ``my (%kwargs) = @_;`` (slurpy array / hash) which we tag with
         # a sigil prefix so the canonical translator can distinguish between
         # var_positional (@) and var_keyword (%).
         # The pattern may appear anywhere on the line (single-line subs put
         # it after `sub NAME {`).
-        if ($bline =~ /\bmy\s*\(\s*([^)]*)\s*\)\s*=\s*\@_\s*;/) {
+        if ( $bline =~ /\bmy\s*\(\s*([^)]*)\s*\)\s*=\s*\@_\s*;/ ) {
             my $vars = $1;
-            for my $v (split /\s*,\s*/, $vars) {
+            for my $v ( split /\s*,\s*/, $vars ) {
+
+                # Trim surrounding whitespace so a perltidy-spaced unpack
+                # ``my ( $self, $query ) = @_;`` yields the same parameter
+                # NAMES as the tight ``my ($self, $query) = @_;`` form. The
+                # split's ``\s*`` collapses inter-element spaces, but the
+                # first/last element can still carry a leading/trailing space
+                # (the capture's ``[^)]*`` swallows the inner padding); without
+                # this trim the trailing var becomes ``query `` (with a space)
+                # and shows up as spurious signature drift. FMT is source-style
+                # only — the parser must be whitespace-agnostic.
+                $v =~ s/^\s+//;
+                $v =~ s/\s+$//;
                 next if $v eq '';
                 my $sigil = '';
-                if ($v =~ /^([\@\%])/) {
+                if ( $v =~ /^([\@\%])/ ) {
                     $sigil = $1;
                 }
                 $v =~ s/^[\$\@\%]//;
@@ -216,17 +238,20 @@ sub parse_params {
             }
             return @params;
         }
+
         # ``my $x = shift;`` style — accumulate
-        if ($bline =~ /\bmy\s+\$(\w+)\s*=\s*shift\s*;/) {
+        if ( $bline =~ /\bmy\s+\$(\w+)\s*=\s*shift\s*;/ ) {
             push @params, { name => $1, sigil => '' };
             next;
         }
+
         # Skip the sub-declaration line itself - it's only included so that
         # single-line definitions get parsed.
         next if $bline =~ /^\s*sub\s+\w+/;
+
         # First non-blank non-comment line that doesn't match either pattern:
         # stop accumulating shift-style and return what we have.
-        if ($bline =~ /^\s*[^#\s]/ && !@params) {
+        if ( $bline =~ /^\s*[^#\s]/ && !@params ) {
             last;
         }
     }


### PR DESCRIPTION
Brings signalwire-perl from 6 minimal gates to the **full 11-gate set**, matching go/rust/dotnet/ruby/java/php. Adds all 5 missing gates in the locked order: **FMT → LINT → DOC-AUDIT → SURFACE-DIFF → SKILL-CONTRACT**.

## What landed
- **FMT** — perltidy + `.perltidyrc`. Local apply / CI `--assert-tidy`. Polices `lib/**/*.pm` + `bin/{emit-corpus,emit-skills,swaig-test}` + `scripts/{enumerate_surface,signature_dump}`.
- **LINT** — perlcritic severity 5, burned to **zero** findings (incl. wiring `bin/swaig-test` in: `return undef`→`return`, replaced a `no strict 'refs'` symbolic deref with a glob-slice).
- **DOC-AUDIT** — `audit_docs.py` (mirrors the existing `doc-audit.yml` invocation, now in run-ci for local==CI parity).
- **SURFACE-DIFF** — `diff_port_surface.py` (mirrors `surface-audit.yml`; snapshot/regen via `enumerate_surface.pl`/restore).
- **SKILL-CONTRACT** — new `bin/emit-skills.pl` (blessed capturing fake-agent; handler + DataMap tools) + **8 real parity fixes** across 5 skills.

## SKILL-CONTRACT caught 8 over-constraint parity bugs
PERL marked params `required` that the Python reference leaves optional (same direction as java/php). Fixed PERL to match Python (verified at the emitted SWAIG schema); handlers already guard empty (added `// ''` guards where needed to match Python's `.get(...,"")`):
- math/calculate, web_search, wikipedia/search_wiki, datasphere/search_knowledge, info_gatherer/submit_answer, google_maps/lookup_address + compute_route — dropped spurious `required`.
- The other 8 corpus tools already matched and were untouched.

13/13 covered skill contracts now match the oracle. Python oracle not regenerated.

## Verification
- Full `bash scripts/run-ci.sh` → **all 11 gates PASS**, local and `CI=true` (independently re-run).
- `diff_skill_contracts.py` exits 0. EMISSION 81/81. `port_signatures.json` + `port_surface.json` byte-identical to committed (wire- and surface-neutral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)