### PR TITLE
feat(security): port the 3 security_utils (filter_sensitive_headers, redact_url, is_valid_hostname)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -206,6 +206,7 @@ lib/SignalWire/REST/Namespaces/Video.pm
 lib/SignalWire/REST/Pagination.pm
 lib/SignalWire/REST/PhoneCallHandler.pm
 lib/SignalWire/REST/RestClient.pm
+lib/SignalWire/Security/SecurityUtils.pm
 lib/SignalWire/Security/SessionManager.pm
 lib/SignalWire/Security/WebhookMiddleware.pm
 lib/SignalWire/Security/WebhookValidator.pm
@@ -375,5 +376,6 @@ t/rest/14_logs_mock.t
 t/rest/15_registry_mock.t
 t/rest/16_pagination_mock.t
 t/security/agent_base_signing_key.t
+t/security/security_utils.t
 t/security/webhook_middleware.t
 t/security/webhook_validator.t

--- a/lib/SignalWire/Security/SecurityUtils.pm
+++ b/lib/SignalWire/Security/SecurityUtils.pm
@@ -1,0 +1,77 @@
+package SignalWire::Security::SecurityUtils;
+
+# Standalone security hygiene utilities.
+#
+# Copyright (c) 2025 SignalWire. Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+#
+# Mirror of the Python reference
+# signalwire.core.security.security_utils (itself a mirror of the
+# TypeScript SDK's SecurityUtils): keep credentials out of user callbacks
+# and logs, and provide a reusable hostname character-level check.
+#
+# Public API (module-level free functions; the enumerate_surface.pl
+# adapter maps this package with class=undef so each sub projects onto a
+# Python module-level function under signalwire.core.security.security_utils):
+#
+#     filter_sensitive_headers($headers) -> hashref
+#     redact_url($url)                    -> string (or input unchanged)
+#     is_valid_hostname($host)            -> 0|1
+
+use strict;
+use warnings;
+
+use Scalar::Util qw(reftype);
+
+use Exporter qw(import);
+our @EXPORT_OK = qw(filter_sensitive_headers redact_url is_valid_hostname);
+
+# Header names whose values are credentials/secrets and must never be handed
+# to user callbacks or written to logs. Compared case-insensitively.
+my %SENSITIVE_HEADERS = map { $_ => 1 } qw(
+    authorization
+    cookie
+    x-api-key
+    proxy-authorization
+    set-cookie
+);
+
+# Return a copy of $headers (a hashref) with sensitive (credential-bearing)
+# headers removed, so request headers can be safely passed to user callbacks.
+# Keys are preserved as given; the sensitivity check is case-insensitive.
+# Empty / undef input yields an empty hashref.
+sub filter_sensitive_headers {
+    my ($headers) = @_;
+    return {} unless $headers && ( reftype($headers) // '' ) eq 'HASH';
+    my %filtered;
+    foreach my $key ( keys %{$headers} ) {
+        next if $SENSITIVE_HEADERS{ lc $key };
+        $filtered{$key} = $headers->{$key};
+    }
+    return \%filtered;
+}
+
+# Mask the password in a URL's userinfo before logging:
+#   https://user:secret@host/path -> https://user:****@host/path
+# A URL with no embedded credentials is returned unchanged. Non-string
+# (reference) input is returned as-is.
+sub redact_url {
+    my ($url) = @_;
+    return $url if !defined $url || ref $url;
+    $url =~ s{://([^:@/]+):([^@/]+)@}{://$1:****@}g;
+    return $url;
+}
+
+# Standalone hostname sanity check: reject empty hosts and any host
+# containing whitespace, slashes, backslashes, or control characters. This is
+# the reusable character-level check, independent of the fuller
+# SignalWire::Utils::UrlValidator::validate_url (scheme checks, DNS
+# resolution, private-IP blocking).
+sub is_valid_hostname {
+    my ($host) = @_;
+    return 0 if !defined $host || $host eq '';
+    return 0 if $host =~ m{[\s/\\\x00-\x1f\x7f]};
+    return 1;
+}
+
+1;

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -5217,6 +5217,41 @@
         }
       }
     },
+    "signalwire.core.security.security_utils": {
+      "classes": {},
+      "functions": {
+        "filter_sensitive_headers": {
+          "params": [
+            {
+              "name": "headers",
+              "type": "any",
+              "required": true
+            }
+          ],
+          "returns": "any"
+        },
+        "is_valid_hostname": {
+          "params": [
+            {
+              "name": "host",
+              "type": "any",
+              "required": true
+            }
+          ],
+          "returns": "any"
+        },
+        "redact_url": {
+          "params": [
+            {
+              "name": "url",
+              "type": "any",
+              "required": true
+            }
+          ],
+          "returns": "any"
+        }
+      }
+    },
     "signalwire.core.security.session_manager": {
       "classes": {
         "SessionManager": {

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,5 +1,5 @@
 {
-   "generated_from" : "signalwire-perl @ 0df0d52705e7080fd86bbc0011e2fb44e7eaecee",
+   "generated_from" : "signalwire-perl @ f026bf3f0686b5cf1bffc8291b2849811e21f16b",
    "modules" : {
       "signalwire" : {
          "classes" : {},
@@ -297,6 +297,14 @@
             ]
          },
          "functions" : []
+      },
+      "signalwire.core.security.security_utils" : {
+         "classes" : {},
+         "functions" : [
+            "filter_sensitive_headers",
+            "is_valid_hostname",
+            "redact_url"
+         ]
       },
       "signalwire.core.security.session_manager" : {
          "classes" : {
@@ -1381,6 +1389,6 @@
          ]
       }
    },
-   "perl_version" : "5.32.1",
+   "perl_version" : "5.34.1",
    "version" : "1"
 }

--- a/scripts/enumerate_signatures.py
+++ b/scripts/enumerate_signatures.py
@@ -143,6 +143,7 @@ FREE_FN_PACKAGES = {
     "SignalWire::Utils::UrlValidator",
     "SignalWire::Security::WebhookValidator",  # validate_webhook_signature, validate_request
     "SignalWire::Security::WebhookMiddleware",  # make_webhook_validation_dependency
+    "SignalWire::Security::SecurityUtils",  # filter_sensitive_headers, redact_url, is_valid_hostname
 }
 
 # Free-function name overrides — for cases where the Python canonical

--- a/scripts/enumerate_surface.pl
+++ b/scripts/enumerate_surface.pl
@@ -71,6 +71,8 @@ my %PACKAGE_TO_PY = (
         { module => 'signalwire.core.security.webhook_validator', class => undef },
     'SignalWire::Security::WebhookMiddleware' =>
         { module => 'signalwire.core.security.webhook_middleware', class => undef },
+    'SignalWire::Security::SecurityUtils' =>
+        { module => 'signalwire.core.security.security_utils', class => undef },
     'SignalWire::Server::AgentServer' =>
         { module => 'signalwire.agent_server', class => 'AgentServer' },
     'SignalWire::Logging' => { module => 'signalwire.core.logging_config', class => undef },

--- a/t/security/security_utils.t
+++ b/t/security/security_utils.t
@@ -1,0 +1,118 @@
+#!/usr/bin/env perl
+# Parity tests for SignalWire::Security::SecurityUtils. Mirrors the
+# Python reference signalwire.core.security.security_utils (filter_
+# sensitive_headers, redact_url, is_valid_hostname) and the TypeScript
+# SecurityUtils these descend from.
+
+use strict;
+use warnings;
+
+use Test::More;
+use SignalWire::Security::SecurityUtils
+    qw(filter_sensitive_headers redact_url is_valid_hostname);
+
+# --- filter_sensitive_headers ----------------------------------------
+
+subtest 'filter_sensitive_headers removes credential headers' => sub {
+    my $in = {
+        'Authorization'       => 'Bearer secret',
+        'Cookie'              => 'session=abc',
+        'X-API-Key'           => 'key123',
+        'Proxy-Authorization' => 'Basic xyz',
+        'Set-Cookie'          => 'a=b',
+        'Content-Type'        => 'application/json',
+        'X-Request-Id'        => 'req-1',
+    };
+    my $out = filter_sensitive_headers($in);
+    is_deeply(
+        $out,
+        { 'Content-Type' => 'application/json', 'X-Request-Id' => 'req-1' },
+        'sensitive headers stripped, non-sensitive preserved as given'
+    );
+    ok( !exists $out->{Authorization}, 'Authorization removed' );
+    ok( !exists $out->{Cookie},        'Cookie removed' );
+    ok( !exists $out->{'X-API-Key'},   'X-API-Key removed' );
+};
+
+subtest 'filter_sensitive_headers is case-insensitive on keys' => sub {
+    my $out = filter_sensitive_headers(
+        { 'AUTHORIZATION' => 'x', 'cookie' => 'y', 'SeT-CookIE' => 'z', 'Accept' => 'text/html' } );
+    is_deeply( $out, { 'Accept' => 'text/html' },
+        'mixed-case sensitive keys all removed regardless of casing' );
+};
+
+subtest 'filter_sensitive_headers preserves original key casing of kept headers' => sub {
+    my $out = filter_sensitive_headers( { 'X-Custom-Header' => 'v' } );
+    ok( exists $out->{'X-Custom-Header'}, 'kept key retains original casing' );
+    is( $out->{'X-Custom-Header'}, 'v', 'kept value intact' );
+};
+
+subtest 'filter_sensitive_headers returns a NEW hashref (copy)' => sub {
+    my $in  = { 'Accept' => 'text/html' };
+    my $out = filter_sensitive_headers($in);
+    isnt( $out, $in, 'returned hashref is a distinct copy' );
+    $out->{Mutated} = 1;
+    ok( !exists $in->{Mutated}, 'mutating the copy does not affect the input' );
+};
+
+subtest 'filter_sensitive_headers empty / undef input -> empty hashref' => sub {
+    is_deeply( filter_sensitive_headers( {} ),    {}, 'empty hash -> empty hash' );
+    is_deeply( filter_sensitive_headers(undef),   {}, 'undef -> empty hash' );
+};
+
+# --- redact_url -------------------------------------------------------
+
+subtest 'redact_url masks password in userinfo' => sub {
+    is(
+        redact_url('https://user:secret@host/path'),
+        'https://user:****@host/path',
+        'password replaced with ****'
+    );
+};
+
+subtest 'redact_url leaves credential-free URL unchanged' => sub {
+    is( redact_url('https://host/path'), 'https://host/path', 'no credentials -> unchanged' );
+    is( redact_url('https://user@host/path'),
+        'https://user@host/path', 'userinfo without password -> unchanged' );
+};
+
+subtest 'redact_url handles multiple occurrences' => sub {
+    is(
+        redact_url('redis://u:p1@a/ x://v:p2@b'),
+        'redis://u:****@a/ x://v:****@b',
+        'all credential pairs masked'
+    );
+};
+
+subtest 'redact_url non-string input returned as-is' => sub {
+    my $ref = { not => 'a string' };
+    is( redact_url($ref),  $ref,  'hashref returned unchanged' );
+    is( redact_url(undef), undef, 'undef returned unchanged' );
+};
+
+# --- is_valid_hostname ------------------------------------------------
+
+subtest 'is_valid_hostname accepts plain hostnames' => sub {
+    ok( is_valid_hostname('example.com'),       'dotted hostname valid' );
+    ok( is_valid_hostname('localhost'),         'bare hostname valid' );
+    ok( is_valid_hostname('host-name_1'),       'hyphen/underscore/digit valid' );
+    ok( is_valid_hostname('192.168.1.1'),       'IP literal valid (char-level)' );
+};
+
+subtest 'is_valid_hostname rejects empty / undef' => sub {
+    ok( !is_valid_hostname(''),    'empty string rejected' );
+    ok( !is_valid_hostname(undef), 'undef rejected' );
+};
+
+subtest 'is_valid_hostname rejects whitespace, slashes, control chars' => sub {
+    ok( !is_valid_hostname('bad host'),       'space rejected' );
+    ok( !is_valid_hostname("tab\thost"),      'tab rejected' );
+    ok( !is_valid_hostname('host/path'),      'forward slash rejected' );
+    ok( !is_valid_hostname('host\\path'),     'backslash rejected' );
+    ok( !is_valid_hostname("host\x00null"),   'null byte rejected' );
+    ok( !is_valid_hostname("host\x1fctl"),    'control char rejected' );
+    ok( !is_valid_hostname("host\x7fdel"),    'DEL char rejected' );
+    ok( !is_valid_hostname("host\nnewline"),  'newline rejected' );
+};
+
+done_testing();


### PR DESCRIPTION
## Summary

Clears the DRIFT gate after the Python reference added `signalwire.core.security.security_utils`. Ports its 3 public free functions to the Perl SDK as `SignalWire::Security::SecurityUtils` (these mirror the TypeScript SDK's `SecurityUtils`).

- **`filter_sensitive_headers($headers)`** — returns a NEW hashref copy of `$headers` with credential-bearing headers removed (`authorization`, `cookie`, `x-api-key`, `proxy-authorization`, `set-cookie`), compared case-insensitively on the key; non-sensitive keys preserved with original casing. Empty/undef input → `{}`.
- **`redact_url($url)`** — masks the password in URL userinfo (`://user:secret@` → `://user:****@`). Credential-free URLs and non-string (ref/undef) input returned unchanged.
- **`is_valid_hostname($host)`** — rejects empty hosts and any host containing whitespace, slashes, backslashes, or control chars (`[\s/\\\x00-\x1f\x7f]`); otherwise true.

## Idiom adjustments

Implemented as module-level free functions (`Exporter`/`@EXPORT_OK`), matching the existing `UrlValidator`/`WebhookValidator` shape. The package is mapped through `scripts/enumerate_surface.pl` `PACKAGE_TO_PY` with `class => undef` and added to `scripts/enumerate_signatures.py` `FREE_FN_PACKAGES`, so the 3 subs project onto the canonical Python module-level functions under `signalwire.core.security.security_utils`. This is the documented enumerator/adapter idiom path, not an omission.

## Verification

`bash scripts/run-ci.sh` → **CI PASS** (all 11 gates: TEST, SIGNATURES, DRIFT, SURFACE-FRESH, NO-CHEAT, EMISSION, FMT, LINT, DOC-AUDIT, SURFACE-DIFF, SKILL-CONTRACT). Regenerated `port_signatures.json` + `port_surface.json`, added MANIFEST entries, and a `t/security/security_utils.t` parity test with real assertions per function (case-insensitivity, copy semantics, multi-credential redaction, control-char rejection, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau