### PR TITLE
test+ci: dynamic free ports + fail-loud for mock servers

### DIFF
--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -199,24 +199,40 @@ run_gate "NO-CHEAT" "audit_no_cheat_tests" \
 # The mock is pre-spawned here (rather than letting the suite self-spawn on first
 # probe) so the run is deterministic and all REST traffic shares one journal; the
 # suite reuses it via the MOCK_SIGNALWIRE_PORT env + the harness's probe-or-reuse.
+# Pick a free TCP port on 127.0.0.1 (bind :0, read the OS-assigned port,
+# release). Never reuse a hardcoded port — a leftover or concurrent mock
+# squatting a fixed port otherwise makes the gate hang on its health poll.
+pick_free_port() {
+    python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'
+}
 rest_coverage_gate() {
-    local port=8770
+    local port
+    port="$(pick_free_port)" || { echo "could not allocate a free port" >&2; return 1; }
     local mock_pkg_parent="$PORTING_SDK_DIR/test_harness/mock_signalwire"
     export PYTHONPATH="$mock_pkg_parent${PYTHONPATH:+:$PYTHONPATH}"
-    # Clear any stale listener on the port (a crashed prior run), then spawn.
-    lsof -ti :"$port" 2>/dev/null | xargs kill 2>/dev/null || true
     python3 -m mock_signalwire --host 127.0.0.1 --port "$port" --log-level error \
         >/tmp/rest_cov_mock_perl.$$.log 2>&1 &
     local mock_pid=$!
     # shellcheck disable=SC2064
     trap "kill $mock_pid 2>/dev/null" RETURN
-    local i
+    # Fail LOUD if the mock dies mid-startup or never becomes healthy — never hang.
+    local i ready=0
     for i in $(seq 1 60); do
+        if ! kill -0 "$mock_pid" 2>/dev/null; then
+            echo "mock_signalwire died on port $port — log:" >&2
+            cat "/tmp/rest_cov_mock_perl.$$.log" >&2
+            return 1
+        fi
         if python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:$port/__mock__/health',timeout=1)" 2>/dev/null; then
+            ready=1
             break
         fi
         sleep 0.5
     done
+    if [ "$ready" -ne 1 ]; then
+        echo "mock_signalwire on port $port not healthy within 30s" >&2
+        return 1
+    fi
     python3 -c "import urllib.request; urllib.request.urlopen(urllib.request.Request('http://127.0.0.1:$port/__mock__/journal/reset',method='POST'),timeout=5).read()"
     # Run the REST suite serially against this one mock (one shared journal). The
     # harness probes 127.0.0.1:$port (MOCK_SIGNALWIRE_PORT), finds it healthy, and

--- a/t/lib/MockTest.pm
+++ b/t/lib/MockTest.pm
@@ -35,8 +35,15 @@ use SignalWire::REST::RestClient;
 
 our $VERSION = '0.01';
 
-our $PORT = $ENV{MOCK_SIGNALWIRE_PORT} || 8770;
+use PortPicker ();
+
+# Port: MOCK_SIGNALWIRE_PORT (set by the CI gate, which pre-spawns the mock)
+# wins; otherwise pick a FREE port rather than a hardcoded default that would
+# collide with a stale/concurrent mock and hang the suite.
 our $HOST = '127.0.0.1';
+our $PORT = ( $ENV{MOCK_SIGNALWIRE_PORT} && $ENV{MOCK_SIGNALWIRE_PORT} =~ /^[0-9]+$/ )
+    ? $ENV{MOCK_SIGNALWIRE_PORT}
+    : PortPicker::pick_free_port($HOST);
 our $BASE_URL = "http://$HOST:$PORT";
 
 our $TOKEN   = 'test_tok';

--- a/t/lib/PortPicker.pm
+++ b/t/lib/PortPicker.pm
@@ -1,0 +1,28 @@
+package PortPicker;
+
+# Pick free loopback TCP ports by binding to :0 and reading the OS-assigned
+# port. Used by the mock-test harnesses so concurrent runs / leftover mocks
+# never collide on a fixed port (and then hang on a health poll). Mirrors the
+# cross-port contract: never reuse a hardcoded default — pick free instead.
+
+use strict;
+use warnings;
+use IO::Socket::INET ();
+
+our $VERSION = '0.01';
+
+sub pick_free_port {
+    my ($host) = @_;
+    $host = '127.0.0.1' unless defined $host;
+    my $s = IO::Socket::INET->new(
+        LocalAddr => $host,
+        LocalPort => 0,
+        Listen    => 1,
+        ReuseAddr => 1,
+    ) or die "PortPicker: failed to bind $host:0: $!";
+    my $port = $s->sockport;
+    $s->close;
+    return $port;
+}
+
+1;

--- a/t/lib/RelayMockTest.pm
+++ b/t/lib/RelayMockTest.pm
@@ -34,9 +34,18 @@ use SignalWire::Relay::Client;
 
 our $VERSION = '0.01';
 
-our $WS_PORT   = $ENV{MOCK_RELAY_PORT}      || 8780;
-our $HTTP_PORT = $ENV{MOCK_RELAY_HTTP_PORT} || 9780;
+use PortPicker ();
+
+# Ports: env overrides win; otherwise pick FREE ports (WS and HTTP control
+# plane independently) rather than hardcoded defaults that collide with a
+# stale/concurrent mock and hang the suite.
 our $HOST      = '127.0.0.1';
+our $WS_PORT   = ( $ENV{MOCK_RELAY_PORT} && $ENV{MOCK_RELAY_PORT} =~ /^[0-9]+$/ )
+    ? $ENV{MOCK_RELAY_PORT}
+    : PortPicker::pick_free_port($HOST);
+our $HTTP_PORT = ( $ENV{MOCK_RELAY_HTTP_PORT} && $ENV{MOCK_RELAY_HTTP_PORT} =~ /^[0-9]+$/ )
+    ? $ENV{MOCK_RELAY_HTTP_PORT}
+    : PortPicker::pick_free_port($HOST);
 our $WS_URL    = "ws://$HOST:$WS_PORT";
 our $HTTP_URL  = "http://$HOST:$HTTP_PORT";
 our $RELAY_HOST = "$HOST:$WS_PORT";

--- a/t/lib/TlsMockTest.pm
+++ b/t/lib/TlsMockTest.pm
@@ -36,10 +36,18 @@ our $VERSION = '0.01';
 
 # Dedicated TLS ports — distinct from the plaintext mock ports so a TLS test
 # never collides with a concurrently-running plaintext mock.
+use PortPicker ();
+
+# TLS mocks are test-local (spawned + killed in this suite). Env overrides win;
+# otherwise pick FREE ports rather than hardcoded defaults that collide with a
+# stale/concurrent listener.
 our $HOST            = '127.0.0.1';
-our $HTTPS_PORT      = $ENV{MOCK_SIGNALWIRE_TLS_PORT} || 18766;
-our $WSS_PORT        = $ENV{MOCK_RELAY_TLS_WS_PORT}   || 18775;
-our $WSS_HTTP_PORT   = $ENV{MOCK_RELAY_TLS_HTTP_PORT} || 19775;
+our $HTTPS_PORT      = ( $ENV{MOCK_SIGNALWIRE_TLS_PORT} && $ENV{MOCK_SIGNALWIRE_TLS_PORT} =~ /^[0-9]+$/ )
+    ? $ENV{MOCK_SIGNALWIRE_TLS_PORT}   : PortPicker::pick_free_port($HOST);
+our $WSS_PORT        = ( $ENV{MOCK_RELAY_TLS_WS_PORT} && $ENV{MOCK_RELAY_TLS_WS_PORT} =~ /^[0-9]+$/ )
+    ? $ENV{MOCK_RELAY_TLS_WS_PORT}     : PortPicker::pick_free_port($HOST);
+our $WSS_HTTP_PORT   = ( $ENV{MOCK_RELAY_TLS_HTTP_PORT} && $ENV{MOCK_RELAY_TLS_HTTP_PORT} =~ /^[0-9]+$/ )
+    ? $ENV{MOCK_RELAY_TLS_HTTP_PORT}   : PortPicker::pick_free_port($HOST);
 
 our $PROJECT = 'test_proj';
 our $TOKEN   = 'test_tok';


### PR DESCRIPTION
Replace hardcoded mock ports in the REST-COVERAGE gate and the REST/RELAY/TLS test harnesses with OS-assigned free ports (new `t/lib/PortPicker.pm` binding :0; python socket :0 in the gate), and add a fail-loud guard so a dead/never-healthy mock fails the gate instead of hanging. Fixes the java↔perl 8770 collision. Env-var overrides preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau