### PR TITLE
test(rest): full success+error REST coverage (286/307) + gate

### DIFF
--- a/REST_COVERAGE_GAPS.md
+++ b/REST_COVERAGE_GAPS.md
@@ -1,0 +1,43 @@
+# REST coverage — signalwire-perl accepted SDK gaps
+
+Canonical REST routes the **Perl SDK** does not implement, so they cannot reach
+success+error coverage here. These are the per-port half of the `REST-COVERAGE`
+allowlist (type `sdk-gap`); the universal gaps (the two doubled-path spec
+artifacts + the video.get_room routing collision) live in
+`porting-sdk/REST_COVERAGE_BASELINE.md` and are NOT repeated here.
+
+Format: `<endpoint_id>: sdk-gap — <rationale>`. If a method is later added, the
+route becomes coverable and the checker fails on the now-stale entry until it's
+removed.
+
+These 18 gaps match the python/java/typescript/go/ruby accepted gaps exactly.
+
+## fabric — dialogflow_agents resource not wired
+
+fabric.list_dialogflow_agents: sdk-gap — no dialogflow_agents resource on the fabric namespace (same gap python carries).
+fabric.get_dialogflow_agent: sdk-gap — no dialogflow_agents resource.
+fabric.update_dialogflow_agent: sdk-gap — no dialogflow_agents resource.
+fabric.delete_dialogflow_agent: sdk-gap — no dialogflow_agents resource.
+fabric.list_dialogflow_agent_addresses: sdk-gap — no dialogflow_agents resource.
+
+## relay-rest — SIP endpoints + domain applications have no relay-rest namespace
+
+relay-rest.list_sip_endpoints: sdk-gap — no SDK namespace for /api/relay/rest/endpoints/sip; SIP endpoints live under the Fabric base path instead (same as python).
+relay-rest.create_sip_endpoint: sdk-gap — see above.
+relay-rest.retrieve_sip_endpoint: sdk-gap — see above.
+relay-rest.update_sip_endpoint: sdk-gap — see above.
+relay-rest.delete_sip_endpoint: sdk-gap — see above.
+relay-rest.list_domain_applications: sdk-gap — no SDK namespace for /api/relay/rest/domain_applications; only a Fabric assign-domain-application exists (same as python).
+relay-rest.create_domain_application: sdk-gap — see above.
+relay-rest.retrieve_domain_application: sdk-gap — see above.
+relay-rest.update_domain_application: sdk-gap — see above.
+relay-rest.delete_domain_application: sdk-gap — see above.
+
+## video — video logs have no accessor
+
+video.list_logs: sdk-gap — VideoNamespace exposes no logs accessor for GET /api/video/logs (same as python).
+video.get_log: sdk-gap — no video logs accessor (see above).
+
+## compatibility — bare per-country available-numbers node
+
+compatibility.list_available_phone_number_resources_by_country: sdk-gap — CompatPhoneNumbers exposes ListAvailableCountries + SearchLocal (/{IsoCountry}/Local) + SearchTollFree (/{IsoCountry}/TollFree), but no method hits the bare /AvailablePhoneNumbers/{IsoCountry} node (same as python).

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -15,6 +15,11 @@
 #                                           Layer-B-not-gated hole; Layer A above
 #                                           only gates signatures)
 #   5. no-cheat gate                      — porting-sdk audit_no_cheat_tests.py
+#   5b. rest-coverage gate                — porting-sdk rest_coverage checker:
+#                                           every implemented REST route covered
+#                                           success+error on the canonical path
+#                                           (spins its own mock, runs t/rest/
+#                                           serially, replays the journal)
 #   6. emission gate                      — porting-sdk diff_port_emission.py
 #                                           (byte-compares bin/emit-corpus.pl's
 #                                           FunctionResult serialisation vs
@@ -178,6 +183,53 @@ run_gate "SURFACE-FRESH" "check_surface_freshness (regen port_surface.json)" \
 # Gate 5: no-cheat
 run_gate "NO-CHEAT" "audit_no_cheat_tests" \
     python3 "$PORTING_SDK_DIR/scripts/audit_no_cheat_tests.py" --root "$PORT_ROOT"
+
+# Gate 5b: REST-COVERAGE — every canonical REST route the SDK implements must be
+# exercised with BOTH a success (2xx) AND an error (4xx/5xx) response on the
+# correct on-the-wire path (parity). Measured by replaying the mock journal of a
+# REST-suite run through porting-sdk's rest_coverage checker. Accepted gaps —
+# routes with no SDK method, malformed canonical routes, mock-router collisions —
+# are allowlisted: the shared baseline (porting-sdk/REST_COVERAGE_BASELINE.md) +
+# this port's REST_COVERAGE_GAPS.md. A stale entry (route now covered) fails the
+# gate. Self-contained: spins its OWN mock (probe-then-spawn with cleanup), resets
+# the journal, runs the t/rest/ suite SERIALLY (prove -j1) against that one mock so
+# all traffic lands in one journal, then checks that journal. Same shape as the
+# go/python/java/typescript gate.
+#
+# The mock is pre-spawned here (rather than letting the suite self-spawn on first
+# probe) so the run is deterministic and all REST traffic shares one journal; the
+# suite reuses it via the MOCK_SIGNALWIRE_PORT env + the harness's probe-or-reuse.
+rest_coverage_gate() {
+    local port=8770
+    local mock_pkg_parent="$PORTING_SDK_DIR/test_harness/mock_signalwire"
+    export PYTHONPATH="$mock_pkg_parent${PYTHONPATH:+:$PYTHONPATH}"
+    # Clear any stale listener on the port (a crashed prior run), then spawn.
+    lsof -ti :"$port" 2>/dev/null | xargs kill 2>/dev/null || true
+    python3 -m mock_signalwire --host 127.0.0.1 --port "$port" --log-level error \
+        >/tmp/rest_cov_mock_perl.$$.log 2>&1 &
+    local mock_pid=$!
+    # shellcheck disable=SC2064
+    trap "kill $mock_pid 2>/dev/null" RETURN
+    local i
+    for i in $(seq 1 60); do
+        if python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:$port/__mock__/health',timeout=1)" 2>/dev/null; then
+            break
+        fi
+        sleep 0.5
+    done
+    python3 -c "import urllib.request; urllib.request.urlopen(urllib.request.Request('http://127.0.0.1:$port/__mock__/journal/reset',method='POST'),timeout=5).read()"
+    # Run the REST suite serially against this one mock (one shared journal). The
+    # harness probes 127.0.0.1:$port (MOCK_SIGNALWIRE_PORT), finds it healthy, and
+    # reuses it instead of self-spawning.
+    MOCK_SIGNALWIRE_PORT="$port" prove -Ilib -It/lib -j1 t/rest/ || return 1
+    python3 -m mock_signalwire.rest_coverage \
+        --mock-url "http://127.0.0.1:$port" \
+        --spec-root "$PORTING_SDK_DIR/rest-apis" \
+        --allowlist "$PORTING_SDK_DIR/REST_COVERAGE_BASELINE.md" \
+        --allowlist "$PORT_ROOT/REST_COVERAGE_GAPS.md"
+}
+run_gate "REST-COVERAGE" "every implemented REST route covered success+error (parity + allowlist)" \
+    rest_coverage_gate
 
 # Gate 6: emission — byte-compare FunctionResult serialisation vs Python's
 # to_dict() over the shared 81-entry corpus. Pure serialisation: no mock

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -99,6 +99,38 @@ if [ -d "$LOCAL_LIB_BIN" ]; then
     export PATH="$LOCAL_LIB_BIN:$PATH"
 fi
 
+# Bootstrap the FMT/LINT develop-deps if missing. CI installs them via
+# `cpanm --with-develop --installdeps .` (.github/workflows/test.yml), but a
+# fresh LOCAL checkout has neither perltidy nor perlcritic on PATH, so the FMT
+# and LINT gates would die with "command not found" rather than run. Rather than
+# require every dev to remember the cpanm incantation, self-heal: when either
+# binary is unresolvable, install the cpanfile's `on 'develop'` block into the
+# local::lib (~/perl5 by convention) and re-expose its bin/ on PATH. Skipped in
+# CI ($CI set — deps already on the system perl) and when cpanm is unavailable
+# (then the gates fail loudly with an actionable message, as before). Keyed off
+# $HOME, never a hard-coded path.
+ensure_dev_tools() {
+    [ -n "${CI:-}" ] && return 0                          # CI installs its own deps
+    if command -v perltidy >/dev/null 2>&1 && command -v perlcritic >/dev/null 2>&1; then
+        return 0                                          # already resolvable
+    fi
+    if ! command -v cpanm >/dev/null 2>&1; then
+        echo "==> WARN: perltidy/perlcritic missing and cpanm unavailable;" \
+             "FMT/LINT gates will fail. Install App::cpanminus + cpanfile develop deps." >&2
+        return 0
+    fi
+    local lib_root="${PERL_LOCAL_LIB_ROOT:-$HOME/perl5}"
+    echo "==> bootstrapping FMT/LINT dev-deps (Perl::Tidy, Perl::Critic) into $lib_root ..."
+    cpanm --local-lib="$lib_root" --notest --quiet --with-develop --installdeps "$PORT_ROOT" \
+        || echo "==> WARN: dev-dep bootstrap failed; FMT/LINT gates may fail." >&2
+    # (Re)expose the local::lib now that it's populated.
+    LOCAL_LIB_DIR="$lib_root/lib/perl5"
+    [ -d "$LOCAL_LIB_DIR" ] && export PERL5LIB="$LOCAL_LIB_DIR${PERL5LIB:+:$PERL5LIB}"
+    LOCAL_LIB_BIN="$lib_root/bin"
+    [ -d "$LOCAL_LIB_BIN" ] && export PATH="$LOCAL_LIB_BIN:$PATH"
+}
+ensure_dev_tools
+
 echo "==> running CI gates for $PORT_NAME (porting-sdk at $PORTING_SDK_DIR)"
 
 # Gate 1: prove

--- a/t/rest/13_fabric_mock.t
+++ b/t/rest/13_fabric_mock.t
@@ -59,10 +59,16 @@ subtest 'TestCxmlApplicationsCreate' => sub {
         ok($err_str, 'create raises');
         like($err_str, qr/cXML applications cannot/,
             'error message mentions cXML applications cannot');
-        # Nothing should have hit the wire.
-        my $journal = MockTest::journal_all();
-        is(scalar(@$journal), 0,
-            'no journal entries after deliberate die');
+        # Nothing should have hit the wire: the create() must add ZERO new
+        # journal entries. Asserted as a delta (count after == count before)
+        # rather than an absolute empty journal, so the check is robust whether
+        # this process's auth-scoped view already holds entries from earlier
+        # subtests or a pre-spawned shared mock — same intent as python's
+        # per-test journal reset, just expressed without depending on a wipe.
+        my $before = scalar @{ MockTest::journal_all() };
+        eval { $client->fabric->cxml_applications->create(name => 'never_built') };
+        my $after = scalar @{ MockTest::journal_all() };
+        is($after, $before, 'create added no journal entries (nothing hit the wire)');
     };
 };
 

--- a/t/rest/20_compat_calls_cov.t
+++ b/t/rest/20_compat_calls_cov.t
@@ -1,0 +1,243 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_compat_calls_full_mock.py
+#
+# Full success + error coverage for $client->compat->calls — the LaML
+# (Twilio-compatible) Calls resource and its Recordings / Streams sub-resources.
+# Each canonical route gets a SUCCESS test (real SDK call, body shape + journal
+# method/path/matched_route) and an ERROR test (scenario_set arms a 4xx/5xx; the
+# SDK raises SignalWire::REST::HttpClient::Error with the matching status_code and
+# the journal records the route hit with that status).
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+my $BASE = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Calls";
+
+# ---- Success ----
+
+subtest 'test_list_all_calls' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->calls->list();
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{calls}, 'has calls');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, $BASE, 'path');
+    is($last->{matched_route}, 'compatibility.list_all_calls', 'matched route');
+};
+
+subtest 'test_create_a_call' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->calls->create(To => '+15551112222', From => '+15553334444');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, $BASE, 'path');
+    is($last->{matched_route}, 'compatibility.create_a_call', 'matched route');
+    is($last->{body}{To}, '+15551112222', 'body To forwarded');
+};
+
+subtest 'test_retrieve_a_call' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->calls->get('CA1');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/CA1", 'path');
+    is($last->{matched_route}, 'compatibility.retrieve_a_call', 'matched route');
+};
+
+subtest 'test_update_a_call' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->calls->update('CA1', Status => 'completed');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, "$BASE/CA1", 'path');
+    is($last->{matched_route}, 'compatibility.update_a_call', 'matched route');
+    is($last->{body}{Status}, 'completed', 'body Status forwarded');
+};
+
+subtest 'test_delete_a_call' => sub {
+    my $client = MockTest::client();
+    $client->compat->calls->delete_resource('CA1');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', 'DELETE');
+    is($last->{path}, "$BASE/CA1", 'path');
+    is($last->{matched_route}, 'compatibility.delete_a_call', 'matched route');
+};
+
+subtest 'test_create_recording' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->calls->start_recording('CA1');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, "$BASE/CA1/Recordings", 'path');
+    is($last->{matched_route}, 'compatibility.create_recording', 'matched route');
+};
+
+subtest 'test_update_recording' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->calls->update_recording('CA1', 'RE1', Status => 'paused');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, "$BASE/CA1/Recordings/RE1", 'path');
+    is($last->{matched_route}, 'compatibility.update_recording', 'matched route');
+    is($last->{body}{Status}, 'paused', 'body Status forwarded');
+};
+
+subtest 'test_create_stream' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->calls->start_stream('CA1', Url => 'wss://a.b/s');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, "$BASE/CA1/Streams", 'path');
+    is($last->{matched_route}, 'compatibility.create_stream', 'matched route');
+    is($last->{body}{Url}, 'wss://a.b/s', 'body Url forwarded');
+};
+
+subtest 'test_update_stream' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->calls->stop_stream('CA1', 'ST1', Status => 'stopped');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, "$BASE/CA1/Streams/ST1", 'path');
+    is($last->{matched_route}, 'compatibility.update_stream', 'matched route');
+    is($last->{body}{Status}, 'stopped', 'body Status forwarded');
+};
+
+# ---- Errors ----
+
+subtest 'test_list_all_calls_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_all_calls', 500, { error => 'internal' });
+    my $ok = eval { $client->compat->calls->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.list_all_calls', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_create_a_call_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.create_a_call', 422, { error => 'bad' });
+    my $ok = eval { $client->compat->calls->create(To => '+1', From => '+1'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.create_a_call', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_retrieve_a_call_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.retrieve_a_call', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->calls->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.retrieve_a_call', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_a_call_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_a_call', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->calls->update('missing', Status => 'completed'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.update_a_call', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_a_call_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.delete_a_call', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->calls->delete_resource('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.delete_a_call', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_create_recording_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.create_recording', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->calls->start_recording('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.create_recording', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_recording_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_recording', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->calls->update_recording('missing', 'RE1', Status => 'paused'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.update_recording', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_create_stream_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.create_stream', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->calls->start_stream('missing', Url => 'wss://a.b/s'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.create_stream', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_stream_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_stream', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->calls->stop_stream('missing', 'ST1', Status => 'stopped'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.update_stream', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+done_testing();

--- a/t/rest/21_compat_messages_cov.t
+++ b/t/rest/21_compat_messages_cov.t
@@ -1,0 +1,412 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_compat_messages_full_mock.py
+#
+# Full success + error coverage for $client->compat->messages and
+# $client->compat->faxes — the LaML (Twilio-compatible) Messages / Faxes
+# resources and their Media sub-resources. Each canonical route gets a SUCCESS
+# test and an ERROR test (scenario_set arms a 4xx/5xx; the SDK raises
+# SignalWire::REST::HttpClient::Error).
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+my $MSG = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Messages";
+my $FAX = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Faxes";
+
+# ---- Messages success ----
+
+subtest 'test_list_messages' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->messages->list();
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{messages}, 'has messages');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, $MSG, 'path');
+    is($last->{matched_route}, 'compatibility.list_messages', 'matched route');
+};
+
+subtest 'test_create_message' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->messages->create(
+        To => '+15551112222', From => '+15553334444', Body => 'hi',
+    );
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, $MSG, 'path');
+    is($last->{matched_route}, 'compatibility.create_message', 'matched route');
+    is($last->{body}{Body}, 'hi', 'body Body forwarded');
+};
+
+subtest 'test_list_media' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->messages->list_media('MM1');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{media_list}, 'has media_list');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$MSG/MM1/Media", 'path');
+    is($last->{matched_route}, 'compatibility.list_media', 'matched route');
+};
+
+subtest 'test_retrieve_media' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->messages->get_media('MM1', 'ME1');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$MSG/MM1/Media/ME1", 'path');
+    is($last->{matched_route}, 'compatibility.retrieve_media', 'matched route');
+};
+
+subtest 'test_delete_message_media' => sub {
+    my $client = MockTest::client();
+    $client->compat->messages->delete_media('MM1', 'ME1');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', 'DELETE');
+    is($last->{path}, "$MSG/MM1/Media/ME1", 'path');
+    is($last->{matched_route}, 'compatibility.delete_message_media', 'matched route');
+};
+
+subtest 'test_retrieve_message' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->messages->get('MM1');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$MSG/MM1", 'path');
+    is($last->{matched_route}, 'compatibility.retrieve_message', 'matched route');
+};
+
+subtest 'test_update_message' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->messages->update('MM1', Body => 'redacted');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, "$MSG/MM1", 'path');
+    is($last->{matched_route}, 'compatibility.update_message', 'matched route');
+    is($last->{body}{Body}, 'redacted', 'body Body forwarded');
+};
+
+subtest 'test_delete_message' => sub {
+    my $client = MockTest::client();
+    $client->compat->messages->delete_resource('MM1');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', 'DELETE');
+    is($last->{path}, "$MSG/MM1", 'path');
+    is($last->{matched_route}, 'compatibility.delete_message', 'matched route');
+};
+
+# ---- Messages errors ----
+
+subtest 'test_list_messages_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_messages', 500, { error => 'internal' });
+    my $ok = eval { $client->compat->messages->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.list_messages', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_create_message_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.create_message', 422, { error => 'bad' });
+    my $ok = eval { $client->compat->messages->create(To => '+1', From => '+1', Body => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.create_message', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_list_media_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_media', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->messages->list_media('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.list_media', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_retrieve_media_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.retrieve_media', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->messages->get_media('MM1', 'missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.retrieve_media', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_message_media_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.delete_message_media', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->messages->delete_media('MM1', 'missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.delete_message_media', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_retrieve_message_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.retrieve_message', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->messages->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.retrieve_message', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_message_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_message', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->messages->update('missing', Body => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.update_message', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_message_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.delete_message', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->messages->delete_resource('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.delete_message', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+# ---- Faxes success ----
+
+subtest 'test_list_all_faxes' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->faxes->list();
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{faxes}, 'has faxes');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, $FAX, 'path');
+    is($last->{matched_route}, 'compatibility.list_all_faxes', 'matched route');
+};
+
+subtest 'test_send_fax' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->faxes->create(
+        To => '+15551112222', From => '+15553334444', MediaUrl => 'https://x/y.pdf',
+    );
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, $FAX, 'path');
+    is($last->{matched_route}, 'compatibility.send_fax', 'matched route');
+    is($last->{body}{MediaUrl}, 'https://x/y.pdf', 'body MediaUrl forwarded');
+};
+
+subtest 'test_list_all_fax_media' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->faxes->list_media('FX1');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{media}, 'has media');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$FAX/FX1/Media", 'path');
+    is($last->{matched_route}, 'compatibility.list_all_fax_media', 'matched route');
+};
+
+subtest 'test_retrieve_medias' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->faxes->get_media('FX1', 'ME1');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$FAX/FX1/Media/ME1", 'path');
+    is($last->{matched_route}, 'compatibility.retrieve_medias', 'matched route');
+};
+
+subtest 'test_delete_fax_media' => sub {
+    my $client = MockTest::client();
+    $client->compat->faxes->delete_media('FX1', 'ME1');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', 'DELETE');
+    is($last->{path}, "$FAX/FX1/Media/ME1", 'path');
+    is($last->{matched_route}, 'compatibility.delete_fax_media', 'matched route');
+};
+
+subtest 'test_retrieve_fax' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->faxes->get('FX1');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$FAX/FX1", 'path');
+    is($last->{matched_route}, 'compatibility.retrieve_fax', 'matched route');
+};
+
+subtest 'test_update_fax' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->faxes->update('FX1', Status => 'canceled');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, "$FAX/FX1", 'path');
+    is($last->{matched_route}, 'compatibility.update_fax', 'matched route');
+    is($last->{body}{Status}, 'canceled', 'body Status forwarded');
+};
+
+subtest 'test_delete_fax' => sub {
+    my $client = MockTest::client();
+    $client->compat->faxes->delete_resource('FX1');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', 'DELETE');
+    is($last->{path}, "$FAX/FX1", 'path');
+    is($last->{matched_route}, 'compatibility.delete_fax', 'matched route');
+};
+
+# ---- Faxes errors ----
+
+subtest 'test_list_all_faxes_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_all_faxes', 500, { error => 'internal' });
+    my $ok = eval { $client->compat->faxes->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.list_all_faxes', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_send_fax_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.send_fax', 422, { error => 'bad' });
+    my $ok = eval { $client->compat->faxes->create(To => '+1', From => '+1', MediaUrl => 'u'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.send_fax', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_list_all_fax_media_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_all_fax_media', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->faxes->list_media('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.list_all_fax_media', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_retrieve_medias_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.retrieve_medias', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->faxes->get_media('FX1', 'missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.retrieve_medias', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_fax_media_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.delete_fax_media', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->faxes->delete_media('FX1', 'missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.delete_fax_media', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_retrieve_fax_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.retrieve_fax', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->faxes->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.retrieve_fax', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_fax_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_fax', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->faxes->update('missing', Status => 'canceled'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.update_fax', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_fax_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.delete_fax', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->faxes->delete_resource('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.delete_fax', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+done_testing();

--- a/t/rest/22_compat_phone_numbers_cov.t
+++ b/t/rest/22_compat_phone_numbers_cov.t
@@ -1,0 +1,246 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_compat_phone_numbers_full_mock.py
+#
+# Full success + error coverage for $client->compat->phone_numbers — the LaML
+# (Twilio-compatible) IncomingPhoneNumbers / ImportedPhoneNumbers /
+# AvailablePhoneNumbers resources. Each canonical route gets a SUCCESS test and
+# an ERROR test (scenario_set arms a 4xx/5xx; the SDK raises
+# SignalWire::REST::HttpClient::Error).
+#
+# GAP (accepted, allowlisted): compatibility.list_available_phone_number_resources_by_country
+# (GET /AvailablePhoneNumbers/{IsoCountry}) has no Perl SDK method, mirroring the
+# Python gap — no test is written for it.
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+my $INC   = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/IncomingPhoneNumbers";
+my $IMP   = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/ImportedPhoneNumbers";
+my $AVAIL = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/AvailablePhoneNumbers";
+
+# ---- Success ----
+
+subtest 'test_list_incoming_phone_numbers' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->phone_numbers->list();
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{incoming_phone_numbers}, 'has incoming_phone_numbers');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, $INC, 'path');
+    is($last->{matched_route}, 'compatibility.list_incoming_phone_numbers', 'matched route');
+};
+
+subtest 'test_create_incoming_phone_number' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->phone_numbers->purchase(PhoneNumber => '+15551112222');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, $INC, 'path');
+    is($last->{matched_route}, 'compatibility.create_incoming_phone_number', 'matched route');
+    is($last->{body}{PhoneNumber}, '+15551112222', 'body PhoneNumber forwarded');
+};
+
+subtest 'test_retrieve_incoming_phone_number' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->phone_numbers->get('PN1');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$INC/PN1", 'path');
+    is($last->{matched_route}, 'compatibility.retrieve_incoming_phone_number', 'matched route');
+};
+
+subtest 'test_update_incoming_phone_number' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->phone_numbers->update('PN1', FriendlyName => 'renamed');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, "$INC/PN1", 'path');
+    is($last->{matched_route}, 'compatibility.update_incoming_phone_number', 'matched route');
+    is($last->{body}{FriendlyName}, 'renamed', 'body FriendlyName forwarded');
+};
+
+subtest 'test_delete_incoming_phone_number' => sub {
+    my $client = MockTest::client();
+    $client->compat->phone_numbers->delete('PN1');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', 'DELETE');
+    is($last->{path}, "$INC/PN1", 'path');
+    is($last->{matched_route}, 'compatibility.delete_incoming_phone_number', 'matched route');
+};
+
+subtest 'test_create_imported_phone_number' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->phone_numbers->import_number(PhoneNumber => '+15551112222');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{sid}, 'has sid');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, $IMP, 'path');
+    is($last->{matched_route}, 'compatibility.create_imported_phone_number', 'matched route');
+    is($last->{body}{PhoneNumber}, '+15551112222', 'body PhoneNumber forwarded');
+};
+
+subtest 'test_list_available_phone_number_resources' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->phone_numbers->list_available_countries();
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{countries}, 'has countries');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, $AVAIL, 'path');
+    is($last->{matched_route}, 'compatibility.list_available_phone_number_resources', 'matched route');
+};
+
+subtest 'test_search_local_available_phone_numbers' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->phone_numbers->search_local('US');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{available_phone_numbers}, 'has available_phone_numbers');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$AVAIL/US/Local", 'path');
+    is($last->{matched_route}, 'compatibility.search_local_available_phone_numbers', 'matched route');
+};
+
+subtest 'test_search_toll_free_available_phone_numbers' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->phone_numbers->search_toll_free('US');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{available_phone_numbers}, 'has available_phone_numbers');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$AVAIL/US/TollFree", 'path');
+    is($last->{matched_route}, 'compatibility.search_toll_free_available_phone_numbers', 'matched route');
+};
+
+# ---- Errors ----
+
+subtest 'test_list_incoming_phone_numbers_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_incoming_phone_numbers', 500, { error => 'internal' });
+    my $ok = eval { $client->compat->phone_numbers->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.list_incoming_phone_numbers', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_create_incoming_phone_number_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.create_incoming_phone_number', 422, { error => 'bad' });
+    my $ok = eval { $client->compat->phone_numbers->purchase(PhoneNumber => '+1'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.create_incoming_phone_number', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_retrieve_incoming_phone_number_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.retrieve_incoming_phone_number', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->phone_numbers->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.retrieve_incoming_phone_number', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_incoming_phone_number_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_incoming_phone_number', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->phone_numbers->update('missing', FriendlyName => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.update_incoming_phone_number', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_incoming_phone_number_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.delete_incoming_phone_number', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->phone_numbers->delete('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.delete_incoming_phone_number', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_create_imported_phone_number_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.create_imported_phone_number', 422, { error => 'bad' });
+    my $ok = eval { $client->compat->phone_numbers->import_number(PhoneNumber => '+1'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.create_imported_phone_number', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_list_available_phone_number_resources_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_available_phone_number_resources', 500, { error => 'internal' });
+    my $ok = eval { $client->compat->phone_numbers->list_available_countries(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.list_available_phone_number_resources', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_search_local_available_phone_numbers_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.search_local_available_phone_numbers', 500, { error => 'internal' });
+    my $ok = eval { $client->compat->phone_numbers->search_local('US'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.search_local_available_phone_numbers', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_search_toll_free_available_phone_numbers_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.search_toll_free_available_phone_numbers', 500, { error => 'internal' });
+    my $ok = eval { $client->compat->phone_numbers->search_toll_free('US'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'compatibility.search_toll_free_available_phone_numbers', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+done_testing();

--- a/t/rest/23_compat_conferences_cov.t
+++ b/t/rest/23_compat_conferences_cov.t
@@ -1,0 +1,326 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_compat_conferences_full_mock.py
+#
+# Each canonical compatibility Conferences route gets BOTH a success (2xx) test
+# and an error (4xx/5xx) test, asserting the on-the-wire method/path and the
+# journaled matched_route + response_status.
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+my $CONF = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Conferences";
+
+# ---------------------------------------------------------------- success ----
+
+subtest 'test_list_all_conferences' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->conferences->list();
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{conferences}, 'conferences key');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, $CONF, 'path');
+    is($j->{matched_route}, 'compatibility.list_all_conferences', 'matched route');
+};
+
+subtest 'test_retrieve_conference' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->conferences->get('CF1');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, "$CONF/CF1", 'path');
+    is($j->{matched_route}, 'compatibility.retrieve_conference', 'matched route');
+};
+
+subtest 'test_update_conference' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->conferences->update('CF1', Status => 'completed');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, "$CONF/CF1", 'path');
+    is($j->{matched_route}, 'compatibility.update_conference', 'matched route');
+    is($j->{body}{Status}, 'completed', 'Status forwarded');
+};
+
+subtest 'test_list_all_participants' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->conferences->list_participants('CF1');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{participants}, 'participants key');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, "$CONF/CF1/Participants", 'path');
+    is($j->{matched_route}, 'compatibility.list_all_participants', 'matched route');
+};
+
+subtest 'test_retrieve_participant' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->conferences->get_participant('CF1', 'CA1');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, "$CONF/CF1/Participants/CA1", 'path');
+    is($j->{matched_route}, 'compatibility.retrieve_participant', 'matched route');
+};
+
+subtest 'test_update_participant' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->conferences->update_participant('CF1', 'CA1', Muted => 'true');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, "$CONF/CF1/Participants/CA1", 'path');
+    is($j->{matched_route}, 'compatibility.update_participant', 'matched route');
+    is($j->{body}{Muted}, 'true', 'Muted forwarded');
+};
+
+subtest 'test_delete_participant' => sub {
+    my $client = MockTest::client();
+    $client->compat->conferences->remove_participant('CF1', 'CA1');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'DELETE', 'DELETE');
+    is($j->{path}, "$CONF/CF1/Participants/CA1", 'path');
+    is($j->{matched_route}, 'compatibility.delete_participant', 'matched route');
+};
+
+subtest 'test_list_conference_recordings' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->conferences->list_recordings('CF1');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{recordings}, 'recordings key');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, "$CONF/CF1/Recordings", 'path');
+    is($j->{matched_route}, 'compatibility.list_conference_recordings', 'matched route');
+};
+
+subtest 'test_get_conference_recording' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->conferences->get_recording('CF1', 'RE1');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, "$CONF/CF1/Recordings/RE1", 'path');
+    is($j->{matched_route}, 'compatibility.get_conference_recording', 'matched route');
+};
+
+subtest 'test_update_conference_recording' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->conferences->update_recording('CF1', 'RE1', Status => 'paused');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, "$CONF/CF1/Recordings/RE1", 'path');
+    is($j->{matched_route}, 'compatibility.update_conference_recording', 'matched route');
+    is($j->{body}{Status}, 'paused', 'Status forwarded');
+};
+
+subtest 'test_delete_conference_recording' => sub {
+    my $client = MockTest::client();
+    $client->compat->conferences->delete_recording('CF1', 'RE1');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'DELETE', 'DELETE');
+    is($j->{path}, "$CONF/CF1/Recordings/RE1", 'path');
+    is($j->{matched_route}, 'compatibility.delete_conference_recording', 'matched route');
+};
+
+subtest 'test_create_conference_stream' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->conferences->start_stream('CF1', Url => 'wss://a.b/s');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, "$CONF/CF1/Streams", 'path');
+    is($j->{matched_route}, 'compatibility.create_conference_stream', 'matched route');
+    is($j->{body}{Url}, 'wss://a.b/s', 'Url forwarded');
+};
+
+subtest 'test_update_conference_stream' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->conferences->stop_stream('CF1', 'ST1', Status => 'stopped');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, "$CONF/CF1/Streams/ST1", 'path');
+    is($j->{matched_route}, 'compatibility.update_conference_stream', 'matched route');
+    is($j->{body}{Status}, 'stopped', 'Status forwarded');
+};
+
+# ------------------------------------------------------------------ error ----
+
+subtest 'test_list_all_conferences_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_all_conferences', 500, { error => 'internal' });
+    my $ok = eval { $client->compat->conferences->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.list_all_conferences', 'matched route');
+    is($j->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_retrieve_conference_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.retrieve_conference', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->conferences->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.retrieve_conference', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_conference_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_conference', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->conferences->update('missing', Status => 'completed'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.update_conference', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_list_all_participants_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_all_participants', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->conferences->list_participants('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.list_all_participants', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_retrieve_participant_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.retrieve_participant', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->conferences->get_participant('CF1', 'missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.retrieve_participant', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_participant_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_participant', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->conferences->update_participant('CF1', 'missing', Muted => 'true'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.update_participant', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_participant_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.delete_participant', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->conferences->remove_participant('CF1', 'missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.delete_participant', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_list_conference_recordings_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_conference_recordings', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->conferences->list_recordings('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.list_conference_recordings', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_get_conference_recording_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.get_conference_recording', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->conferences->get_recording('CF1', 'missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.get_conference_recording', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_conference_recording_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_conference_recording', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->conferences->update_recording('CF1', 'missing', Status => 'paused'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.update_conference_recording', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_conference_recording_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.delete_conference_recording', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->conferences->delete_recording('CF1', 'missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.delete_conference_recording', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_create_conference_stream_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.create_conference_stream', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->conferences->start_stream('missing', Url => 'wss://a.b/s'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.create_conference_stream', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_conference_stream_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_conference_stream', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->conferences->stop_stream('missing', 'ST1', Status => 'stopped'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.update_conference_stream', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+done_testing();

--- a/t/rest/24_compat_accounts_cov.t
+++ b/t/rest/24_compat_accounts_cov.t
@@ -1,0 +1,306 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_compat_accounts_full_mock.py
+#
+# Covers client.compat.accounts / .applications / .tokens. Each canonical route
+# gets BOTH a success (2xx) and an error (4xx/5xx) test, asserting the
+# on-the-wire method/path and the journaled matched_route + response_status.
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+my $ACCOUNTS = "/api/laml/2010-04-01/Accounts";
+my $BASE     = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT";
+
+# ----------------------------------------------------------- Accounts ----
+
+subtest 'test_list_accounts' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->accounts->list();
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{accounts}, 'accounts key');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, $ACCOUNTS, 'path');
+    is($j->{matched_route}, 'compatibility.list_accounts', 'matched route');
+};
+
+subtest 'test_create_subprojects' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->accounts->create(FriendlyName => 'Sub-A');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, $ACCOUNTS, 'path');
+    is($j->{matched_route}, 'compatibility.create_subprojects', 'matched route');
+    is($j->{body}{FriendlyName}, 'Sub-A', 'FriendlyName forwarded');
+};
+
+subtest 'test_get_account' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->accounts->get('AC123');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, "$ACCOUNTS/AC123", 'path');
+    is($j->{matched_route}, 'compatibility.get_account', 'matched route');
+};
+
+subtest 'test_update_account' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->accounts->update('AC123', FriendlyName => 'Renamed');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, "$ACCOUNTS/AC123", 'path');
+    is($j->{matched_route}, 'compatibility.update_account', 'matched route');
+    is($j->{body}{FriendlyName}, 'Renamed', 'FriendlyName forwarded');
+};
+
+subtest 'test_list_accounts_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_accounts', 500, { error => 'internal' });
+    my $ok = eval { $client->compat->accounts->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.list_accounts', 'matched route');
+    is($j->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_create_subprojects_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.create_subprojects', 422, { error => 'bad' });
+    my $ok = eval { $client->compat->accounts->create(FriendlyName => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.create_subprojects', 'matched route');
+    is($j->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_get_account_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.get_account', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->accounts->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.get_account', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_account_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_account', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->accounts->update('missing', FriendlyName => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.update_account', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+# --------------------------------------------------------- Applications ----
+
+subtest 'test_list_applications' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->applications->list();
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{applications}, 'applications key');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, "$BASE/Applications", 'path');
+    is($j->{matched_route}, 'compatibility.list_applications', 'matched route');
+};
+
+subtest 'test_create_application' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->applications->create(FriendlyName => 'App-A');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, "$BASE/Applications", 'path');
+    is($j->{matched_route}, 'compatibility.create_application', 'matched route');
+    is($j->{body}{FriendlyName}, 'App-A', 'FriendlyName forwarded');
+};
+
+subtest 'test_get_application' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->applications->get('AP1');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, "$BASE/Applications/AP1", 'path');
+    is($j->{matched_route}, 'compatibility.get_application', 'matched route');
+};
+
+subtest 'test_update_application' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->applications->update('AP1', FriendlyName => 'renamed');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, "$BASE/Applications/AP1", 'path');
+    is($j->{matched_route}, 'compatibility.update_application', 'matched route');
+    is($j->{body}{FriendlyName}, 'renamed', 'FriendlyName forwarded');
+};
+
+subtest 'test_delete_application' => sub {
+    my $client = MockTest::client();
+    $client->compat->applications->delete_resource('AP1');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'DELETE', 'DELETE');
+    is($j->{path}, "$BASE/Applications/AP1", 'path');
+    is($j->{matched_route}, 'compatibility.delete_application', 'matched route');
+};
+
+subtest 'test_list_applications_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_applications', 500, { error => 'internal' });
+    my $ok = eval { $client->compat->applications->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.list_applications', 'matched route');
+    is($j->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_create_application_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.create_application', 422, { error => 'bad' });
+    my $ok = eval { $client->compat->applications->create(FriendlyName => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.create_application', 'matched route');
+    is($j->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_get_application_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.get_application', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->applications->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.get_application', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_application_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_application', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->applications->update('missing', FriendlyName => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.update_application', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_application_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.delete_application', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->applications->delete_resource('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.delete_application', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+# -------------------------------------------------------------- Tokens ----
+
+subtest 'test_create_token' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->tokens->create(name => 'tok-a');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, "$BASE/tokens", 'path');
+    is($j->{matched_route}, 'compatibility.create_token', 'matched route');
+    is($j->{body}{name}, 'tok-a', 'name forwarded');
+};
+
+subtest 'test_update_token' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->tokens->update('tok1', name => 'renamed');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'PATCH', 'PATCH');
+    is($j->{path}, "$BASE/tokens/tok1", 'path');
+    is($j->{matched_route}, 'compatibility.update_token', 'matched route');
+    is($j->{body}{name}, 'renamed', 'name forwarded');
+};
+
+subtest 'test_delete_token' => sub {
+    my $client = MockTest::client();
+    $client->compat->tokens->delete('tok1');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'DELETE', 'DELETE');
+    is($j->{path}, "$BASE/tokens/tok1", 'path');
+    is($j->{matched_route}, 'compatibility.delete_token', 'matched route');
+};
+
+subtest 'test_create_token_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.create_token', 422, { error => 'bad' });
+    my $ok = eval { $client->compat->tokens->create(name => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.create_token', 'matched route');
+    is($j->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_update_token_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_token', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->tokens->update('missing', name => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.update_token', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_token_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.delete_token', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->tokens->delete('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.delete_token', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+done_testing();

--- a/t/rest/25_compat_misc_cov.t
+++ b/t/rest/25_compat_misc_cov.t
@@ -1,0 +1,472 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_compat_misc_full_mock.py
+#
+# Covers client.compat.laml_bins / .queues (+members) / .recordings /
+# .transcriptions. Each canonical route gets BOTH a success (2xx) and an error
+# (4xx/5xx) test, asserting the on-the-wire method/path and the journaled
+# matched_route + response_status.
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+my $BINS   = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/LamlBins";
+my $QUEUES = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Queues";
+my $RECS   = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Recordings";
+my $TRANS  = "/api/laml/2010-04-01/Accounts/$MockTest::PROJECT/Transcriptions";
+
+# ------------------------------------------------------------ LamlBins ----
+
+subtest 'test_list_cxml_scripts' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->laml_bins->list();
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{laml_bins}, 'laml_bins key');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, $BINS, 'path');
+    is($j->{matched_route}, 'compatibility.list_cxml_scripts', 'matched route');
+};
+
+subtest 'test_create_cxml_script' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->laml_bins->create(Name => 'bin-a', Contents => '<Response/>');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, $BINS, 'path');
+    is($j->{matched_route}, 'compatibility.create_cxml_script', 'matched route');
+    is($j->{body}{Name}, 'bin-a', 'Name forwarded');
+};
+
+subtest 'test_retrieve_cxml_script' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->laml_bins->get('LB1');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, "$BINS/LB1", 'path');
+    is($j->{matched_route}, 'compatibility.retrieve_cxml_script', 'matched route');
+};
+
+subtest 'test_update_cxml_script' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->laml_bins->update('LB1', Name => 'renamed');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, "$BINS/LB1", 'path');
+    is($j->{matched_route}, 'compatibility.update_cxml_script', 'matched route');
+    is($j->{body}{Name}, 'renamed', 'Name forwarded');
+};
+
+subtest 'test_delete_cxml_script' => sub {
+    my $client = MockTest::client();
+    $client->compat->laml_bins->delete_resource('LB1');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'DELETE', 'DELETE');
+    is($j->{path}, "$BINS/LB1", 'path');
+    is($j->{matched_route}, 'compatibility.delete_cxml_script', 'matched route');
+};
+
+subtest 'test_list_cxml_scripts_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_cxml_scripts', 500, { error => 'internal' });
+    my $ok = eval { $client->compat->laml_bins->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.list_cxml_scripts', 'matched route');
+    is($j->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_create_cxml_script_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.create_cxml_script', 422, { error => 'bad' });
+    my $ok = eval { $client->compat->laml_bins->create(Name => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.create_cxml_script', 'matched route');
+    is($j->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_retrieve_cxml_script_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.retrieve_cxml_script', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->laml_bins->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.retrieve_cxml_script', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_cxml_script_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_cxml_script', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->laml_bins->update('missing', Name => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.update_cxml_script', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_cxml_script_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.delete_cxml_script', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->laml_bins->delete_resource('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.delete_cxml_script', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+# -------------------------------------------------------------- Queues ----
+
+subtest 'test_list_queues' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->queues->list();
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{queues}, 'queues key');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, $QUEUES, 'path');
+    is($j->{matched_route}, 'compatibility.list_queues', 'matched route');
+};
+
+subtest 'test_create_queue' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->queues->create(FriendlyName => 'q-a');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, $QUEUES, 'path');
+    is($j->{matched_route}, 'compatibility.create_queue', 'matched route');
+    is($j->{body}{FriendlyName}, 'q-a', 'FriendlyName forwarded');
+};
+
+subtest 'test_list_all_queue_members' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->queues->list_members('QU1');
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{queue_members}, 'queue_members key');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, "$QUEUES/QU1/Members", 'path');
+    is($j->{matched_route}, 'compatibility.list_all_queue_members', 'matched route');
+};
+
+subtest 'test_retrieve_queue_member' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->queues->get_member('QU1', 'CA1');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, "$QUEUES/QU1/Members/CA1", 'path');
+    is($j->{matched_route}, 'compatibility.retrieve_queue_member', 'matched route');
+};
+
+subtest 'test_update_queue_member' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->queues->dequeue_member('QU1', 'CA1', Url => 'https://x/y');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, "$QUEUES/QU1/Members/CA1", 'path');
+    is($j->{matched_route}, 'compatibility.update_queue_member', 'matched route');
+    is($j->{body}{Url}, 'https://x/y', 'Url forwarded');
+};
+
+subtest 'test_retrieve_queue' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->queues->get('QU1');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, "$QUEUES/QU1", 'path');
+    is($j->{matched_route}, 'compatibility.retrieve_queue', 'matched route');
+};
+
+subtest 'test_update_queue' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->queues->update('QU1', FriendlyName => 'renamed');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'POST', 'POST');
+    is($j->{path}, "$QUEUES/QU1", 'path');
+    is($j->{matched_route}, 'compatibility.update_queue', 'matched route');
+    is($j->{body}{FriendlyName}, 'renamed', 'FriendlyName forwarded');
+};
+
+subtest 'test_delete_queue' => sub {
+    my $client = MockTest::client();
+    $client->compat->queues->delete_resource('QU1');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'DELETE', 'DELETE');
+    is($j->{path}, "$QUEUES/QU1", 'path');
+    is($j->{matched_route}, 'compatibility.delete_queue', 'matched route');
+};
+
+subtest 'test_list_queues_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_queues', 500, { error => 'internal' });
+    my $ok = eval { $client->compat->queues->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.list_queues', 'matched route');
+    is($j->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_create_queue_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.create_queue', 422, { error => 'bad' });
+    my $ok = eval { $client->compat->queues->create(FriendlyName => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.create_queue', 'matched route');
+    is($j->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_list_all_queue_members_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_all_queue_members', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->queues->list_members('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.list_all_queue_members', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_retrieve_queue_member_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.retrieve_queue_member', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->queues->get_member('QU1', 'missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.retrieve_queue_member', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_queue_member_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_queue_member', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->queues->dequeue_member('QU1', 'missing', Url => 'https://x/y'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.update_queue_member', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_retrieve_queue_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.retrieve_queue', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->queues->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.retrieve_queue', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_queue_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.update_queue', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->queues->update('missing', FriendlyName => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.update_queue', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_queue_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.delete_queue', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->queues->delete_resource('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.delete_queue', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+# ---------------------------------------------------------- Recordings ----
+
+subtest 'test_list_recordings' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->recordings->list();
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{recordings}, 'recordings key');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, $RECS, 'path');
+    is($j->{matched_route}, 'compatibility.list_recordings', 'matched route');
+};
+
+subtest 'test_retrieve_recording' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->recordings->get('RE1');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, "$RECS/RE1", 'path');
+    is($j->{matched_route}, 'compatibility.retrieve_recording', 'matched route');
+};
+
+subtest 'test_delete_recording' => sub {
+    my $client = MockTest::client();
+    $client->compat->recordings->delete('RE1');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'DELETE', 'DELETE');
+    is($j->{path}, "$RECS/RE1", 'path');
+    is($j->{matched_route}, 'compatibility.delete_recording', 'matched route');
+};
+
+subtest 'test_list_recordings_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_recordings', 500, { error => 'internal' });
+    my $ok = eval { $client->compat->recordings->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.list_recordings', 'matched route');
+    is($j->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_retrieve_recording_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.retrieve_recording', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->recordings->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.retrieve_recording', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_recording_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.delete_recording', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->recordings->delete('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.delete_recording', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+# ----------------------------------------------------- Transcriptions ----
+
+subtest 'test_list_transcriptions' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->transcriptions->list();
+    is(ref $body, 'HASH', 'hashref');
+    ok(exists $body->{transcriptions}, 'transcriptions key');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, $TRANS, 'path');
+    is($j->{matched_route}, 'compatibility.list_transcriptions', 'matched route');
+};
+
+subtest 'test_retrieve_transcription' => sub {
+    my $client = MockTest::client();
+    my $body = $client->compat->transcriptions->get('TR1');
+    is(ref $body, 'HASH', 'hashref');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'GET', 'GET');
+    is($j->{path}, "$TRANS/TR1", 'path');
+    is($j->{matched_route}, 'compatibility.retrieve_transcription', 'matched route');
+};
+
+subtest 'test_delete_transcription' => sub {
+    my $client = MockTest::client();
+    $client->compat->transcriptions->delete('TR1');
+    my $j = MockTest::journal_last();
+    is($j->{method}, 'DELETE', 'DELETE');
+    is($j->{path}, "$TRANS/TR1", 'path');
+    is($j->{matched_route}, 'compatibility.delete_transcription', 'matched route');
+};
+
+subtest 'test_list_transcriptions_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.list_transcriptions', 500, { error => 'internal' });
+    my $ok = eval { $client->compat->transcriptions->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.list_transcriptions', 'matched route');
+    is($j->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_retrieve_transcription_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.retrieve_transcription', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->transcriptions->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.retrieve_transcription', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_transcription_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('compatibility.delete_transcription', 404, { error => 'not found' });
+    my $ok = eval { $client->compat->transcriptions->delete('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, 'compatibility.delete_transcription', 'matched route');
+    is($j->{response_status}, 404, 'journaled 404');
+};
+
+done_testing();

--- a/t/rest/30_fabric_resources_cov.t
+++ b/t/rest/30_fabric_resources_cov.t
@@ -1,0 +1,223 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_fabric_resources_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+# resources = generic cross-type resource (GenericResources):
+#   list / get / delete / list_addresses + assign_phone_route / assign_domain_application.
+# addresses = read-only FabricAddresses: list / get.
+# assign_phone_route is deprecated and carps (Carp::carp -> warning, not death).
+
+subtest 'TestFabricResourcesSuccess' => sub {
+    subtest 'test_list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->resources->list();
+        is(ref $body, 'HASH', 'hashref');
+        ok(exists $body->{data}, 'data present');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/fabric/resources', 'path');
+        is($last->{matched_route}, 'fabric.list_resources', 'matched route');
+    };
+
+    subtest 'test_get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->resources->get('res-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/fabric/resources/res-1', 'path');
+        is($last->{matched_route}, 'fabric.get_resource', 'matched route');
+    };
+
+    subtest 'test_delete' => sub {
+        my $client = MockTest::client();
+        $client->fabric->resources->delete('res-1');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'DELETE', 'DELETE');
+        is($last->{path}, '/api/fabric/resources/res-1', 'path');
+        is($last->{matched_route}, 'fabric.delete_resource', 'matched route');
+    };
+
+    subtest 'test_list_addresses' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->resources->list_addresses('res-1');
+        ok(ref $body eq 'HASH' || ref $body eq 'ARRAY', 'hashref or arrayref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/fabric/resources/res-1/addresses', 'path');
+        is($last->{matched_route}, 'fabric.list_resource_addresses', 'matched route');
+    };
+
+    subtest 'test_assign_phone_route' => sub {
+        my $client = MockTest::client();
+        my $body;
+        {
+            local $SIG{__WARN__} = sub {};    # swallow the deprecation carp
+            $body = $client->fabric->resources->assign_phone_route(
+                'res-1', phone_number => '+15551230000',
+            );
+        }
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/fabric/resources/res-1/phone_routes', 'path');
+        is($last->{matched_route}, 'fabric.assign_resource_phone_route', 'matched route');
+    };
+
+    subtest 'test_assign_domain_application' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->resources->assign_domain_application(
+            'res-1', domain => 'example.test',
+        );
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/fabric/resources/res-1/domain_applications', 'path');
+        is($last->{matched_route}, 'fabric.assign_resource_domain_application', 'matched route');
+    };
+};
+
+subtest 'TestFabricAddressesSuccess' => sub {
+    subtest 'test_list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->addresses->list();
+        ok(ref $body eq 'HASH' || ref $body eq 'ARRAY', 'hashref or arrayref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/fabric/addresses', 'path');
+        is($last->{matched_route}, 'fabric.list_fabric_addresses', 'matched route');
+    };
+
+    subtest 'test_get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->addresses->get('addr-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/fabric/addresses/addr-1', 'path');
+        is($last->{matched_route}, 'fabric.get_fabric_address', 'matched route');
+    };
+};
+
+subtest 'TestFabricResourcesErrors' => sub {
+    subtest 'test_list_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.list_resources', 500, { error => 'internal' });
+        my $ok = eval { $client->fabric->resources->list(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.list_resources', 'matched route');
+        is($last->{response_status}, 500, 'journaled 500');
+    };
+
+    subtest 'test_get_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.get_resource', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->resources->get('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.get_resource', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_delete_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.delete_resource', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->resources->delete('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.delete_resource', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_list_addresses_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.list_resource_addresses', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->resources->list_addresses('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.list_resource_addresses', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_assign_phone_route_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.assign_resource_phone_route', 422, { error => 'bad target' });
+        my $ok = eval {
+            local $SIG{__WARN__} = sub {};
+            $client->fabric->resources->assign_phone_route('res-1', phone_number => '+15551230000');
+            1;
+        };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.assign_resource_phone_route', 'matched route');
+        is($last->{response_status}, 422, 'journaled 422');
+    };
+
+    subtest 'test_assign_domain_application_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.assign_resource_domain_application', 422, { error => 'bad domain' });
+        my $ok = eval {
+            $client->fabric->resources->assign_domain_application('res-1', domain => 'bad');
+            1;
+        };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.assign_resource_domain_application', 'matched route');
+        is($last->{response_status}, 422, 'journaled 422');
+    };
+};
+
+subtest 'TestFabricAddressesErrors' => sub {
+    subtest 'test_list_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.list_fabric_addresses', 500, { error => 'internal' });
+        my $ok = eval { $client->fabric->addresses->list(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.list_fabric_addresses', 'matched route');
+        is($last->{response_status}, 500, 'journaled 500');
+    };
+
+    subtest 'test_get_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.get_fabric_address', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->addresses->get('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.get_fabric_address', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+};
+
+done_testing();

--- a/t/rest/31_fabric_subscribers_cov.t
+++ b/t/rest/31_fabric_subscribers_cov.t
@@ -1,0 +1,270 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_fabric_subscribers_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+# Subscribers: PUT-update CRUD (+addresses) at /api/fabric/resources/subscribers,
+# AND a nested sip_endpoints CRUD (PATCH-update). Perl CRUD delete is delete_resource.
+
+my $SUB = 'sub-1001';
+my $EP  = 'ep-2002';
+
+subtest 'TestFabricSubscribersSuccess' => sub {
+    subtest 'test_list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->subscribers->list();
+        is(ref $body, 'HASH', 'hashref');
+        ok(exists $body->{data}, 'data present');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/fabric/resources/subscribers', 'path');
+        is($last->{matched_route}, 'fabric.list_subscribers', 'matched route');
+    };
+
+    subtest 'test_create' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->subscribers->create(email => 'a@b.c');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/fabric/resources/subscribers', 'path');
+        is($last->{matched_route}, 'fabric.create_subscriber', 'matched route');
+        is($last->{body}{email}, 'a@b.c', 'email forwarded');
+    };
+
+    subtest 'test_get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->subscribers->get($SUB);
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, "/api/fabric/resources/subscribers/$SUB", 'path');
+        is($last->{matched_route}, 'fabric.get_subscriber', 'matched route');
+    };
+
+    subtest 'test_update' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->subscribers->update($SUB, email => 'x@y.z');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'PUT', 'PUT');
+        is($last->{path}, "/api/fabric/resources/subscribers/$SUB", 'path');
+        is($last->{matched_route}, 'fabric.update_subscriber', 'matched route');
+        is($last->{body}{email}, 'x@y.z', 'email forwarded');
+    };
+
+    subtest 'test_delete' => sub {
+        my $client = MockTest::client();
+        $client->fabric->subscribers->delete_resource($SUB);
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'DELETE', 'DELETE');
+        is($last->{path}, "/api/fabric/resources/subscribers/$SUB", 'path');
+        is($last->{matched_route}, 'fabric.delete_subscriber', 'matched route');
+    };
+
+    subtest 'test_list_addresses' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->subscribers->list_addresses($SUB);
+        ok(ref $body eq 'HASH' || ref $body eq 'ARRAY', 'hashref or arrayref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, "/api/fabric/resources/subscribers/$SUB/addresses", 'path');
+        is($last->{matched_route}, 'fabric.list_subscriber_addresses', 'matched route');
+    };
+};
+
+subtest 'TestFabricSubscriberSipEndpointsSuccess' => sub {
+    subtest 'test_list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->subscribers->list_sip_endpoints($SUB);
+        ok(ref $body eq 'HASH' || ref $body eq 'ARRAY', 'hashref or arrayref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, "/api/fabric/resources/subscribers/$SUB/sip_endpoints", 'path');
+        is($last->{matched_route}, 'fabric.list_subscriber_sip_endpoints', 'matched route');
+    };
+
+    subtest 'test_create' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->subscribers->create_sip_endpoint($SUB, username => 'alice');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, "/api/fabric/resources/subscribers/$SUB/sip_endpoints", 'path');
+        is($last->{matched_route}, 'fabric.create_subscriber_sip_endpoint', 'matched route');
+        is($last->{body}{username}, 'alice', 'username forwarded');
+    };
+
+    subtest 'test_get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->subscribers->get_sip_endpoint($SUB, $EP);
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, "/api/fabric/resources/subscribers/$SUB/sip_endpoints/$EP", 'path');
+        is($last->{matched_route}, 'fabric.get_subscriber_sip_endpoint', 'matched route');
+    };
+
+    subtest 'test_update' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->subscribers->update_sip_endpoint($SUB, $EP, username => 'bob');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'PATCH', 'PATCH');
+        is($last->{path}, "/api/fabric/resources/subscribers/$SUB/sip_endpoints/$EP", 'path');
+        is($last->{matched_route}, 'fabric.update_subscriber_sip_endpoint', 'matched route');
+        is($last->{body}{username}, 'bob', 'username forwarded');
+    };
+
+    subtest 'test_delete' => sub {
+        my $client = MockTest::client();
+        $client->fabric->subscribers->delete_sip_endpoint($SUB, $EP);
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'DELETE', 'DELETE');
+        is($last->{path}, "/api/fabric/resources/subscribers/$SUB/sip_endpoints/$EP", 'path');
+        is($last->{matched_route}, 'fabric.delete_subscriber_sip_endpoint', 'matched route');
+    };
+};
+
+subtest 'TestFabricSubscribersErrors' => sub {
+    subtest 'test_list_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.list_subscribers', 500, { error => 'internal' });
+        my $ok = eval { $client->fabric->subscribers->list(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.list_subscribers', 'matched route');
+        is($last->{response_status}, 500, 'journaled 500');
+    };
+
+    subtest 'test_create_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.create_subscriber', 422, { error => 'email required' });
+        my $ok = eval { $client->fabric->subscribers->create(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.create_subscriber', 'matched route');
+        is($last->{response_status}, 422, 'journaled 422');
+    };
+
+    subtest 'test_get_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.get_subscriber', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->subscribers->get('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.get_subscriber', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_update_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.update_subscriber', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->subscribers->update('missing', email => 'x@y.z'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.update_subscriber', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_delete_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.delete_subscriber', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->subscribers->delete_resource('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.delete_subscriber', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_list_addresses_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.list_subscriber_addresses', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->subscribers->list_addresses('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.list_subscriber_addresses', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+};
+
+subtest 'TestFabricSubscriberSipEndpointsErrors' => sub {
+    subtest 'test_list_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.list_subscriber_sip_endpoints', 500, { error => 'internal' });
+        my $ok = eval { $client->fabric->subscribers->list_sip_endpoints($SUB); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.list_subscriber_sip_endpoints', 'matched route');
+        is($last->{response_status}, 500, 'journaled 500');
+    };
+
+    subtest 'test_create_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.create_subscriber_sip_endpoint', 422, { error => 'username required' });
+        my $ok = eval { $client->fabric->subscribers->create_sip_endpoint($SUB); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.create_subscriber_sip_endpoint', 'matched route');
+        is($last->{response_status}, 422, 'journaled 422');
+    };
+
+    subtest 'test_get_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.get_subscriber_sip_endpoint', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->subscribers->get_sip_endpoint($SUB, 'missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.get_subscriber_sip_endpoint', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_update_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.update_subscriber_sip_endpoint', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->subscribers->update_sip_endpoint($SUB, 'missing', username => 'bob'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.update_subscriber_sip_endpoint', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_delete_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.delete_subscriber_sip_endpoint', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->subscribers->delete_sip_endpoint($SUB, 'missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.delete_subscriber_sip_endpoint', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+};
+
+done_testing();

--- a/t/rest/32_fabric_tokens_cov.t
+++ b/t/rest/32_fabric_tokens_cov.t
@@ -1,0 +1,130 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_fabric_tokens_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+# FabricTokens: subscriber / guest / invite / embed tokens under /api/fabric.
+# Perl method names differ from route IDs (e.g. create_invite_token hits
+# fabric.create_subscriber_invite_token).
+
+subtest 'TestFabricTokensSuccess' => sub {
+    subtest 'test_create_subscriber_token' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->tokens->create_subscriber_token(reference => 'sub-1001');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/fabric/subscribers/tokens', 'path');
+        is($last->{matched_route}, 'fabric.create_subscriber_token', 'matched route');
+        is($last->{body}{reference}, 'sub-1001', 'reference forwarded');
+    };
+
+    subtest 'test_refresh_subscriber_token' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->tokens->refresh_subscriber_token(token => 't-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/fabric/subscribers/tokens/refresh', 'path');
+        is($last->{matched_route}, 'fabric.refresh_subscriber_token', 'matched route');
+    };
+
+    subtest 'test_create_invite_token' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->tokens->create_invite_token(email => 'a@b.c');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/fabric/subscriber/invites', 'path');
+        is($last->{matched_route}, 'fabric.create_subscriber_invite_token', 'matched route');
+    };
+
+    subtest 'test_create_guest_token' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->tokens->create_guest_token(allowed_addresses => ['addr-1']);
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/fabric/guests/tokens', 'path');
+        is($last->{matched_route}, 'fabric.create_subscriber_guest_token', 'matched route');
+    };
+
+    subtest 'test_create_embed_token' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->tokens->create_embed_token(embed_id => 'e-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/fabric/embeds/tokens', 'path');
+        is($last->{matched_route}, 'fabric.create_embeds_token', 'matched route');
+    };
+};
+
+subtest 'TestFabricTokensErrors' => sub {
+    subtest 'test_create_subscriber_token_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.create_subscriber_token', 422, { error => 'reference required' });
+        my $ok = eval { $client->fabric->tokens->create_subscriber_token(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.create_subscriber_token', 'matched route');
+        is($last->{response_status}, 422, 'journaled 422');
+    };
+
+    subtest 'test_refresh_subscriber_token_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.refresh_subscriber_token', 404, { error => 'token not found' });
+        my $ok = eval { $client->fabric->tokens->refresh_subscriber_token(token => 'missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.refresh_subscriber_token', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_create_invite_token_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.create_subscriber_invite_token', 422, { error => 'email required' });
+        my $ok = eval { $client->fabric->tokens->create_invite_token(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.create_subscriber_invite_token', 'matched route');
+        is($last->{response_status}, 422, 'journaled 422');
+    };
+
+    subtest 'test_create_guest_token_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.create_subscriber_guest_token', 422, { error => 'bad input' });
+        my $ok = eval { $client->fabric->tokens->create_guest_token(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.create_subscriber_guest_token', 'matched route');
+        is($last->{response_status}, 422, 'journaled 422');
+    };
+
+    subtest 'test_create_embed_token_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.create_embeds_token', 500, { error => 'internal' });
+        my $ok = eval { $client->fabric->tokens->create_embed_token(embed_id => 'e-1'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised'); isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.create_embeds_token', 'matched route');
+        is($last->{response_status}, 500, 'journaled 500');
+    };
+};
+
+done_testing();

--- a/t/rest/33_fabric_ai_agents_cov.t
+++ b/t/rest/33_fabric_ai_agents_cov.t
@@ -1,0 +1,159 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_fabric_ai_agents_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+# ai_agents is a plain FabricResource CRUD at /api/fabric/resources/ai_agents:
+# list / create / get / update (PATCH) / delete, plus list_addresses.
+# Perl CRUD delete is delete_resource (only GenericResources has a 'delete' alias).
+
+subtest 'TestFabricAIAgentsSuccess' => sub {
+    subtest 'test_list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->ai_agents->list();
+        is(ref $body, 'HASH', 'hashref');
+        ok(exists $body->{data}, "data present");
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/fabric/resources/ai_agents', 'path');
+        is($last->{matched_route}, 'fabric.list_ai_agents', 'matched route');
+    };
+
+    subtest 'test_create' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->ai_agents->create(name => 'agent-alpha');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/fabric/resources/ai_agents', 'path');
+        is($last->{matched_route}, 'fabric.create_ai_agent', 'matched route');
+        is($last->{body}{name}, 'agent-alpha', 'name forwarded');
+    };
+
+    subtest 'test_get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->ai_agents->get('aa-1001');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/fabric/resources/ai_agents/aa-1001', 'path');
+        is($last->{matched_route}, 'fabric.get_ai_agent', 'matched route');
+    };
+
+    subtest 'test_update' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->ai_agents->update('aa-1001', name => 'renamed');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'PATCH', 'PATCH');
+        is($last->{path}, '/api/fabric/resources/ai_agents/aa-1001', 'path');
+        is($last->{matched_route}, 'fabric.update_ai_agent', 'matched route');
+        is($last->{body}{name}, 'renamed', 'name forwarded');
+    };
+
+    subtest 'test_delete' => sub {
+        my $client = MockTest::client();
+        $client->fabric->ai_agents->delete_resource('aa-1001');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'DELETE', 'DELETE');
+        is($last->{path}, '/api/fabric/resources/ai_agents/aa-1001', 'path');
+        is($last->{matched_route}, 'fabric.delete_ai_agent', 'matched route');
+    };
+
+    subtest 'test_list_addresses' => sub {
+        my $client = MockTest::client();
+        my $body = $client->fabric->ai_agents->list_addresses('aa-1001');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/fabric/resources/ai_agents/aa-1001/addresses', 'path');
+        is($last->{matched_route}, 'fabric.list_ai_agent_addresses', 'matched route');
+    };
+};
+
+subtest 'TestFabricAIAgentsErrors' => sub {
+    subtest 'test_list_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.list_ai_agents', 500, { error => 'internal' });
+        my $ok = eval { $client->fabric->ai_agents->list(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.list_ai_agents', 'matched route');
+        is($last->{response_status}, 500, 'journaled 500');
+    };
+
+    subtest 'test_create_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.create_ai_agent', 422, { error => 'name required' });
+        my $ok = eval { $client->fabric->ai_agents->create(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.create_ai_agent', 'matched route');
+        is($last->{response_status}, 422, 'journaled 422');
+    };
+
+    subtest 'test_get_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.get_ai_agent', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->ai_agents->get('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.get_ai_agent', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_update_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.update_ai_agent', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->ai_agents->update('missing', name => 'x'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.update_ai_agent', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_delete_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.delete_ai_agent', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->ai_agents->delete_resource('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.delete_ai_agent', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_list_addresses_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fabric.list_ai_agent_addresses', 404, { error => 'not found' });
+        my $ok = eval { $client->fabric->ai_agents->list_addresses('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'fabric.list_ai_agent_addresses', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+};
+
+done_testing();

--- a/t/rest/34_fabric_typed_resources_cov.t
+++ b/t/rest/34_fabric_typed_resources_cov.t
@@ -1,0 +1,358 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_fabric_typed_resources_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+# Typed fabric resource families that are plain CRUD(+addresses) wrappers.
+#  - PUT-update CRUD(+addresses): swml_scripts, relay_applications,
+#    freeswitch_connectors, cxml_scripts, sip_endpoints
+#  - PATCH-update CRUD(+addresses): cxml_webhooks, swml_webhooks (create warns)
+#  - sip_gateways: PATCH CRUD (no addresses route — see GAP)
+#  - cxml_applications: read/update(PUT)/delete(+addresses); create dies
+#  - call_flows: PUT CRUD + custom call_flow/{id}/addresses|versions
+#  - conference_rooms: PUT CRUD + custom conference_room/{id}/addresses
+#
+# Perl CRUD delete is delete_resource (only GenericResources has a 'delete' alias).
+
+my $BASE = '/api/fabric/resources';
+my $ID   = 'rid-1001';
+
+# Drive list/create/get/update/delete (+addresses) and assert each canonical route.
+sub crud_success {
+    my (%a) = @_;
+    my ($rget, $base, $update_method, $prefix, $addresses)
+        = @a{qw(rget base update_method prefix addresses)};
+    $addresses = 1 unless defined $addresses;
+
+    my $r = $rget->();
+    my $body = $r->list();
+    ok(ref $body eq 'HASH' || ref $body eq 'ARRAY', "$prefix list shape");
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', "$prefix list GET");
+    is($last->{path}, $base, "$prefix list path");
+    is($last->{matched_route}, "fabric.list_${prefix}s", "$prefix list route");
+
+    $body = $r->create(name => 'thing');
+    is(ref $body, 'HASH', "$prefix create hashref");
+    $last = MockTest::journal_last();
+    is($last->{method}, 'POST', "$prefix create POST");
+    is($last->{path}, $base, "$prefix create path");
+    is($last->{matched_route}, "fabric.create_${prefix}", "$prefix create route");
+    is($last->{body}{name}, 'thing', "$prefix create body");
+
+    $body = $r->get($ID);
+    is(ref $body, 'HASH', "$prefix get hashref");
+    $last = MockTest::journal_last();
+    is($last->{method}, 'GET', "$prefix get GET");
+    is($last->{path}, "$base/$ID", "$prefix get path");
+    is($last->{matched_route}, "fabric.get_${prefix}", "$prefix get route");
+
+    $body = $r->update($ID, name => 'renamed');
+    is(ref $body, 'HASH', "$prefix update hashref");
+    $last = MockTest::journal_last();
+    is($last->{method}, $update_method, "$prefix update method");
+    is($last->{path}, "$base/$ID", "$prefix update path");
+    is($last->{matched_route}, "fabric.update_${prefix}", "$prefix update route");
+    is($last->{body}{name}, 'renamed', "$prefix update body");
+
+    $r->delete_resource($ID);
+    $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', "$prefix delete DELETE");
+    is($last->{path}, "$base/$ID", "$prefix delete path");
+    is($last->{matched_route}, "fabric.delete_${prefix}", "$prefix delete route");
+
+    if ($addresses) {
+        $body = $r->list_addresses($ID);
+        ok(ref $body eq 'HASH' || ref $body eq 'ARRAY', "$prefix addresses shape");
+        $last = MockTest::journal_last();
+        is($last->{method}, 'GET', "$prefix addresses GET");
+        is($last->{path}, "$base/$ID/addresses", "$prefix addresses path");
+        is($last->{matched_route}, "fabric.list_${prefix}_addresses", "$prefix addresses route");
+    }
+}
+
+# Drive a representative error per CRUD route and assert HttpClient::Error.
+sub crud_errors {
+    my (%a) = @_;
+    my ($rget, $prefix, $addresses) = @a{qw(rget prefix addresses)};
+    $addresses = 1 unless defined $addresses;
+
+    _err($rget, "fabric.list_${prefix}s", 500, sub { $_[0]->list() });
+    _err($rget, "fabric.create_${prefix}", 422, sub { $_[0]->create() });
+    _err($rget, "fabric.get_${prefix}", 404, sub { $_[0]->get('missing') });
+    _err($rget, "fabric.update_${prefix}", 404, sub { $_[0]->update('missing', name => 'x') });
+    _err($rget, "fabric.delete_${prefix}", 404, sub { $_[0]->delete_resource('missing') });
+    if ($addresses) {
+        _err($rget, "fabric.list_${prefix}_addresses", 404, sub { $_[0]->list_addresses('missing') });
+    }
+}
+
+# Arm a scenario, invoke, assert it raised with the right status + journaled route.
+sub _err {
+    my ($rget, $route, $status, $call) = @_;
+    my $r = $rget->();
+    MockTest::scenario_set($route, $status, { error => 'x' });
+    my $ok = eval { $call->($r); 1 };
+    my $e = $@;
+    ok(!$ok, "$route raised");
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, $status, "$route status $status");
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, $route, "$route matched route");
+    is($last->{response_status}, $status, "$route journaled $status");
+}
+
+subtest 'TestFabricPutResourceFamilies' => sub {
+    for my $f (
+        ['swml_scripts',         'swml_script'],
+        ['relay_applications',   'relay_application'],
+        ['freeswitch_connectors','freeswitch_connector'],
+        ['cxml_scripts',         'cxml_script'],
+        ['sip_endpoints',        'sip_endpoint'],
+    ) {
+        my ($accessor, $prefix) = @$f;
+        subtest "test_$accessor" => sub {
+            crud_success(
+                rget => sub { MockTest::client()->fabric->$accessor },
+                base => "$BASE/$accessor", update_method => 'PUT', prefix => $prefix,
+            );
+        };
+        subtest "test_${accessor}_errors" => sub {
+            crud_errors(
+                rget => sub { MockTest::client()->fabric->$accessor },
+                prefix => $prefix,
+            );
+        };
+    }
+};
+
+subtest 'TestFabricPatchResourceFamilies' => sub {
+    # cxml_webhooks + swml_webhooks: PATCH CRUD(+addresses); create() carps.
+    for my $f (
+        ['cxml_webhooks', 'cxml_webhook'],
+        ['swml_webhooks', 'swml_webhook'],
+    ) {
+        my ($accessor, $prefix) = @$f;
+        subtest "test_$accessor" => sub {
+            # create (deprecation carp swallowed)
+            my $client = MockTest::client();
+            {
+                local $SIG{__WARN__} = sub {};
+                $client->fabric->$accessor->create(name => 'thing');
+            }
+            my $last = MockTest::journal_last();
+            is($last->{method}, 'POST', "$prefix create POST");
+            is($last->{path}, "$BASE/$accessor", "$prefix create path");
+            is($last->{matched_route}, "fabric.create_${prefix}", "$prefix create route");
+
+            # remaining CRUD (list/get/update/delete/addresses)
+            $client->fabric->$accessor->list();
+            is(MockTest::journal_last()->{matched_route}, "fabric.list_${prefix}s", "$prefix list route");
+            $client->fabric->$accessor->get($ID);
+            is(MockTest::journal_last()->{matched_route}, "fabric.get_${prefix}", "$prefix get route");
+            $client->fabric->$accessor->update($ID, name => 'x');
+            $last = MockTest::journal_last();
+            is($last->{method}, 'PATCH', "$prefix update PATCH");
+            is($last->{matched_route}, "fabric.update_${prefix}", "$prefix update route");
+            $client->fabric->$accessor->delete_resource($ID);
+            is(MockTest::journal_last()->{matched_route}, "fabric.delete_${prefix}", "$prefix delete route");
+            $client->fabric->$accessor->list_addresses($ID);
+            is(MockTest::journal_last()->{matched_route}, "fabric.list_${prefix}_addresses", "$prefix addresses route");
+        };
+
+        subtest "test_${accessor}_errors" => sub {
+            crud_errors(
+                rget => sub { MockTest::client()->fabric->$accessor },
+                prefix => $prefix,
+            );
+            # create error (deprecation carp + raise)
+            my $r = MockTest::client()->fabric->$accessor;
+            MockTest::scenario_set("fabric.create_${prefix}", 422, { error => 'bad' });
+            my $ok = eval {
+                local $SIG{__WARN__} = sub {};
+                $r->create(name => 'thing');
+                1;
+            };
+            my $e = $@;
+            ok(!$ok, "$prefix create raised");
+            isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+            is($e->status_code, 422, "$prefix create status 422");
+            my $last = MockTest::journal_last();
+            is($last->{matched_route}, "fabric.create_${prefix}", "$prefix create route");
+            is($last->{response_status}, 422, "$prefix create journaled 422");
+        };
+    }
+};
+
+subtest 'TestFabricSipGateways' => sub {
+    # PATCH CRUD, NO addresses route reachable (accepted GAP per python note).
+    subtest 'test_crud' => sub {
+        crud_success(
+            rget => sub { MockTest::client()->fabric->sip_gateways },
+            base => "$BASE/sip_gateways", update_method => 'PATCH',
+            prefix => 'sip_gateway', addresses => 0,
+        );
+    };
+    subtest 'test_crud_errors' => sub {
+        crud_errors(
+            rget => sub { MockTest::client()->fabric->sip_gateways },
+            prefix => 'sip_gateway', addresses => 0,
+        );
+    };
+};
+
+subtest 'TestFabricCxmlApplications' => sub {
+    # read/update(PUT)/delete(+addresses); create dies (not a canonical route).
+    subtest 'test_read_update_delete' => sub {
+        my $client = MockTest::client();
+        my $r = $client->fabric->cxml_applications;
+
+        my $body = $r->list();
+        ok(ref $body eq 'HASH' || ref $body eq 'ARRAY', 'list shape');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'list GET');
+        is($last->{path}, "$BASE/cxml_applications", 'list path');
+        is($last->{matched_route}, 'fabric.list_cxml_applications', 'list route');
+
+        $r->get($ID);
+        $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'get GET');
+        is($last->{matched_route}, 'fabric.get_cxml_application', 'get route');
+
+        $r->update($ID, name => 'x');
+        $last = MockTest::journal_last();
+        is($last->{method}, 'PUT', 'update PUT');
+        is($last->{matched_route}, 'fabric.update_cxml_application', 'update route');
+
+        $r->delete_resource($ID);
+        $last = MockTest::journal_last();
+        is($last->{method}, 'DELETE', 'delete DELETE');
+        is($last->{matched_route}, 'fabric.delete_cxml_application', 'delete route');
+
+        $r->list_addresses($ID);
+        $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'addresses GET');
+        is($last->{matched_route}, 'fabric.list_cxml_application_addresses', 'addresses route');
+    };
+
+    subtest 'test_create_not_implemented' => sub {
+        my $client = MockTest::client();
+        my $ok = eval { $client->fabric->cxml_applications->create(name => 'x'); 1 };
+        my $e = $@;
+        ok(!$ok, 'create dies');
+        like($e, qr/cXML applications cannot/, 'error mentions cXML applications cannot');
+    };
+
+    subtest 'test_errors' => sub {
+        my $rget = sub { MockTest::client()->fabric->cxml_applications };
+        _err($rget, 'fabric.list_cxml_applications', 500, sub { $_[0]->list() });
+        _err($rget, 'fabric.get_cxml_application', 404, sub { $_[0]->get('missing') });
+        _err($rget, 'fabric.update_cxml_application', 404, sub { $_[0]->update('missing', name => 'x') });
+        _err($rget, 'fabric.delete_cxml_application', 404, sub { $_[0]->delete_resource('missing') });
+        _err($rget, 'fabric.list_cxml_application_addresses', 404, sub { $_[0]->list_addresses('missing') });
+    };
+};
+
+subtest 'TestFabricCallFlows' => sub {
+    # PUT CRUD + custom call_flow/{id}/addresses|versions (SINGULAR segment).
+    subtest 'test_crud' => sub {
+        my $client = MockTest::client();
+        my $r = $client->fabric->call_flows;
+        $r->list();
+        is(MockTest::journal_last()->{matched_route}, 'fabric.list_call_flows', 'list route');
+        $r->create(name => 'cf');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'create POST');
+        is($last->{matched_route}, 'fabric.create_call_flow', 'create route');
+        $r->get($ID);
+        is(MockTest::journal_last()->{matched_route}, 'fabric.get_call_flow', 'get route');
+        $r->update($ID, name => 'x');
+        $last = MockTest::journal_last();
+        is($last->{method}, 'PUT', 'update PUT');
+        is($last->{matched_route}, 'fabric.update_call_flow', 'update route');
+        $r->delete_resource($ID);
+        is(MockTest::journal_last()->{matched_route}, 'fabric.delete_call_flow', 'delete route');
+    };
+
+    subtest 'test_custom_subpaths' => sub {
+        my $client = MockTest::client();
+        my $r = $client->fabric->call_flows;
+        $r->list_addresses($ID);
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'addresses GET');
+        is($last->{path}, "$BASE/call_flow/$ID/addresses", 'addresses singular path');
+        is($last->{matched_route}, 'fabric.list_call_flow_addresses', 'addresses route');
+
+        $r->list_versions($ID);
+        $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'versions GET');
+        is($last->{path}, "$BASE/call_flow/$ID/versions", 'versions singular path');
+        is($last->{matched_route}, 'fabric.list_call_flow_versions', 'versions route');
+
+        $r->deploy_version($ID, version => 'v2');
+        $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'deploy POST');
+        is($last->{path}, "$BASE/call_flow/$ID/versions", 'deploy singular path');
+        is($last->{matched_route}, 'fabric.deploy_call_flow_version', 'deploy route');
+    };
+
+    subtest 'test_errors' => sub {
+        my $rget = sub { MockTest::client()->fabric->call_flows };
+        _err($rget, 'fabric.list_call_flows', 500, sub { $_[0]->list() });
+        _err($rget, 'fabric.create_call_flow', 422, sub { $_[0]->create() });
+        _err($rget, 'fabric.get_call_flow', 404, sub { $_[0]->get('missing') });
+        _err($rget, 'fabric.update_call_flow', 404, sub { $_[0]->update('missing', name => 'x') });
+        _err($rget, 'fabric.delete_call_flow', 404, sub { $_[0]->delete_resource('missing') });
+        _err($rget, 'fabric.list_call_flow_addresses', 404, sub { $_[0]->list_addresses('missing') });
+        _err($rget, 'fabric.list_call_flow_versions', 404, sub { $_[0]->list_versions('missing') });
+        _err($rget, 'fabric.deploy_call_flow_version', 422, sub { $_[0]->deploy_version('missing', version => 'v2') });
+    };
+};
+
+subtest 'TestFabricConferenceRooms' => sub {
+    # PUT CRUD + custom conference_room/{id}/addresses (SINGULAR segment).
+    subtest 'test_crud' => sub {
+        my $client = MockTest::client();
+        my $r = $client->fabric->conference_rooms;
+        $r->list();
+        is(MockTest::journal_last()->{matched_route}, 'fabric.list_conference_rooms', 'list route');
+        $r->create(name => 'room');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'create POST');
+        is($last->{matched_route}, 'fabric.create_conference_room', 'create route');
+        $r->get($ID);
+        is(MockTest::journal_last()->{matched_route}, 'fabric.get_conference_room', 'get route');
+        $r->update($ID, name => 'x');
+        $last = MockTest::journal_last();
+        is($last->{method}, 'PUT', 'update PUT');
+        is($last->{matched_route}, 'fabric.update_conference_room', 'update route');
+        $r->delete_resource($ID);
+        is(MockTest::journal_last()->{matched_route}, 'fabric.delete_conference_room', 'delete route');
+    };
+
+    subtest 'test_list_addresses' => sub {
+        my $client = MockTest::client();
+        $client->fabric->conference_rooms->list_addresses($ID);
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'addresses GET');
+        is($last->{path}, "$BASE/conference_room/$ID/addresses", 'addresses singular path');
+        is($last->{matched_route}, 'fabric.list_conference_room_addresses', 'addresses route');
+    };
+
+    subtest 'test_errors' => sub {
+        my $rget = sub { MockTest::client()->fabric->conference_rooms };
+        _err($rget, 'fabric.list_conference_rooms', 500, sub { $_[0]->list() });
+        _err($rget, 'fabric.create_conference_room', 422, sub { $_[0]->create() });
+        _err($rget, 'fabric.get_conference_room', 404, sub { $_[0]->get('missing') });
+        _err($rget, 'fabric.update_conference_room', 404, sub { $_[0]->update('missing', name => 'x') });
+        _err($rget, 'fabric.delete_conference_room', 404, sub { $_[0]->delete_resource('missing') });
+        _err($rget, 'fabric.list_conference_room_addresses', 404, sub { $_[0]->list_addresses('missing') });
+    };
+};
+
+done_testing();

--- a/t/rest/40_relay_queues_cov.t
+++ b/t/rest/40_relay_queues_cov.t
@@ -1,0 +1,202 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_relay_queues_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+my $BASE = '/api/relay/rest/queues';
+
+# -------------------- Success --------------------
+
+subtest 'test_list' => sub {
+    my $client = MockTest::client();
+    my $body = $client->queues->list();
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, $BASE, 'path');
+    is($last->{matched_route}, 'relay-rest.list_queues', 'matched route');
+};
+
+subtest 'test_create' => sub {
+    my $client = MockTest::client();
+    my $body = $client->queues->create(name => 'support');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, $BASE, 'path');
+    is($last->{matched_route}, 'relay-rest.create_queue', 'matched route');
+    is(($last->{body} || {})->{name}, 'support', 'name forwarded');
+};
+
+subtest 'test_get' => sub {
+    my $client = MockTest::client();
+    my $body = $client->queues->get('q-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/q-1", 'path');
+    is($last->{matched_route}, 'relay-rest.get_queue', 'matched route');
+};
+
+subtest 'test_update' => sub {
+    my $client = MockTest::client();
+    my $body = $client->queues->update('q-1', name => 'renamed');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'PUT', 'PUT');
+    is($last->{path}, "$BASE/q-1", 'path');
+    is($last->{matched_route}, 'relay-rest.update_queue', 'matched route');
+    is(($last->{body} || {})->{name}, 'renamed', 'name forwarded');
+};
+
+subtest 'test_delete' => sub {
+    my $client = MockTest::client();
+    $client->queues->delete_resource('q-1');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', 'DELETE');
+    is($last->{path}, "$BASE/q-1", 'path');
+    is($last->{matched_route}, 'relay-rest.delete_queue', 'matched route');
+};
+
+subtest 'test_list_members' => sub {
+    my $client = MockTest::client();
+    my $body = $client->queues->list_members('q-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/q-1/members", 'path');
+    is($last->{matched_route}, 'relay-rest.list_queue_members', 'matched route');
+};
+
+subtest 'test_get_next_member' => sub {
+    my $client = MockTest::client();
+    my $body = $client->queues->get_next_member('q-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/q-1/members/next", 'path');
+    is($last->{matched_route}, 'relay-rest.retrieve_next_queue_member', 'matched route');
+};
+
+subtest 'test_get_member' => sub {
+    my $client = MockTest::client();
+    my $body = $client->queues->get_member('q-1', 'm-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/q-1/members/m-1", 'path');
+    is($last->{matched_route}, 'relay-rest.retrieve_queue_member', 'matched route');
+};
+
+# -------------------- Errors --------------------
+
+subtest 'test_list_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.list_queues', 500, { error => 'internal' });
+    my $ok = eval { $client->queues->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.list_queues', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_create_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.create_queue', 422, { error => 'name required' });
+    my $ok = eval { $client->queues->create(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.create_queue', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_get_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.get_queue', 404, { error => 'nope' });
+    my $ok = eval { $client->queues->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.get_queue', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.update_queue', 404, { error => 'nope' });
+    my $ok = eval { $client->queues->update('missing', name => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.update_queue', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.delete_queue', 404, { error => 'nope' });
+    my $ok = eval { $client->queues->delete_resource('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.delete_queue', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_list_members_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.list_queue_members', 404, { error => 'nope' });
+    my $ok = eval { $client->queues->list_members('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.list_queue_members', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_get_next_member_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.retrieve_next_queue_member', 404, { error => 'empty' });
+    my $ok = eval { $client->queues->get_next_member('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.retrieve_next_queue_member', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_get_member_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.retrieve_queue_member', 404, { error => 'nope' });
+    my $ok = eval { $client->queues->get_member('missing', 'm-1'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.retrieve_queue_member', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+done_testing();

--- a/t/rest/41_relay_addresses_cov.t
+++ b/t/rest/41_relay_addresses_cov.t
@@ -1,0 +1,109 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_relay_addresses_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+my $BASE = '/api/relay/rest/addresses';
+
+# -------------------- Success --------------------
+
+subtest 'test_list' => sub {
+    my $client = MockTest::client();
+    my $body = $client->addresses->list();
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, $BASE, 'path');
+    is($last->{matched_route}, 'relay-rest.list_addresses', 'matched route');
+};
+
+subtest 'test_create' => sub {
+    my $client = MockTest::client();
+    my $body = $client->addresses->create(name => 'HQ');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, $BASE, 'path');
+    is($last->{matched_route}, 'relay-rest.create_address', 'matched route');
+    is(($last->{body} || {})->{name}, 'HQ', 'name forwarded');
+};
+
+subtest 'test_get' => sub {
+    my $client = MockTest::client();
+    my $body = $client->addresses->get('addr-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/addr-1", 'path');
+    is($last->{matched_route}, 'relay-rest.get_address', 'matched route');
+};
+
+subtest 'test_delete' => sub {
+    my $client = MockTest::client();
+    $client->addresses->delete('addr-1');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', 'DELETE');
+    is($last->{path}, "$BASE/addr-1", 'path');
+    is($last->{matched_route}, 'relay-rest.delete_address', 'matched route');
+};
+
+# -------------------- Errors --------------------
+
+subtest 'test_list_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.list_addresses', 500, { error => 'internal' });
+    my $ok = eval { $client->addresses->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.list_addresses', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_create_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.create_address', 422, { error => 'name required' });
+    my $ok = eval { $client->addresses->create(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.create_address', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_get_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.get_address', 404, { error => 'nope' });
+    my $ok = eval { $client->addresses->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.get_address', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.delete_address', 404, { error => 'nope' });
+    my $ok = eval { $client->addresses->delete('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.delete_address', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+done_testing();

--- a/t/rest/42_relay_recordings_cov.t
+++ b/t/rest/42_relay_recordings_cov.t
@@ -1,0 +1,85 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_relay_recordings_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+my $BASE = '/api/relay/rest/recordings';
+
+# -------------------- Success --------------------
+
+subtest 'test_list' => sub {
+    my $client = MockTest::client();
+    my $body = $client->recordings->list();
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, $BASE, 'path');
+    is($last->{matched_route}, 'relay-rest.list_recordings', 'matched route');
+};
+
+subtest 'test_get' => sub {
+    my $client = MockTest::client();
+    my $body = $client->recordings->get('rec-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/rec-1", 'path');
+    is($last->{matched_route}, 'relay-rest.get_recording', 'matched route');
+};
+
+subtest 'test_delete' => sub {
+    my $client = MockTest::client();
+    $client->recordings->delete('rec-1');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', 'DELETE');
+    is($last->{path}, "$BASE/rec-1", 'path');
+    is($last->{matched_route}, 'relay-rest.delete_recording', 'matched route');
+};
+
+# -------------------- Errors --------------------
+
+subtest 'test_list_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.list_recordings', 500, { error => 'internal' });
+    my $ok = eval { $client->recordings->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.list_recordings', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_get_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.get_recording', 404, { error => 'nope' });
+    my $ok = eval { $client->recordings->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.get_recording', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.delete_recording', 404, { error => 'nope' });
+    my $ok = eval { $client->recordings->delete('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.delete_recording', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+done_testing();

--- a/t/rest/43_relay_number_groups_cov.t
+++ b/t/rest/43_relay_number_groups_cov.t
@@ -1,0 +1,226 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_relay_number_groups_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+my $BASE = '/api/relay/rest/number_groups';
+my $MEMBERSHIPS = '/api/relay/rest/number_group_memberships';
+
+# -------------------- Success --------------------
+
+subtest 'test_list' => sub {
+    my $client = MockTest::client();
+    my $body = $client->number_groups->list();
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, $BASE, 'path');
+    is($last->{matched_route}, 'relay-rest.list_number_groups', 'matched route');
+};
+
+subtest 'test_create' => sub {
+    my $client = MockTest::client();
+    my $body = $client->number_groups->create(name => 'group-a');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, $BASE, 'path');
+    is($last->{matched_route}, 'relay-rest.create_number_group', 'matched route');
+    is(($last->{body} || {})->{name}, 'group-a', 'name forwarded');
+};
+
+subtest 'test_get' => sub {
+    my $client = MockTest::client();
+    my $body = $client->number_groups->get('ng-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/ng-1", 'path');
+    is($last->{matched_route}, 'relay-rest.retrieve_number_group', 'matched route');
+};
+
+subtest 'test_update' => sub {
+    my $client = MockTest::client();
+    my $body = $client->number_groups->update('ng-1', name => 'renamed');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'PUT', 'PUT');
+    is($last->{path}, "$BASE/ng-1", 'path');
+    is($last->{matched_route}, 'relay-rest.update_number_group', 'matched route');
+    is(($last->{body} || {})->{name}, 'renamed', 'name forwarded');
+};
+
+subtest 'test_delete' => sub {
+    my $client = MockTest::client();
+    $client->number_groups->delete_resource('ng-1');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', 'DELETE');
+    is($last->{path}, "$BASE/ng-1", 'path');
+    is($last->{matched_route}, 'relay-rest.delete_number_group', 'matched route');
+};
+
+subtest 'test_list_memberships' => sub {
+    my $client = MockTest::client();
+    my $body = $client->number_groups->list_memberships('ng-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/ng-1/number_group_memberships", 'path');
+    is($last->{matched_route}, 'relay-rest.list_number_group_memberships', 'matched route');
+};
+
+subtest 'test_add_membership' => sub {
+    my $client = MockTest::client();
+    my $body = $client->number_groups->add_membership('ng-1', phone_number_id => 'pn-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, "$BASE/ng-1/number_group_memberships", 'path');
+    is($last->{matched_route}, 'relay-rest.create_number_group_membership', 'matched route');
+    is(($last->{body} || {})->{phone_number_id}, 'pn-1', 'phone_number_id forwarded');
+};
+
+subtest 'test_get_membership' => sub {
+    my $client = MockTest::client();
+    my $body = $client->number_groups->get_membership('ngm-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$MEMBERSHIPS/ngm-1", 'path');
+    is($last->{matched_route}, 'relay-rest.retrieve_number_group_membership', 'matched route');
+};
+
+subtest 'test_delete_membership' => sub {
+    my $client = MockTest::client();
+    $client->number_groups->delete_membership('ngm-1');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', 'DELETE');
+    is($last->{path}, "$MEMBERSHIPS/ngm-1", 'path');
+    is($last->{matched_route}, 'relay-rest.delete_number_group_membership', 'matched route');
+};
+
+# -------------------- Errors --------------------
+
+subtest 'test_list_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.list_number_groups', 500, { error => 'internal' });
+    my $ok = eval { $client->number_groups->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.list_number_groups', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_create_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.create_number_group', 422, { error => 'name required' });
+    my $ok = eval { $client->number_groups->create(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.create_number_group', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_get_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.retrieve_number_group', 404, { error => 'nope' });
+    my $ok = eval { $client->number_groups->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.retrieve_number_group', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.update_number_group', 404, { error => 'nope' });
+    my $ok = eval { $client->number_groups->update('missing', name => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.update_number_group', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.delete_number_group', 404, { error => 'nope' });
+    my $ok = eval { $client->number_groups->delete_resource('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.delete_number_group', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_list_memberships_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.list_number_group_memberships', 404, { error => 'nope' });
+    my $ok = eval { $client->number_groups->list_memberships('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.list_number_group_memberships', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_add_membership_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.create_number_group_membership', 422, { error => 'bad' });
+    my $ok = eval { $client->number_groups->add_membership('ng-1'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.create_number_group_membership', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_get_membership_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.retrieve_number_group_membership', 404, { error => 'nope' });
+    my $ok = eval { $client->number_groups->get_membership('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.retrieve_number_group_membership', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_membership_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.delete_number_group_membership', 404, { error => 'nope' });
+    my $ok = eval { $client->number_groups->delete_membership('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.delete_number_group_membership', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+done_testing();

--- a/t/rest/44_relay_phone_numbers_cov.t
+++ b/t/rest/44_relay_phone_numbers_cov.t
@@ -1,0 +1,156 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_relay_phone_numbers_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+my $BASE = '/api/relay/rest/phone_numbers';
+
+# -------------------- Success --------------------
+
+subtest 'test_list' => sub {
+    my $client = MockTest::client();
+    my $body = $client->phone_numbers->list();
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, $BASE, 'path');
+    is($last->{matched_route}, 'relay-rest.list_phone_numbers', 'matched route');
+};
+
+subtest 'test_search' => sub {
+    my $client = MockTest::client();
+    my $body = $client->phone_numbers->search(area_code => '512');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/search", 'path');
+    is($last->{matched_route}, 'relay-rest.search_available_phone_numbers', 'matched route');
+};
+
+subtest 'test_purchase' => sub {
+    my $client = MockTest::client();
+    my $body = $client->phone_numbers->create(number => '+15551230000');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, $BASE, 'path');
+    is($last->{matched_route}, 'relay-rest.purchase_phone_number', 'matched route');
+    is(($last->{body} || {})->{number}, '+15551230000', 'number forwarded');
+};
+
+subtest 'test_get' => sub {
+    my $client = MockTest::client();
+    my $body = $client->phone_numbers->get('pn-1001');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/pn-1001", 'path');
+    is($last->{matched_route}, 'relay-rest.retrieve_phone_number', 'matched route');
+};
+
+subtest 'test_update' => sub {
+    my $client = MockTest::client();
+    my $body = $client->phone_numbers->update('pn-1001', name => 'main line');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'PUT', 'PUT');
+    is($last->{path}, "$BASE/pn-1001", 'path');
+    is($last->{matched_route}, 'relay-rest.update_phone_number', 'matched route');
+    is(($last->{body} || {})->{name}, 'main line', 'name forwarded');
+};
+
+subtest 'test_release' => sub {
+    my $client = MockTest::client();
+    $client->phone_numbers->delete_resource('pn-1001');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', 'DELETE');
+    is($last->{path}, "$BASE/pn-1001", 'path');
+    is($last->{matched_route}, 'relay-rest.release_phone_number', 'matched route');
+};
+
+# -------------------- Errors --------------------
+
+subtest 'test_list_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.list_phone_numbers', 500, { error => 'internal' });
+    my $ok = eval { $client->phone_numbers->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.list_phone_numbers', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_search_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.search_available_phone_numbers', 500, { error => 'internal' });
+    my $ok = eval { $client->phone_numbers->search(area_code => '512'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.search_available_phone_numbers', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_purchase_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.purchase_phone_number', 422, { error => 'number required' });
+    my $ok = eval { $client->phone_numbers->create(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.purchase_phone_number', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_get_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.retrieve_phone_number', 404, { error => 'nope' });
+    my $ok = eval { $client->phone_numbers->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.retrieve_phone_number', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.update_phone_number', 404, { error => 'nope' });
+    my $ok = eval { $client->phone_numbers->update('missing', name => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.update_phone_number', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_release_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.release_phone_number', 404, { error => 'nope' });
+    my $ok = eval { $client->phone_numbers->delete_resource('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.release_phone_number', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+done_testing();

--- a/t/rest/45_relay_verified_callers_cov.t
+++ b/t/rest/45_relay_verified_callers_cov.t
@@ -1,0 +1,180 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_relay_verified_callers_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+my $BASE = '/api/relay/rest/verified_caller_ids';
+
+# -------------------- Success --------------------
+
+subtest 'test_list' => sub {
+    my $client = MockTest::client();
+    my $body = $client->verified_callers->list();
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, $BASE, 'path');
+    is($last->{matched_route}, 'relay-rest.list_verified_caller_ids', 'matched route');
+};
+
+subtest 'test_create' => sub {
+    my $client = MockTest::client();
+    my $body = $client->verified_callers->create(phone_number => '+15551112222');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, $BASE, 'path');
+    is($last->{matched_route}, 'relay-rest.create_verified_caller_id', 'matched route');
+    is(($last->{body} || {})->{phone_number}, '+15551112222', 'phone_number forwarded');
+};
+
+subtest 'test_get' => sub {
+    my $client = MockTest::client();
+    my $body = $client->verified_callers->get('vc-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/vc-1", 'path');
+    is($last->{matched_route}, 'relay-rest.retrieve_verified_caller_id', 'matched route');
+};
+
+subtest 'test_update' => sub {
+    my $client = MockTest::client();
+    my $body = $client->verified_callers->update('vc-1', name => 'renamed');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'PUT', 'PUT');
+    is($last->{path}, "$BASE/vc-1", 'path');
+    is($last->{matched_route}, 'relay-rest.update_verified_caller_id', 'matched route');
+    is(($last->{body} || {})->{name}, 'renamed', 'name forwarded');
+};
+
+subtest 'test_delete' => sub {
+    my $client = MockTest::client();
+    $client->verified_callers->delete_resource('vc-1');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', 'DELETE');
+    is($last->{path}, "$BASE/vc-1", 'path');
+    is($last->{matched_route}, 'relay-rest.delete_verified_caller_id', 'matched route');
+};
+
+subtest 'test_redial_verification' => sub {
+    my $client = MockTest::client();
+    my $body = $client->verified_callers->redial_verification('vc-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, "$BASE/vc-1/verification", 'path');
+    is($last->{matched_route}, 'relay-rest.redial_verification_call', 'matched route');
+};
+
+subtest 'test_submit_verification' => sub {
+    my $client = MockTest::client();
+    my $body = $client->verified_callers->submit_verification('vc-1', verification_code => '123456');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'PUT', 'PUT');
+    is($last->{path}, "$BASE/vc-1/verification", 'path');
+    is($last->{matched_route}, 'relay-rest.validate_verification_code', 'matched route');
+    is(($last->{body} || {})->{verification_code}, '123456', 'verification_code forwarded');
+};
+
+# -------------------- Errors --------------------
+
+subtest 'test_list_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.list_verified_caller_ids', 500, { error => 'internal' });
+    my $ok = eval { $client->verified_callers->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.list_verified_caller_ids', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'test_create_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.create_verified_caller_id', 422, { error => 'bad' });
+    my $ok = eval { $client->verified_callers->create(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.create_verified_caller_id', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'test_get_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.retrieve_verified_caller_id', 404, { error => 'nope' });
+    my $ok = eval { $client->verified_callers->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.retrieve_verified_caller_id', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_update_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.update_verified_caller_id', 404, { error => 'nope' });
+    my $ok = eval { $client->verified_callers->update('missing', name => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.update_verified_caller_id', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_delete_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.delete_verified_caller_id', 404, { error => 'nope' });
+    my $ok = eval { $client->verified_callers->delete_resource('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.delete_verified_caller_id', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_redial_verification_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.redial_verification_call', 404, { error => 'nope' });
+    my $ok = eval { $client->verified_callers->redial_verification('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.redial_verification_call', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'test_submit_verification_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.validate_verification_code', 422, { error => 'wrong code' });
+    my $ok = eval { $client->verified_callers->submit_verification('vc-1', verification_code => '000000'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.validate_verification_code', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+done_testing();

--- a/t/rest/46_relay_registry_cov.t
+++ b/t/rest/46_relay_registry_cov.t
@@ -1,0 +1,304 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_relay_registry_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+my $BASE = '/api/relay/rest/registry/beta';
+
+# -------------------- Brands: Success --------------------
+
+subtest 'brands_test_list' => sub {
+    my $client = MockTest::client();
+    my $body = $client->registry->brands->list();
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/brands", 'path');
+    is($last->{matched_route}, 'relay-rest.list_brands', 'matched route');
+};
+
+subtest 'brands_test_create' => sub {
+    my $client = MockTest::client();
+    my $body = $client->registry->brands->create(entity_type => 'PRIVATE_PROFIT');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, "$BASE/brands", 'path');
+    is($last->{matched_route}, 'relay-rest.create_brand', 'matched route');
+    is(($last->{body} || {})->{entity_type}, 'PRIVATE_PROFIT', 'entity_type forwarded');
+};
+
+subtest 'brands_test_get' => sub {
+    my $client = MockTest::client();
+    my $body = $client->registry->brands->get('brand-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/brands/brand-1", 'path');
+    is($last->{matched_route}, 'relay-rest.retrieve_brand', 'matched route');
+};
+
+subtest 'brands_test_list_campaigns' => sub {
+    my $client = MockTest::client();
+    my $body = $client->registry->brands->list_campaigns('brand-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/brands/brand-1/campaigns", 'path');
+    is($last->{matched_route}, 'relay-rest.list_campaigns', 'matched route');
+};
+
+subtest 'brands_test_create_campaign' => sub {
+    my $client = MockTest::client();
+    my $body = $client->registry->brands->create_campaign('brand-1', usecase => 'LOW_VOLUME');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, "$BASE/brands/brand-1/campaigns", 'path');
+    is($last->{matched_route}, 'relay-rest.create_campaign', 'matched route');
+    is(($last->{body} || {})->{usecase}, 'LOW_VOLUME', 'usecase forwarded');
+};
+
+# -------------------- Brands: Errors --------------------
+
+subtest 'brands_test_list_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.list_brands', 500, { error => 'boom' });
+    my $ok = eval { $client->registry->brands->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.list_brands', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'brands_test_create_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.create_brand', 422, { error => 'bad' });
+    my $ok = eval { $client->registry->brands->create(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.create_brand', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'brands_test_get_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.retrieve_brand', 404, { error => 'nope' });
+    my $ok = eval { $client->registry->brands->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.retrieve_brand', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'brands_test_list_campaigns_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.list_campaigns', 404, { error => 'nope' });
+    my $ok = eval { $client->registry->brands->list_campaigns('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.list_campaigns', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'brands_test_create_campaign_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.create_campaign', 422, { error => 'bad' });
+    my $ok = eval { $client->registry->brands->create_campaign('brand-1'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.create_campaign', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+# -------------------- Campaigns: Success --------------------
+
+subtest 'campaigns_test_get' => sub {
+    my $client = MockTest::client();
+    my $body = $client->registry->campaigns->get('camp-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/campaigns/camp-1", 'path');
+    is($last->{matched_route}, 'relay-rest.retrieve_campaign', 'matched route');
+};
+
+subtest 'campaigns_test_update' => sub {
+    my $client = MockTest::client();
+    my $body = $client->registry->campaigns->update('camp-1', description => 'x');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'PUT', 'PUT');
+    is($last->{path}, "$BASE/campaigns/camp-1", 'path');
+    is($last->{matched_route}, 'relay-rest.update_campaign', 'matched route');
+    is(($last->{body} || {})->{description}, 'x', 'description forwarded');
+};
+
+subtest 'campaigns_test_list_numbers' => sub {
+    my $client = MockTest::client();
+    my $body = $client->registry->campaigns->list_numbers('camp-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/campaigns/camp-1/numbers", 'path');
+    is($last->{matched_route}, 'relay-rest.list_number_assignments', 'matched route');
+};
+
+subtest 'campaigns_test_list_orders' => sub {
+    my $client = MockTest::client();
+    my $body = $client->registry->campaigns->list_orders('camp-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/campaigns/camp-1/orders", 'path');
+    is($last->{matched_route}, 'relay-rest.list_orders', 'matched route');
+};
+
+subtest 'campaigns_test_create_order' => sub {
+    my $client = MockTest::client();
+    my $body = $client->registry->campaigns->create_order('camp-1', numbers => ['pn-1']);
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, "$BASE/campaigns/camp-1/orders", 'path');
+    is($last->{matched_route}, 'relay-rest.create_order', 'matched route');
+    is_deeply(($last->{body} || {})->{numbers}, ['pn-1'], 'numbers forwarded');
+};
+
+# -------------------- Campaigns: Errors --------------------
+
+subtest 'campaigns_test_get_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.retrieve_campaign', 404, { error => 'nope' });
+    my $ok = eval { $client->registry->campaigns->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.retrieve_campaign', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'campaigns_test_update_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.update_campaign', 404, { error => 'nope' });
+    my $ok = eval { $client->registry->campaigns->update('missing', description => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.update_campaign', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'campaigns_test_list_numbers_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.list_number_assignments', 404, { error => 'nope' });
+    my $ok = eval { $client->registry->campaigns->list_numbers('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.list_number_assignments', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'campaigns_test_list_orders_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.list_orders', 404, { error => 'nope' });
+    my $ok = eval { $client->registry->campaigns->list_orders('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.list_orders', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'campaigns_test_create_order_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.create_order', 422, { error => 'bad' });
+    my $ok = eval { $client->registry->campaigns->create_order('camp-1'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.create_order', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+# -------------------- Orders: Success + Error --------------------
+
+subtest 'orders_test_get' => sub {
+    my $client = MockTest::client();
+    my $body = $client->registry->orders->get('order-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$BASE/orders/order-1", 'path');
+    is($last->{matched_route}, 'relay-rest.retrieve_order', 'matched route');
+};
+
+subtest 'orders_test_get_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.retrieve_order', 404, { error => 'nope' });
+    my $ok = eval { $client->registry->orders->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.retrieve_order', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+# -------------------- Numbers: Success + Error --------------------
+
+subtest 'numbers_test_delete' => sub {
+    my $client = MockTest::client();
+    $client->registry->numbers->delete('num-1');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'DELETE', 'DELETE');
+    is($last->{path}, "$BASE/numbers/num-1", 'path');
+    is($last->{matched_route}, 'relay-rest.delete_number_assignment', 'matched route');
+};
+
+subtest 'numbers_test_delete_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.delete_number_assignment', 404, { error => 'nope' });
+    my $ok = eval { $client->registry->numbers->delete('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.delete_number_assignment', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+done_testing();

--- a/t/rest/47_relay_small_namespaces_cov.t
+++ b/t/rest/47_relay_small_namespaces_cov.t
@@ -1,0 +1,269 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_relay_small_namespaces_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+# -------------------- SipProfile: Success --------------------
+
+my $SIP = '/api/relay/rest/sip_profile';
+
+subtest 'sip_profile_test_get' => sub {
+    my $client = MockTest::client();
+    my $body = $client->sip_profile->get();
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, $SIP, 'path');
+    is($last->{matched_route}, 'relay-rest.retrieve_sip_profile', 'matched route');
+};
+
+subtest 'sip_profile_test_update' => sub {
+    my $client = MockTest::client();
+    my $body = $client->sip_profile->update(domain => 'acme');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'PUT', 'PUT');
+    is($last->{path}, $SIP, 'path');
+    is($last->{matched_route}, 'relay-rest.update_sip_profile', 'matched route');
+    is(($last->{body} || {})->{domain}, 'acme', 'domain forwarded');
+};
+
+# -------------------- SipProfile: Errors --------------------
+
+subtest 'sip_profile_test_get_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.retrieve_sip_profile', 500, { error => 'boom' });
+    my $ok = eval { $client->sip_profile->get(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.retrieve_sip_profile', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'sip_profile_test_update_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.update_sip_profile', 422, { error => 'bad' });
+    my $ok = eval { $client->sip_profile->update(domain => ''); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.update_sip_profile', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+# -------------------- Lookup: Success + Error --------------------
+
+subtest 'lookup_test_phone_number' => sub {
+    my $client = MockTest::client();
+    my $body = $client->lookup->phone_number('+15551230000');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, '/api/relay/rest/lookup/phone_number/+15551230000', 'path');
+    is($last->{matched_route}, 'relay-rest.lookup_phone_number', 'matched route');
+};
+
+subtest 'lookup_test_phone_number_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.lookup_phone_number', 404, { error => 'nope' });
+    my $ok = eval { $client->lookup->phone_number('+19999999999'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.lookup_phone_number', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+# -------------------- ShortCodes: Success --------------------
+
+my $SC = '/api/relay/rest/short_codes';
+
+subtest 'short_codes_test_list' => sub {
+    my $client = MockTest::client();
+    my $body = $client->short_codes->list();
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, $SC, 'path');
+    is($last->{matched_route}, 'relay-rest.list_short_codes', 'matched route');
+};
+
+subtest 'short_codes_test_get' => sub {
+    my $client = MockTest::client();
+    my $body = $client->short_codes->get('sc-1');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'GET', 'GET');
+    is($last->{path}, "$SC/sc-1", 'path');
+    is($last->{matched_route}, 'relay-rest.retrieve_short_code', 'matched route');
+};
+
+subtest 'short_codes_test_update' => sub {
+    my $client = MockTest::client();
+    my $body = $client->short_codes->update('sc-1', friendly_name => 'promo');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'PUT', 'PUT');
+    is($last->{path}, "$SC/sc-1", 'path');
+    is($last->{matched_route}, 'relay-rest.update_short_code', 'matched route');
+    is(($last->{body} || {})->{friendly_name}, 'promo', 'friendly_name forwarded');
+};
+
+# -------------------- ShortCodes: Errors --------------------
+
+subtest 'short_codes_test_list_server_error' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.list_short_codes', 500, { error => 'boom' });
+    my $ok = eval { $client->short_codes->list(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 500, 'status 500');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.list_short_codes', 'matched route');
+    is($last->{response_status}, 500, 'journaled 500');
+};
+
+subtest 'short_codes_test_get_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.retrieve_short_code', 404, { error => 'nope' });
+    my $ok = eval { $client->short_codes->get('missing'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.retrieve_short_code', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+subtest 'short_codes_test_update_not_found' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.update_short_code', 404, { error => 'nope' });
+    my $ok = eval { $client->short_codes->update('missing', friendly_name => 'x'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 404, 'status 404');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.update_short_code', 'matched route');
+    is($last->{response_status}, 404, 'journaled 404');
+};
+
+# -------------------- ImportedNumbers: Success + Error --------------------
+
+my $IMP = '/api/relay/rest/imported_phone_numbers';
+
+subtest 'imported_numbers_test_create' => sub {
+    my $client = MockTest::client();
+    my $body = $client->imported_numbers->create(number => '+15551230000');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, $IMP, 'path');
+    is($last->{matched_route}, 'relay-rest.create_imported_phone_number', 'matched route');
+    is(($last->{body} || {})->{number}, '+15551230000', 'number forwarded');
+};
+
+subtest 'imported_numbers_test_create_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.create_imported_phone_number', 422, { error => 'bad' });
+    my $ok = eval { $client->imported_numbers->create(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.create_imported_phone_number', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+# -------------------- MFA: Success --------------------
+
+subtest 'mfa_test_call' => sub {
+    my $client = MockTest::client();
+    my $body = $client->mfa->call(to => '+15551230000');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, '/api/relay/rest/mfa/call', 'path');
+    is($last->{matched_route}, 'relay-rest.request_mfa_call', 'matched route');
+    is(($last->{body} || {})->{to}, '+15551230000', 'to forwarded');
+};
+
+subtest 'mfa_test_sms' => sub {
+    my $client = MockTest::client();
+    my $body = $client->mfa->sms(to => '+15551230000');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, '/api/relay/rest/mfa/sms', 'path');
+    is($last->{matched_route}, 'relay-rest.request_mfa_sms', 'matched route');
+    is(($last->{body} || {})->{to}, '+15551230000', 'to forwarded');
+};
+
+subtest 'mfa_test_verify' => sub {
+    my $client = MockTest::client();
+    my $body = $client->mfa->verify('mfa-1', token => '123456');
+    is(ref $body, 'HASH', 'response is a hashref');
+    my $last = MockTest::journal_last();
+    is($last->{method}, 'POST', 'POST');
+    is($last->{path}, '/api/relay/rest/mfa/mfa-1/verify', 'path');
+    is($last->{matched_route}, 'relay-rest.verify_mfa_token', 'matched route');
+    is(($last->{body} || {})->{token}, '123456', 'token forwarded');
+};
+
+# -------------------- MFA: Errors --------------------
+
+subtest 'mfa_test_call_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.request_mfa_call', 422, { error => 'to required' });
+    my $ok = eval { $client->mfa->call(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.request_mfa_call', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'mfa_test_sms_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.request_mfa_sms', 422, { error => 'to required' });
+    my $ok = eval { $client->mfa->sms(); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.request_mfa_sms', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+subtest 'mfa_test_verify_unprocessable' => sub {
+    my $client = MockTest::client();
+    MockTest::scenario_set('relay-rest.verify_mfa_token', 422, { error => 'bad token' });
+    my $ok = eval { $client->mfa->verify('mfa-1', token => '000000'); 1 };
+    my $e = $@;
+    ok(!$ok, 'raised');
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, 422, 'status 422');
+    my $last = MockTest::journal_last();
+    is($last->{matched_route}, 'relay-rest.verify_mfa_token', 'matched route');
+    is($last->{response_status}, 422, 'journaled 422');
+};
+
+done_testing();

--- a/t/rest/50_video_rooms_cov.t
+++ b/t/rest/50_video_rooms_cov.t
@@ -1,0 +1,213 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_video_rooms_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+# video.rooms is a CRUD resource at /api/video/rooms (PUT update), plus the
+# streams sub-collection (list_streams / create_stream). room_tokens.create
+# posts to /api/video/room_tokens.
+#
+# Perl CRUD delete is delete_resource (Rooms inherits CrudResource which has no
+# 'delete' alias). rooms.get hits GET /api/video/rooms/{id} which the router
+# resolves to video.get_room_by_name (longer {name} template wins). video.get_room
+# is an accepted gap (not independently reachable).
+
+subtest 'TestVideoRoomsSuccess' => sub {
+    subtest 'test_list_rooms' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->rooms->list();
+        is(ref $body, 'HASH', 'hashref');
+        ok(exists $body->{data}, 'data present');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/rooms', 'path');
+        is($last->{matched_route}, 'video.list_rooms', 'matched route');
+    };
+
+    subtest 'test_create_room' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->rooms->create(name => 'room-alpha');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/video/rooms', 'path');
+        is($last->{matched_route}, 'video.create_room', 'matched route');
+        is($last->{body}{name}, 'room-alpha', 'name forwarded');
+    };
+
+    subtest 'test_get_room_by_name' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->rooms->get('room-1001');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/rooms/room-1001', 'path');
+        is($last->{matched_route}, 'video.get_room_by_name', 'matched route');
+    };
+
+    subtest 'test_update_room' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->rooms->update('room-1001', display_name => 'renamed');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'PUT', 'PUT');
+        is($last->{path}, '/api/video/rooms/room-1001', 'path');
+        is($last->{matched_route}, 'video.update_room', 'matched route');
+        is($last->{body}{display_name}, 'renamed', 'display_name forwarded');
+    };
+
+    subtest 'test_delete_room' => sub {
+        my $client = MockTest::client();
+        $client->video->rooms->delete_resource('room-1001');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'DELETE', 'DELETE');
+        is($last->{path}, '/api/video/rooms/room-1001', 'path');
+        is($last->{matched_route}, 'video.delete_room', 'matched route');
+    };
+
+    subtest 'test_list_room_streams' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->rooms->list_streams('room-1001');
+        is(ref $body, 'HASH', 'hashref');
+        ok(exists $body->{data}, 'data present');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/rooms/room-1001/streams', 'path');
+        is($last->{matched_route}, 'video.list_room_streams', 'matched route');
+    };
+
+    subtest 'test_create_room_stream' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->rooms->create_stream('room-1001', url => 'rtmp://example.com/live');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/video/rooms/room-1001/streams', 'path');
+        is($last->{matched_route}, 'video.create_room_stream', 'matched route');
+        is($last->{body}{url}, 'rtmp://example.com/live', 'url forwarded');
+    };
+
+    subtest 'test_create_room_token' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->room_tokens->create(room_name => 'room-alpha');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/video/room_tokens', 'path');
+        is($last->{matched_route}, 'video.create_room_token', 'matched route');
+        is($last->{body}{room_name}, 'room-alpha', 'room_name forwarded');
+    };
+};
+
+subtest 'TestVideoRoomsErrors' => sub {
+    subtest 'test_list_rooms_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.list_rooms', 500, { error => 'internal' });
+        my $ok = eval { $client->video->rooms->list(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.list_rooms', 'matched route');
+        is($last->{response_status}, 500, 'journaled 500');
+    };
+
+    subtest 'test_create_room_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.create_room', 422, { error => 'name required' });
+        my $ok = eval { $client->video->rooms->create(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.create_room', 'matched route');
+        is($last->{response_status}, 422, 'journaled 422');
+    };
+
+    subtest 'test_get_room_by_name_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.get_room_by_name', 404, { error => 'not found' });
+        my $ok = eval { $client->video->rooms->get('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.get_room_by_name', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_update_room_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.update_room', 404, { error => 'not found' });
+        my $ok = eval { $client->video->rooms->update('missing', display_name => 'x'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.update_room', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_delete_room_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.delete_room', 404, { error => 'not found' });
+        my $ok = eval { $client->video->rooms->delete_resource('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.delete_room', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_list_room_streams_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.list_room_streams', 404, { error => 'not found' });
+        my $ok = eval { $client->video->rooms->list_streams('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.list_room_streams', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_create_room_stream_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.create_room_stream', 422, { error => 'url required' });
+        my $ok = eval { $client->video->rooms->create_stream('room-1001'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.create_room_stream', 'matched route');
+        is($last->{response_status}, 422, 'journaled 422');
+    };
+
+    subtest 'test_create_room_token_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.create_room_token', 422, { error => 'room_name required' });
+        my $ok = eval { $client->video->room_tokens->create(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.create_room_token', 'matched route');
+        is($last->{response_status}, 422, 'journaled 422');
+    };
+};
+
+done_testing();

--- a/t/rest/51_video_room_sessions_cov.t
+++ b/t/rest/51_video_room_sessions_cov.t
@@ -1,0 +1,137 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_video_room_sessions_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+# video.room_sessions is read-only: list / get plus events, members, recordings
+# sub-collections at /api/video/room_sessions[/{id}[/{sub}]].
+
+subtest 'TestVideoRoomSessionsSuccess' => sub {
+    subtest 'test_list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->room_sessions->list();
+        is(ref $body, 'HASH', 'hashref');
+        ok(exists $body->{data}, 'data present');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/room_sessions', 'path');
+        is($last->{matched_route}, 'video.list_room_sessions', 'matched route');
+    };
+
+    subtest 'test_get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->room_sessions->get('sess-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/room_sessions/sess-1', 'path');
+        is($last->{matched_route}, 'video.get_room_session', 'matched route');
+    };
+
+    subtest 'test_list_events' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->room_sessions->list_events('sess-1');
+        is(ref $body, 'HASH', 'hashref');
+        ok(exists $body->{data}, 'data present');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/room_sessions/sess-1/events', 'path');
+        is($last->{matched_route}, 'video.list_room_session_events', 'matched route');
+    };
+
+    subtest 'test_list_members' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->room_sessions->list_members('sess-1');
+        is(ref $body, 'HASH', 'hashref');
+        ok(exists $body->{data}, 'data present');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/room_sessions/sess-1/members', 'path');
+        is($last->{matched_route}, 'video.list_room_session_members', 'matched route');
+    };
+
+    subtest 'test_list_recordings' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->room_sessions->list_recordings('sess-1');
+        is(ref $body, 'HASH', 'hashref');
+        ok(exists $body->{data}, 'data present');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/room_sessions/sess-1/recordings', 'path');
+        is($last->{matched_route}, 'video.list_room_session_recordings', 'matched route');
+    };
+};
+
+subtest 'TestVideoRoomSessionsErrors' => sub {
+    subtest 'test_list_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.list_room_sessions', 500, { error => 'internal' });
+        my $ok = eval { $client->video->room_sessions->list(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.list_room_sessions', 'matched route');
+        is($last->{response_status}, 500, 'journaled 500');
+    };
+
+    subtest 'test_get_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.get_room_session', 404, { error => 'not found' });
+        my $ok = eval { $client->video->room_sessions->get('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.get_room_session', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_list_events_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.list_room_session_events', 404, { error => 'not found' });
+        my $ok = eval { $client->video->room_sessions->list_events('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.list_room_session_events', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_list_members_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.list_room_session_members', 404, { error => 'not found' });
+        my $ok = eval { $client->video->room_sessions->list_members('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.list_room_session_members', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_list_recordings_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.list_room_session_recordings', 404, { error => 'not found' });
+        my $ok = eval { $client->video->room_sessions->list_recordings('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.list_room_session_recordings', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+};
+
+done_testing();

--- a/t/rest/52_video_room_recordings_cov.t
+++ b/t/rest/52_video_room_recordings_cov.t
@@ -1,0 +1,112 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_video_room_recordings_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+# video.room_recordings is the top-level recordings collection: list / get /
+# delete plus the events sub-collection. RoomRecordings has a 'delete' alias.
+
+subtest 'TestVideoRoomRecordingsSuccess' => sub {
+    subtest 'test_list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->room_recordings->list();
+        is(ref $body, 'HASH', 'hashref');
+        ok(exists $body->{data}, 'data present');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/room_recordings', 'path');
+        is($last->{matched_route}, 'video.list_room_recordings', 'matched route');
+    };
+
+    subtest 'test_get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->room_recordings->get('rec-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/room_recordings/rec-1', 'path');
+        is($last->{matched_route}, 'video.get_room_recording', 'matched route');
+    };
+
+    subtest 'test_delete' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->room_recordings->delete('rec-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'DELETE', 'DELETE');
+        is($last->{path}, '/api/video/room_recordings/rec-1', 'path');
+        is($last->{matched_route}, 'video.delete_room_recording', 'matched route');
+    };
+
+    subtest 'test_list_events' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->room_recordings->list_events('rec-1');
+        is(ref $body, 'HASH', 'hashref');
+        ok(exists $body->{data}, 'data present');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/room_recordings/rec-1/events', 'path');
+        is($last->{matched_route}, 'video.list_room_recording_events', 'matched route');
+    };
+};
+
+subtest 'TestVideoRoomRecordingsErrors' => sub {
+    subtest 'test_list_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.list_room_recordings', 500, { error => 'internal' });
+        my $ok = eval { $client->video->room_recordings->list(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.list_room_recordings', 'matched route');
+        is($last->{response_status}, 500, 'journaled 500');
+    };
+
+    subtest 'test_get_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.get_room_recording', 404, { error => 'not found' });
+        my $ok = eval { $client->video->room_recordings->get('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.get_room_recording', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_delete_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.delete_room_recording', 404, { error => 'not found' });
+        my $ok = eval { $client->video->room_recordings->delete('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.delete_room_recording', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_list_events_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.list_room_recording_events', 404, { error => 'not found' });
+        my $ok = eval { $client->video->room_recordings->list_events('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.list_room_recording_events', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+};
+
+done_testing();

--- a/t/rest/53_video_conferences_cov.t
+++ b/t/rest/53_video_conferences_cov.t
@@ -1,0 +1,208 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_video_conferences_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+# video.conferences is a CRUD resource at /api/video/conferences (PUT update)
+# plus conference_tokens / streams sub-collections and create_stream.
+# Conferences inherits CrudResource; delete is delete_resource.
+
+subtest 'TestVideoConferencesSuccess' => sub {
+    subtest 'test_list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->conferences->list();
+        is(ref $body, 'HASH', 'hashref');
+        ok(exists $body->{data}, 'data present');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/conferences', 'path');
+        is($last->{matched_route}, 'video.list_video_conferences', 'matched route');
+    };
+
+    subtest 'test_create' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->conferences->create(name => 'conf-alpha');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/video/conferences', 'path');
+        is($last->{matched_route}, 'video.create_video_conference', 'matched route');
+        is($last->{body}{name}, 'conf-alpha', 'name forwarded');
+    };
+
+    subtest 'test_get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->conferences->get('conf-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/conferences/conf-1', 'path');
+        is($last->{matched_route}, 'video.get_video_conference', 'matched route');
+    };
+
+    subtest 'test_update' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->conferences->update('conf-1', name => 'renamed');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'PUT', 'PUT');
+        is($last->{path}, '/api/video/conferences/conf-1', 'path');
+        is($last->{matched_route}, 'video.update_video_conference', 'matched route');
+        is($last->{body}{name}, 'renamed', 'name forwarded');
+    };
+
+    subtest 'test_delete' => sub {
+        my $client = MockTest::client();
+        $client->video->conferences->delete_resource('conf-1');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'DELETE', 'DELETE');
+        is($last->{path}, '/api/video/conferences/conf-1', 'path');
+        is($last->{matched_route}, 'video.delete_video_conference', 'matched route');
+    };
+
+    subtest 'test_list_conference_tokens' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->conferences->list_conference_tokens('conf-1');
+        is(ref $body, 'HASH', 'hashref');
+        ok(exists $body->{data}, 'data present');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/conferences/conf-1/conference_tokens', 'path');
+        is($last->{matched_route}, 'video.list_conference_tokens', 'matched route');
+    };
+
+    subtest 'test_list_streams' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->conferences->list_streams('conf-1');
+        is(ref $body, 'HASH', 'hashref');
+        ok(exists $body->{data}, 'data present');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/conferences/conf-1/streams', 'path');
+        is($last->{matched_route}, 'video.list_conference_streams', 'matched route');
+    };
+
+    subtest 'test_create_stream' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->conferences->create_stream('conf-1', url => 'rtmp://example.com/live');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/video/conferences/conf-1/streams', 'path');
+        is($last->{matched_route}, 'video.create_conference_stream', 'matched route');
+        is($last->{body}{url}, 'rtmp://example.com/live', 'url forwarded');
+    };
+};
+
+subtest 'TestVideoConferencesErrors' => sub {
+    subtest 'test_list_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.list_video_conferences', 500, { error => 'internal' });
+        my $ok = eval { $client->video->conferences->list(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.list_video_conferences', 'matched route');
+        is($last->{response_status}, 500, 'journaled 500');
+    };
+
+    subtest 'test_create_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.create_video_conference', 422, { error => 'name required' });
+        my $ok = eval { $client->video->conferences->create(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.create_video_conference', 'matched route');
+        is($last->{response_status}, 422, 'journaled 422');
+    };
+
+    subtest 'test_get_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.get_video_conference', 404, { error => 'not found' });
+        my $ok = eval { $client->video->conferences->get('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.get_video_conference', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_update_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.update_video_conference', 404, { error => 'not found' });
+        my $ok = eval { $client->video->conferences->update('missing', name => 'x'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.update_video_conference', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_delete_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.delete_video_conference', 404, { error => 'not found' });
+        my $ok = eval { $client->video->conferences->delete_resource('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.delete_video_conference', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_list_conference_tokens_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.list_conference_tokens', 404, { error => 'not found' });
+        my $ok = eval { $client->video->conferences->list_conference_tokens('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.list_conference_tokens', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_list_streams_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.list_conference_streams', 404, { error => 'not found' });
+        my $ok = eval { $client->video->conferences->list_streams('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.list_conference_streams', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_create_stream_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.create_conference_stream', 422, { error => 'url required' });
+        my $ok = eval { $client->video->conferences->create_stream('conf-1'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.create_conference_stream', 'matched route');
+        is($last->{response_status}, 422, 'journaled 422');
+    };
+};
+
+done_testing();

--- a/t/rest/54_video_tokens_streams_cov.t
+++ b/t/rest/54_video_tokens_streams_cov.t
@@ -1,0 +1,139 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_video_tokens_streams_full_mock.py
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+# video.conference_tokens: get / reset.
+# video.streams (top-level): get / update (PUT) / delete. Streams has a
+# 'delete' alias.
+
+subtest 'TestVideoConferenceTokensSuccess' => sub {
+    subtest 'test_get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->conference_tokens->get('tok-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/conference_tokens/tok-1', 'path');
+        is($last->{matched_route}, 'video.get_conference_token', 'matched route');
+    };
+
+    subtest 'test_reset' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->conference_tokens->reset('tok-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'POST', 'POST');
+        is($last->{path}, '/api/video/conference_tokens/tok-1/reset', 'path');
+        is($last->{matched_route}, 'video.reset_conference_token', 'matched route');
+    };
+};
+
+subtest 'TestVideoConferenceTokensErrors' => sub {
+    subtest 'test_get_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.get_conference_token', 404, { error => 'not found' });
+        my $ok = eval { $client->video->conference_tokens->get('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.get_conference_token', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_reset_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.reset_conference_token', 404, { error => 'not found' });
+        my $ok = eval { $client->video->conference_tokens->reset('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.reset_conference_token', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+};
+
+subtest 'TestVideoStreamsSuccess' => sub {
+    subtest 'test_get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->streams->get('stream-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'GET', 'GET');
+        is($last->{path}, '/api/video/streams/stream-1', 'path');
+        is($last->{matched_route}, 'video.get_stream', 'matched route');
+    };
+
+    subtest 'test_update' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->streams->update('stream-1', url => 'rtmp://example.com/new');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'PUT', 'PUT');
+        is($last->{path}, '/api/video/streams/stream-1', 'path');
+        is($last->{matched_route}, 'video.update_stream', 'matched route');
+        is($last->{body}{url}, 'rtmp://example.com/new', 'url forwarded');
+    };
+
+    subtest 'test_delete' => sub {
+        my $client = MockTest::client();
+        my $body = $client->video->streams->delete('stream-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $last = MockTest::journal_last();
+        is($last->{method}, 'DELETE', 'DELETE');
+        is($last->{path}, '/api/video/streams/stream-1', 'path');
+        is($last->{matched_route}, 'video.delete_stream', 'matched route');
+    };
+};
+
+subtest 'TestVideoStreamsErrors' => sub {
+    subtest 'test_get_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.get_stream', 404, { error => 'not found' });
+        my $ok = eval { $client->video->streams->get('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.get_stream', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_update_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.update_stream', 404, { error => 'not found' });
+        my $ok = eval { $client->video->streams->update('missing', url => 'x'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.update_stream', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'test_delete_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('video.delete_stream', 404, { error => 'not found' });
+        my $ok = eval { $client->video->streams->delete('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $last = MockTest::journal_last();
+        is($last->{matched_route}, 'video.delete_stream', 'matched route');
+        is($last->{response_status}, 404, 'journaled 404');
+    };
+};
+
+done_testing();

--- a/t/rest/60_datasphere_cov.t
+++ b/t/rest/60_datasphere_cov.t
@@ -1,0 +1,233 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_datasphere_full_mock.py
+#
+# Full success + error coverage for $client->datasphere->documents:
+#   list / create / get / update (PATCH) / delete, search (POST /search),
+#   list_chunks / get_chunk / delete_chunk under {id}/chunks.
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+# -------------------- Success --------------------
+
+subtest 'TestDatasphereSuccess' => sub {
+    subtest 'list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->datasphere->documents->list();
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/datasphere/documents', 'path');
+        is($j->{matched_route}, 'datasphere.list_documents', 'matched route');
+    };
+
+    subtest 'create' => sub {
+        my $client = MockTest::client();
+        my $body = $client->datasphere->documents->create(
+            url => 'https://example.com/doc.pdf',
+        );
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'POST', 'POST');
+        is($j->{path}, '/api/datasphere/documents', 'path');
+        is($j->{matched_route}, 'datasphere.create_document', 'matched route');
+        is(($j->{body} || {})->{url}, 'https://example.com/doc.pdf', 'url forwarded');
+    };
+
+    subtest 'search' => sub {
+        my $client = MockTest::client();
+        my $body = $client->datasphere->documents->search(query_string => 'hello');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'POST', 'POST');
+        is($j->{path}, '/api/datasphere/documents/search', 'path');
+        is($j->{matched_route}, 'datasphere.search_documents', 'matched route');
+        is(($j->{body} || {})->{query_string}, 'hello', 'query_string forwarded');
+    };
+
+    subtest 'list_chunks' => sub {
+        my $client = MockTest::client();
+        my $body = $client->datasphere->documents->list_chunks('doc-1001');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/datasphere/documents/doc-1001/chunks', 'path');
+        is($j->{matched_route}, 'datasphere.list_document_chunks', 'matched route');
+    };
+
+    subtest 'get_chunk' => sub {
+        my $client = MockTest::client();
+        my $body = $client->datasphere->documents->get_chunk('doc-1001', 'ch-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/datasphere/documents/doc-1001/chunks/ch-1', 'path');
+        is($j->{matched_route}, 'datasphere.get_document_chunk', 'matched route');
+    };
+
+    subtest 'delete_chunk' => sub {
+        my $client = MockTest::client();
+        $client->datasphere->documents->delete_chunk('doc-1001', 'ch-1');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'DELETE', 'DELETE');
+        is($j->{path}, '/api/datasphere/documents/doc-1001/chunks/ch-1', 'path');
+        is($j->{matched_route}, 'datasphere.delete_document_chunk', 'matched route');
+    };
+
+    subtest 'get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->datasphere->documents->get('doc-1001');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/datasphere/documents/doc-1001', 'path');
+        is($j->{matched_route}, 'datasphere.get_document', 'matched route');
+    };
+
+    subtest 'update' => sub {
+        my $client = MockTest::client();
+        my $body = $client->datasphere->documents->update('doc-1001', tags => ['x']);
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'PATCH', 'PATCH');
+        is($j->{path}, '/api/datasphere/documents/doc-1001', 'path');
+        is($j->{matched_route}, 'datasphere.update_document', 'matched route');
+        is_deeply(($j->{body} || {})->{tags}, ['x'], 'tags forwarded');
+    };
+
+    subtest 'delete' => sub {
+        my $client = MockTest::client();
+        $client->datasphere->documents->delete_resource('doc-1001');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'DELETE', 'DELETE');
+        is($j->{path}, '/api/datasphere/documents/doc-1001', 'path');
+        is($j->{matched_route}, 'datasphere.delete_document', 'matched route');
+    };
+};
+
+# -------------------- Errors --------------------
+
+subtest 'TestDatasphereErrors' => sub {
+    subtest 'list_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('datasphere.list_documents', 500, { error => 'internal' });
+        my $ok = eval { $client->datasphere->documents->list(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'datasphere.list_documents', 'matched route');
+        is($j->{response_status}, 500, 'journaled 500');
+    };
+
+    subtest 'create_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('datasphere.create_document', 422, { error => 'url required' });
+        my $ok = eval { $client->datasphere->documents->create(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'datasphere.create_document', 'matched route');
+        is($j->{response_status}, 422, 'journaled 422');
+    };
+
+    subtest 'search_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('datasphere.search_documents', 422, { error => 'bad query' });
+        my $ok = eval { $client->datasphere->documents->search(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'datasphere.search_documents', 'matched route');
+        is($j->{response_status}, 422, 'journaled 422');
+    };
+
+    subtest 'list_chunks_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('datasphere.list_document_chunks', 404, { error => 'not found' });
+        my $ok = eval { $client->datasphere->documents->list_chunks('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'datasphere.list_document_chunks', 'matched route');
+        is($j->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'get_chunk_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('datasphere.get_document_chunk', 404, { error => 'not found' });
+        my $ok = eval { $client->datasphere->documents->get_chunk('doc-1001', 'missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'datasphere.get_document_chunk', 'matched route');
+        is($j->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'delete_chunk_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('datasphere.delete_document_chunk', 404, { error => 'not found' });
+        my $ok = eval { $client->datasphere->documents->delete_chunk('doc-1001', 'missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'datasphere.delete_document_chunk', 'matched route');
+        is($j->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'get_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('datasphere.get_document', 404, { error => 'not found' });
+        my $ok = eval { $client->datasphere->documents->get('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'datasphere.get_document', 'matched route');
+        is($j->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'update_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('datasphere.update_document', 404, { error => 'not found' });
+        my $ok = eval { $client->datasphere->documents->update('missing', tags => ['x']); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'datasphere.update_document', 'matched route');
+        is($j->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'delete_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('datasphere.delete_document', 404, { error => 'not found' });
+        my $ok = eval { $client->datasphere->documents->delete_resource('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'datasphere.delete_document', 'matched route');
+        is($j->{response_status}, 404, 'journaled 404');
+    };
+};
+
+done_testing();

--- a/t/rest/61_misc_specs_cov.t
+++ b/t/rest/61_misc_specs_cov.t
@@ -1,0 +1,392 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_misc_specs_full_mock.py
+#
+# Full success + error coverage for the small REST specs:
+#   project (create/update/delete token), voice logs (list/get/list_events),
+#   fax logs (list/get), message logs (list/get), calling command dispatch,
+#   chat token, conference logs (list), pubsub token.
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+# -------------------- project tokens --------------------
+
+subtest 'TestProjectTokensSuccess' => sub {
+    subtest 'create' => sub {
+        my $client = MockTest::client();
+        my $body = $client->project_ns->tokens->create(name => 'ci-token');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'POST', 'POST');
+        is($j->{path}, '/api/project/tokens', 'path');
+        is($j->{matched_route}, 'project.create_token', 'matched route');
+        is(($j->{body} || {})->{name}, 'ci-token', 'name forwarded');
+    };
+
+    subtest 'update' => sub {
+        my $client = MockTest::client();
+        my $body = $client->project_ns->tokens->update('tok-1', name => 'renamed');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'PATCH', 'PATCH');
+        is($j->{path}, '/api/project/tokens/tok-1', 'path');
+        is($j->{matched_route}, 'project.update_token', 'matched route');
+        is(($j->{body} || {})->{name}, 'renamed', 'name forwarded');
+    };
+
+    subtest 'delete' => sub {
+        my $client = MockTest::client();
+        $client->project_ns->tokens->delete('tok-1');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'DELETE', 'DELETE');
+        is($j->{path}, '/api/project/tokens/tok-1', 'path');
+        is($j->{matched_route}, 'project.delete_token', 'matched route');
+    };
+};
+
+subtest 'TestProjectTokensErrors' => sub {
+    subtest 'create_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('project.create_token', 422, { error => 'name required' });
+        my $ok = eval { $client->project_ns->tokens->create(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'project.create_token', 'matched route');
+        is($j->{response_status}, 422, 'journaled 422');
+    };
+
+    subtest 'update_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('project.update_token', 404, { error => 'not found' });
+        my $ok = eval { $client->project_ns->tokens->update('missing', name => 'x'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'project.update_token', 'matched route');
+        is($j->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'delete_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('project.delete_token', 404, { error => 'not found' });
+        my $ok = eval { $client->project_ns->tokens->delete('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'project.delete_token', 'matched route');
+        is($j->{response_status}, 404, 'journaled 404');
+    };
+};
+
+# -------------------- voice logs --------------------
+
+subtest 'TestVoiceLogsSuccess' => sub {
+    subtest 'list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->voice->list();
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/voice/logs', 'path');
+        is($j->{matched_route}, 'voice.list_voice_logs', 'matched route');
+    };
+
+    subtest 'get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->voice->get('vl-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/voice/logs/vl-1', 'path');
+        is($j->{matched_route}, 'voice.get_voice_log', 'matched route');
+    };
+
+    subtest 'list_events' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->voice->list_events('vl-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/voice/logs/vl-1/events', 'path');
+        is($j->{matched_route}, 'voice.list_voice_log_events', 'matched route');
+    };
+};
+
+subtest 'TestVoiceLogsErrors' => sub {
+    subtest 'list_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('voice.list_voice_logs', 500, { error => 'internal' });
+        my $ok = eval { $client->logs->voice->list(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'voice.list_voice_logs', 'matched route');
+        is($j->{response_status}, 500, 'journaled 500');
+    };
+
+    subtest 'get_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('voice.get_voice_log', 404, { error => 'not found' });
+        my $ok = eval { $client->logs->voice->get('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'voice.get_voice_log', 'matched route');
+        is($j->{response_status}, 404, 'journaled 404');
+    };
+
+    subtest 'list_events_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('voice.list_voice_log_events', 404, { error => 'not found' });
+        my $ok = eval { $client->logs->voice->list_events('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'voice.list_voice_log_events', 'matched route');
+        is($j->{response_status}, 404, 'journaled 404');
+    };
+};
+
+# -------------------- fax logs --------------------
+
+subtest 'TestFaxLogsSuccess' => sub {
+    subtest 'list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->fax->list();
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/fax/logs', 'path');
+        is($j->{matched_route}, 'fax.list_fax_logs', 'matched route');
+    };
+
+    subtest 'get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->fax->get('fl-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/fax/logs/fl-1', 'path');
+        is($j->{matched_route}, 'fax.get_fax_log', 'matched route');
+    };
+};
+
+subtest 'TestFaxLogsErrors' => sub {
+    subtest 'list_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fax.list_fax_logs', 500, { error => 'internal' });
+        my $ok = eval { $client->logs->fax->list(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'fax.list_fax_logs', 'matched route');
+        is($j->{response_status}, 500, 'journaled 500');
+    };
+
+    subtest 'get_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('fax.get_fax_log', 404, { error => 'not found' });
+        my $ok = eval { $client->logs->fax->get('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'fax.get_fax_log', 'matched route');
+        is($j->{response_status}, 404, 'journaled 404');
+    };
+};
+
+# -------------------- message logs --------------------
+
+subtest 'TestMessageLogsSuccess' => sub {
+    subtest 'list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->messages->list();
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/messaging/logs', 'path');
+        is($j->{matched_route}, 'message.list_message_logs', 'matched route');
+    };
+
+    subtest 'get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->messages->get('ml-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/messaging/logs/ml-1', 'path');
+        is($j->{matched_route}, 'message.get_message_log', 'matched route');
+    };
+};
+
+subtest 'TestMessageLogsErrors' => sub {
+    subtest 'list_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('message.list_message_logs', 500, { error => 'internal' });
+        my $ok = eval { $client->logs->messages->list(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'message.list_message_logs', 'matched route');
+        is($j->{response_status}, 500, 'journaled 500');
+    };
+
+    subtest 'get_not_found' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('message.get_message_log', 404, { error => 'not found' });
+        my $ok = eval { $client->logs->messages->get('missing'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 404, 'status 404');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'message.get_message_log', 'matched route');
+        is($j->{response_status}, 404, 'journaled 404');
+    };
+};
+
+# -------------------- calling command dispatch --------------------
+
+subtest 'TestCallingCommandSuccess' => sub {
+    subtest 'dial' => sub {
+        my $client = MockTest::client();
+        my $body = $client->calling->dial(
+            url => 'https://example.com/swml', to => '+15551234567',
+        );
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'POST', 'POST');
+        is($j->{path}, '/api/calling/calls', 'path');
+        is($j->{matched_route}, 'calling.call-commands', 'matched route');
+        is(($j->{body} || {})->{command}, 'dial', 'command is dial');
+    };
+};
+
+subtest 'TestCallingCommandErrors' => sub {
+    subtest 'dial_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('calling.call-commands', 422, { error => 'bad command' });
+        my $ok = eval { $client->calling->dial(url => 'https://example.com/swml'); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'calling.call-commands', 'matched route');
+        is($j->{response_status}, 422, 'journaled 422');
+    };
+};
+
+# -------------------- chat token --------------------
+
+subtest 'TestChatTokenSuccess' => sub {
+    subtest 'create_token' => sub {
+        my $client = MockTest::client();
+        my $body = $client->chat->create_token(channels => { room => {} });
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'POST', 'POST');
+        is($j->{path}, '/api/chat/tokens', 'path');
+        is($j->{matched_route}, 'chat.create_chat_token', 'matched route');
+        is_deeply(($j->{body} || {})->{channels}, { room => {} }, 'channels forwarded');
+    };
+};
+
+subtest 'TestChatTokenErrors' => sub {
+    subtest 'create_token_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('chat.create_chat_token', 422, { error => 'channels required' });
+        my $ok = eval { $client->chat->create_token(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'chat.create_chat_token', 'matched route');
+        is($j->{response_status}, 422, 'journaled 422');
+    };
+};
+
+# -------------------- conference logs --------------------
+
+subtest 'TestConferenceLogsSuccess' => sub {
+    subtest 'list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->conferences->list();
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/logs/conferences', 'path');
+        is($j->{matched_route}, 'logs.list_conferences', 'matched route');
+    };
+};
+
+subtest 'TestConferenceLogsErrors' => sub {
+    subtest 'list_server_error' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('logs.list_conferences', 500, { error => 'internal' });
+        my $ok = eval { $client->logs->conferences->list(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 500, 'status 500');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'logs.list_conferences', 'matched route');
+        is($j->{response_status}, 500, 'journaled 500');
+    };
+};
+
+# -------------------- pubsub token --------------------
+
+subtest 'TestPubSubTokenSuccess' => sub {
+    subtest 'create_token' => sub {
+        my $client = MockTest::client();
+        my $body = $client->pubsub->create_token(channels => { news => {} });
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'POST', 'POST');
+        is($j->{path}, '/api/pubsub/tokens', 'path');
+        is($j->{matched_route}, 'pubsub.create_token', 'matched route');
+        is_deeply(($j->{body} || {})->{channels}, { news => {} }, 'channels forwarded');
+    };
+};
+
+subtest 'TestPubSubTokenErrors' => sub {
+    subtest 'create_token_unprocessable' => sub {
+        my $client = MockTest::client();
+        MockTest::scenario_set('pubsub.create_token', 422, { error => 'channels required' });
+        my $ok = eval { $client->pubsub->create_token(); 1 };
+        my $e = $@;
+        ok(!$ok, 'raised');
+        isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+        is($e->status_code, 422, 'status 422');
+        my $j = MockTest::journal_last();
+        is($j->{matched_route}, 'pubsub.create_token', 'matched route');
+        is($j->{response_status}, 422, 'journaled 422');
+    };
+};
+
+done_testing();

--- a/t/rest/62_small_namespaces_cov.t
+++ b/t/rest/62_small_namespaces_cov.t
@@ -1,0 +1,369 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_small_namespaces_mock.py
+#
+# Success + error coverage for the small namespaces:
+#   addresses (list/create/get/delete), recordings (list/get/delete),
+#   short_codes (list/get/update), imported_numbers (create), mfa (call),
+#   sip_profile (update), number_groups (list_memberships/delete_membership),
+#   project.tokens (update/delete), datasphere.documents (get_chunk),
+#   queues (get_member).
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+# Helper for an error subtest: arm a one-shot scenario, call CODEREF once,
+# assert it raises with the right status and the journal records the route.
+sub _err {
+    my ($endpoint_id, $status, $code_ref) = @_;
+    MockTest::scenario_set($endpoint_id, $status, { error => 'boom' });
+    my $ok = eval { $code_ref->(); 1 };
+    my $e = $@;
+    ok(!$ok, "raised for $endpoint_id");
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, $status, "status $status for $endpoint_id");
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, $endpoint_id, "matched route $endpoint_id");
+    is($j->{response_status}, $status, "journaled $status for $endpoint_id");
+}
+
+# -------------------- Addresses --------------------
+
+subtest 'TestAddresses' => sub {
+    subtest 'list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->addresses->list(page_size => 10);
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/relay/rest/addresses', 'path');
+        is($j->{matched_route}, 'relay-rest.list_addresses', 'matched route');
+    };
+    subtest 'list_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.list_addresses', 500, sub { $client->addresses->list() });
+    };
+
+    subtest 'create' => sub {
+        my $client = MockTest::client();
+        my $body = $client->addresses->create(
+            address_type => 'commercial',
+            first_name   => 'Ada',
+            last_name    => 'Lovelace',
+            country      => 'US',
+        );
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'POST', 'POST');
+        is($j->{path}, '/api/relay/rest/addresses', 'path');
+        is($j->{matched_route}, 'relay-rest.create_address', 'matched route');
+        is(($j->{body} || {})->{address_type}, 'commercial', 'address_type forwarded');
+    };
+    subtest 'create_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.create_address', 422, sub { $client->addresses->create() });
+    };
+
+    subtest 'get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->addresses->get('addr-123');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/relay/rest/addresses/addr-123', 'path');
+        is($j->{matched_route}, 'relay-rest.get_address', 'matched route');
+    };
+    subtest 'get_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.get_address', 404, sub { $client->addresses->get('missing') });
+    };
+
+    subtest 'delete' => sub {
+        my $client = MockTest::client();
+        $client->addresses->delete('addr-123');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'DELETE', 'DELETE');
+        is($j->{path}, '/api/relay/rest/addresses/addr-123', 'path');
+        is($j->{matched_route}, 'relay-rest.delete_address', 'matched route');
+    };
+    subtest 'delete_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.delete_address', 404, sub { $client->addresses->delete('missing') });
+    };
+};
+
+# -------------------- Recordings --------------------
+
+subtest 'TestRecordings' => sub {
+    subtest 'list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->recordings->list(page_size => 5);
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/relay/rest/recordings', 'path');
+        is($j->{matched_route}, 'relay-rest.list_recordings', 'matched route');
+    };
+    subtest 'list_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.list_recordings', 500, sub { $client->recordings->list() });
+    };
+
+    subtest 'get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->recordings->get('rec-123');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/relay/rest/recordings/rec-123', 'path');
+        is($j->{matched_route}, 'relay-rest.get_recording', 'matched route');
+    };
+    subtest 'get_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.get_recording', 404, sub { $client->recordings->get('missing') });
+    };
+
+    subtest 'delete' => sub {
+        my $client = MockTest::client();
+        $client->recordings->delete('rec-123');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'DELETE', 'DELETE');
+        is($j->{path}, '/api/relay/rest/recordings/rec-123', 'path');
+        is($j->{matched_route}, 'relay-rest.delete_recording', 'matched route');
+    };
+    subtest 'delete_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.delete_recording', 404, sub { $client->recordings->delete('missing') });
+    };
+};
+
+# -------------------- Short Codes --------------------
+
+subtest 'TestShortCodes' => sub {
+    subtest 'list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->short_codes->list(page_size => 20);
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/relay/rest/short_codes', 'path');
+        is($j->{matched_route}, 'relay-rest.list_short_codes', 'matched route');
+    };
+    subtest 'list_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.list_short_codes', 500, sub { $client->short_codes->list() });
+    };
+
+    subtest 'get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->short_codes->get('sc-1');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/relay/rest/short_codes/sc-1', 'path');
+        is($j->{matched_route}, 'relay-rest.retrieve_short_code', 'matched route');
+    };
+    subtest 'get_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.retrieve_short_code', 404, sub { $client->short_codes->get('missing') });
+    };
+
+    subtest 'update' => sub {
+        my $client = MockTest::client();
+        my $body = $client->short_codes->update('sc-1', name => 'Marketing SMS');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'PUT', 'PUT');
+        is($j->{path}, '/api/relay/rest/short_codes/sc-1', 'path');
+        is($j->{matched_route}, 'relay-rest.update_short_code', 'matched route');
+        is(($j->{body} || {})->{name}, 'Marketing SMS', 'name forwarded');
+    };
+    subtest 'update_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.update_short_code', 404,
+            sub { $client->short_codes->update('missing', name => 'x') });
+    };
+};
+
+# -------------------- Imported Numbers --------------------
+
+subtest 'TestImportedNumbers' => sub {
+    subtest 'create' => sub {
+        my $client = MockTest::client();
+        my $body = $client->imported_numbers->create(
+            number       => '+15551234567',
+            sip_username => 'alice',
+            sip_password => 'secret',
+            sip_proxy    => 'sip.example.com',
+        );
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'POST', 'POST');
+        is($j->{path}, '/api/relay/rest/imported_phone_numbers', 'path');
+        is($j->{matched_route}, 'relay-rest.create_imported_phone_number', 'matched route');
+        is(($j->{body} || {})->{number}, '+15551234567', 'number forwarded');
+    };
+    subtest 'create_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.create_imported_phone_number', 422,
+            sub { $client->imported_numbers->create() });
+    };
+};
+
+# -------------------- MFA --------------------
+
+subtest 'TestMfa' => sub {
+    subtest 'call' => sub {
+        my $client = MockTest::client();
+        my $body = $client->mfa->call(
+            to      => '+15551234567',
+            from_   => '+15559876543',
+            message => 'Your code is {code}',
+        );
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'POST', 'POST');
+        is($j->{path}, '/api/relay/rest/mfa/call', 'path');
+        is($j->{matched_route}, 'relay-rest.request_mfa_call', 'matched route');
+        is(($j->{body} || {})->{to}, '+15551234567', 'to forwarded');
+    };
+    subtest 'call_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.request_mfa_call', 422,
+            sub { $client->mfa->call(to => '+15551234567') });
+    };
+};
+
+# -------------------- SIP Profile --------------------
+
+subtest 'TestSipProfile' => sub {
+    subtest 'update' => sub {
+        my $client = MockTest::client();
+        my $body = $client->sip_profile->update(
+            domain         => 'myco.sip.signalwire.com',
+            default_codecs => ['PCMU', 'PCMA'],
+        );
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'PUT', 'PUT');
+        is($j->{path}, '/api/relay/rest/sip_profile', 'path');
+        is($j->{matched_route}, 'relay-rest.update_sip_profile', 'matched route');
+        is(($j->{body} || {})->{domain}, 'myco.sip.signalwire.com', 'domain forwarded');
+    };
+    subtest 'update_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.update_sip_profile', 422,
+            sub { $client->sip_profile->update(domain => 'x') });
+    };
+};
+
+# -------------------- Number Groups --------------------
+
+subtest 'TestNumberGroups' => sub {
+    subtest 'list_memberships' => sub {
+        my $client = MockTest::client();
+        my $body = $client->number_groups->list_memberships('ng-1', page_size => 10);
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path},
+           '/api/relay/rest/number_groups/ng-1/number_group_memberships', 'path');
+        is($j->{matched_route}, 'relay-rest.list_number_group_memberships', 'matched route');
+    };
+    subtest 'list_memberships_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.list_number_group_memberships', 404,
+            sub { $client->number_groups->list_memberships('missing') });
+    };
+
+    subtest 'delete_membership' => sub {
+        my $client = MockTest::client();
+        $client->number_groups->delete_membership('mem-1');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'DELETE', 'DELETE');
+        is($j->{path}, '/api/relay/rest/number_group_memberships/mem-1', 'path');
+        is($j->{matched_route}, 'relay-rest.delete_number_group_membership', 'matched route');
+    };
+    subtest 'delete_membership_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.delete_number_group_membership', 404,
+            sub { $client->number_groups->delete_membership('missing') });
+    };
+};
+
+# -------------------- Project tokens --------------------
+
+subtest 'TestProjectTokens' => sub {
+    subtest 'update' => sub {
+        my $client = MockTest::client();
+        my $body = $client->project_ns->tokens->update('tok-1', name => 'renamed-token');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'PATCH', 'PATCH');
+        is($j->{path}, '/api/project/tokens/tok-1', 'path');
+        is($j->{matched_route}, 'project.update_token', 'matched route');
+        is(($j->{body} || {})->{name}, 'renamed-token', 'name forwarded');
+    };
+    subtest 'update_error' => sub {
+        my $client = MockTest::client();
+        _err('project.update_token', 404,
+            sub { $client->project_ns->tokens->update('missing', name => 'x') });
+    };
+
+    subtest 'delete' => sub {
+        my $client = MockTest::client();
+        $client->project_ns->tokens->delete('tok-1');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'DELETE', 'DELETE');
+        is($j->{path}, '/api/project/tokens/tok-1', 'path');
+        is($j->{matched_route}, 'project.delete_token', 'matched route');
+    };
+    subtest 'delete_error' => sub {
+        my $client = MockTest::client();
+        _err('project.delete_token', 404,
+            sub { $client->project_ns->tokens->delete('missing') });
+    };
+};
+
+# -------------------- Datasphere get_chunk --------------------
+
+subtest 'TestDatasphere' => sub {
+    subtest 'get_chunk' => sub {
+        my $client = MockTest::client();
+        my $body = $client->datasphere->documents->get_chunk('doc-1', 'chunk-99');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/datasphere/documents/doc-1/chunks/chunk-99', 'path');
+        is($j->{matched_route}, 'datasphere.get_document_chunk', 'matched route');
+    };
+    subtest 'get_chunk_error' => sub {
+        my $client = MockTest::client();
+        _err('datasphere.get_document_chunk', 404,
+            sub { $client->datasphere->documents->get_chunk('doc-1', 'missing') });
+    };
+};
+
+# -------------------- Queues get_member --------------------
+
+subtest 'TestQueues' => sub {
+    subtest 'get_member' => sub {
+        my $client = MockTest::client();
+        my $body = $client->queues->get_member('q-1', 'mem-7');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/relay/rest/queues/q-1/members/mem-7', 'path');
+        is($j->{matched_route}, 'relay-rest.retrieve_queue_member', 'matched route');
+    };
+    subtest 'get_member_error' => sub {
+        my $client = MockTest::client();
+        _err('relay-rest.retrieve_queue_member', 404,
+            sub { $client->queues->get_member('q-1', 'missing') });
+    };
+};
+
+done_testing();

--- a/t/rest/63_logs_cov.t
+++ b/t/rest/63_logs_cov.t
@@ -1,0 +1,142 @@
+#!/usr/bin/env perl
+# Mock-backed REST coverage tests translated from
+# signalwire-python/tests/unit/rest/test_logs_mock.py
+#
+# Success + error coverage for the Logs namespace, which fans out across four
+# spec docs (message/voice/fax/logs):
+#   messages (list/get), voice (list/get), fax (list/get), conferences (list).
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use MockTest;
+
+sub _err {
+    my ($endpoint_id, $status, $code_ref) = @_;
+    MockTest::scenario_set($endpoint_id, $status, { error => 'boom' });
+    my $ok = eval { $code_ref->(); 1 };
+    my $e = $@;
+    ok(!$ok, "raised for $endpoint_id");
+    isa_ok($e, 'SignalWire::REST::HttpClient::Error');
+    is($e->status_code, $status, "status $status for $endpoint_id");
+    my $j = MockTest::journal_last();
+    is($j->{matched_route}, $endpoint_id, "matched route $endpoint_id");
+    is($j->{response_status}, $status, "journaled $status for $endpoint_id");
+}
+
+# -------------------- Message Logs --------------------
+
+subtest 'TestMessageLogs' => sub {
+    subtest 'list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->messages->list();
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/messaging/logs', 'path');
+        is($j->{matched_route}, 'message.list_message_logs', 'matched route');
+    };
+    subtest 'list_error' => sub {
+        my $client = MockTest::client();
+        _err('message.list_message_logs', 500, sub { $client->logs->messages->list() });
+    };
+
+    subtest 'get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->messages->get('ml-42');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/messaging/logs/ml-42', 'path');
+        is($j->{matched_route}, 'message.get_message_log', 'matched route');
+    };
+    subtest 'get_error' => sub {
+        my $client = MockTest::client();
+        _err('message.get_message_log', 404, sub { $client->logs->messages->get('missing') });
+    };
+};
+
+# -------------------- Voice Logs --------------------
+
+subtest 'TestVoiceLogs' => sub {
+    subtest 'list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->voice->list();
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/voice/logs', 'path');
+        is($j->{matched_route}, 'voice.list_voice_logs', 'matched route');
+    };
+    subtest 'list_error' => sub {
+        my $client = MockTest::client();
+        _err('voice.list_voice_logs', 500, sub { $client->logs->voice->list() });
+    };
+
+    subtest 'get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->voice->get('vl-99');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/voice/logs/vl-99', 'path');
+        is($j->{matched_route}, 'voice.get_voice_log', 'matched route');
+    };
+    subtest 'get_error' => sub {
+        my $client = MockTest::client();
+        _err('voice.get_voice_log', 404, sub { $client->logs->voice->get('missing') });
+    };
+};
+
+# -------------------- Fax Logs --------------------
+
+subtest 'TestFaxLogs' => sub {
+    subtest 'list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->fax->list();
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/fax/logs', 'path');
+        is($j->{matched_route}, 'fax.list_fax_logs', 'matched route');
+    };
+    subtest 'list_error' => sub {
+        my $client = MockTest::client();
+        _err('fax.list_fax_logs', 500, sub { $client->logs->fax->list() });
+    };
+
+    subtest 'get' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->fax->get('fl-7');
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/fax/logs/fl-7', 'path');
+        is($j->{matched_route}, 'fax.get_fax_log', 'matched route');
+    };
+    subtest 'get_error' => sub {
+        my $client = MockTest::client();
+        _err('fax.get_fax_log', 404, sub { $client->logs->fax->get('missing') });
+    };
+};
+
+# -------------------- Conference Logs --------------------
+
+subtest 'TestConferenceLogs' => sub {
+    subtest 'list' => sub {
+        my $client = MockTest::client();
+        my $body = $client->logs->conferences->list();
+        is(ref $body, 'HASH', 'hashref');
+        my $j = MockTest::journal_last();
+        is($j->{method}, 'GET', 'GET');
+        is($j->{path}, '/api/logs/conferences', 'path');
+        is($j->{matched_route}, 'logs.list_conferences', 'matched route');
+    };
+    subtest 'list_error' => sub {
+        my $client = MockTest::client();
+        _err('logs.list_conferences', 500, sub { $client->logs->conferences->list() });
+    };
+};
+
+done_testing();


### PR DESCRIPTION
Replicates the python reference REST full-coverage suite to the Perl SDK: a success (2xx) and error (4xx/5xx) test for every canonical REST route the SDK implements, asserting the correct on-the-wire path + journaled `matched_route`.

## Result
- **286/307** coverable routes fully covered (success+error); 21 universal accepted gaps allowlisted.
- All 12 `run-ci.sh` gates green: TEST, SIGNATURES, DRIFT, SURFACE-FRESH, NO-CHEAT, **REST-COVERAGE**, EMISSION, FMT, LINT, DOC-AUDIT, SURFACE-DIFF, SKILL-CONTRACT.

## What's here
- 28 new `t/rest/*_cov.t` files (one per python reference mock), each route with a 2xx success + a 4xx/5xx error case (error paths assert the SDK raises `SignalWire::REST::HttpClient::Error` with the right `status_code` + journaled `matched_route`/`response_status`).
- `REST_COVERAGE_GAPS.md` — the 18 per-port `sdk-gap` entries (matches the other ports); the 3 shared baseline gaps come from `porting-sdk/REST_COVERAGE_BASELINE.md`.
- `scripts/run-ci.sh` — `REST-COVERAGE` gate (after NO-CHEAT): spins its own mock, runs `prove -j1 t/rest/` serially into one journal, then runs porting-sdk's `rest_coverage` checker.

## SDK parity
No SDK methods needed — every non-allowlisted route already had a Perl SDK method on the correct path (full parity confirmed). One pre-existing test (`t/rest/13_fabric_mock.t`) hardened from an absolute-empty-journal assertion to a journal-count delta, to be deterministic against the gate's pre-spawned shared mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau