### PR TITLE
docs(drift): excuse 3 skill ctor divergences (mypy re-drift)

### DIFF
--- a/PORT_SIGNATURE_OMISSIONS.md
+++ b/PORT_SIGNATURE_OMISSIONS.md
@@ -59,6 +59,9 @@ signalwire.relay.event.ReferEvent.__init__: Perl ReferEvent doesn't model `sip_r
 signalwire.relay.event.RelayEvent.__init__: Perl base RelayEvent omits `call_id` (subclasses add it where applicable); Python keeps it on the base class with `''` default
 signalwire.relay.event.StreamEvent.__init__: Perl StreamEvent doesn't model `url` / `name` as Moo attrs; the Perl SDK reads them from the underlying CallStream payload
 signalwire.relay.event.TranscribeEvent.__init__: Perl TranscribeEvent doesn't model `url`, `recording_id`, `duration`, `size` as Moo attrs; the Perl SDK reads them from the underlying CallTranscribe payload
+signalwire.skills.api_ninjas_trivia.skill.ApiNinjasTriviaSkill.__init__: Perl declares the skill's constructor explicitly (Moo `extends` SkillBase); Python's same skill now simply inherits `SkillBase.__init__` verbatim, so the reference no longer emits a per-skill ctor. Same construction contract (agent, params) — Perl just keeps it explicit.
+signalwire.skills.play_background_file.skill.PlayBackgroundFileSkill.__init__: Perl declares the skill's constructor explicitly (Moo `extends` SkillBase); Python's same skill now inherits `SkillBase.__init__` verbatim, so the reference no longer emits a per-skill ctor. Same construction contract.
+signalwire.skills.weather_api.skill.WeatherApiSkill.__init__: Perl declares the skill's constructor explicitly (Moo `extends` SkillBase); Python's same skill now inherits `SkillBase.__init__` verbatim, so the reference no longer emits a per-skill ctor. Same construction contract.
 
 
 ## Idiom: Perl-side helpers replicated on AgentBase


### PR DESCRIPTION
Part of the signalwire-python mypy pass re-drift. Python's mypy work made the weather_api / api_ninjas_trivia / play_background_file skills inherit `SkillBase.__init__` verbatim, so the reference oracle no longer emits per-skill constructors. Perl declares them explicitly (Moo `extends`) — same `(agent, params)` construction contract. Three `PORT_SIGNATURE_OMISSIONS.md` entries (matches the existing per-skill `__init__` divergence block). **No code change.**

Coupled to porting-sdk `chore/python-mypy-oracle-redrift` (#40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau