### PR TITLE
docs+examples: wire-truth W1 burn — play media key, params-wrapped tts, from_ (perl)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ my $client = SignalWire::Relay::Client->new(
 $client->on_call(sub {
     my ($call) = @_;
     $call->answer;
-    $call->play(media => [{ type => 'tts', params => { text => 'Hello!' } }]);
+    $call->play(play => [{ type => 'tts', params => { text => 'Hello!' } }]);
     $call->hangup;
 });
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ $client->on_call(
         my ($call) = @_;
         $call->answer;
         my $action =
-            $call->play( media => [ { type => 'tts', params => { text => 'Welcome!' } } ] );
+            $call->play( play => [ { type => 'tts', params => { text => 'Welcome!' } } ] );
         $action->wait;
         $call->hangup;
     }
@@ -185,8 +185,8 @@ $client->fabric->ai_agents->create(
 );
 
 my $call_id = 'call-id-from-a-prior-request';
-$client->calling->play( $call_id, play => [ { type => 'tts', text => 'Hello!' } ] );
-$client->phone_numbers->search( area_code => '512' );
+$client->calling->play( $call_id, play => [ { type => 'tts', params => { text => 'Hello!' } } ] );
+$client->phone_numbers->search( areacode => '512' );
 $client->datasphere->documents->search( query_string => 'billing policy' );
 
 ```

--- a/examples/relay_answer_and_welcome.pl
+++ b/examples/relay_answer_and_welcome.pl
@@ -28,7 +28,7 @@ $client->on_call(sub {
 
     # Play a welcome message
     my $action = $call->play(
-        media => [{
+        play => [{
             type   => 'tts',
             params => { text => 'Hello! This is a demo of the RELAY client in Perl.' },
         }],
@@ -37,7 +37,7 @@ $client->on_call(sub {
 
     # Say goodbye
     my $bye = $call->play(
-        media => [{
+        play => [{
             type   => 'tts',
             params => { text => 'Thank you for testing. Goodbye!' },
         }],

--- a/examples/rest_demo.pl
+++ b/examples/rest_demo.pl
@@ -44,7 +44,7 @@ if ($numbers) {
 # 2. Search available numbers
 print "\nSearching available numbers...\n";
 safe('Search 512', sub {
-    my $avail = $client->phone_numbers->search(area_code => '512', max_results => 3);
+    my $avail = $client->phone_numbers->search(areacode => '512', max_results => 3);
     for my $n (@{ $avail->{data} // [] }) {
         print "    - " . ($n->{e164} // $n->{number} // 'unknown') . "\n";
     }

--- a/relay/README.md
+++ b/relay/README.md
@@ -19,7 +19,7 @@ $client->on_call(sub {
     my ($call) = @_;
     print "Incoming call: ${\$call->call_id}\n";
     $call->answer;
-    my $action = $call->play(media => [
+    my $action = $call->play(play => [
         { type => 'tts', params => { text => 'Welcome to SignalWire!' } },
     ]);
     $action->wait;

--- a/relay/docs/call-methods.md
+++ b/relay/docs/call-methods.md
@@ -33,7 +33,7 @@ You choose how to handle completion.
 
 ```perl
 my $action = $call->play(
-    media => [ { type => 'tts', params => { text => 'Hello' } } ],
+    play => [ { type => 'tts', params => { text => 'Hello' } } ],
 );
 $action->wait;   # blocks until playback finishes
 # execution continues only after play is done
@@ -43,7 +43,7 @@ $action->wait;   # blocks until playback finishes
 
 ```perl
 my $action = $call->play(
-    media => [ { type => 'tts', params => { text => 'Hello' } } ],
+    play => [ { type => 'tts', params => { text => 'Hello' } } ],
 );
 # don't call $action->wait — continue immediately while audio plays
 $call->send_digits(digits => '1234');
@@ -58,7 +58,7 @@ if ($action->is_done) {
 
 ```perl
 my $action = $call->play(
-    media        => [ { type => 'tts', params => { text => 'Hello' } } ],
+    play         => [ { type => 'tts', params => { text => 'Hello' } } ],
     on_completed => sub {
         my ($a) = @_;
         print "Done in state: ", $a->state, "\n";
@@ -115,7 +115,7 @@ $call->pass;
 
 ## Audio Playback
 
-### `play(media => [...], %opts)`
+### `play(play => [...], %opts)`
 
 Play audio. Returns a Play action with `stop`, `pause`, `resume`,
 `volume($vol)`, and `wait`.
@@ -123,23 +123,23 @@ Play audio. Returns a Play action with `stop`, `pause`, `resume`,
 ```perl
 # TTS
 my $action = $call->play(
-    media => [ { type => 'tts', params => { text => 'Hello!' } } ],
+    play => [ { type => 'tts', params => { text => 'Hello!' } } ],
 );
 $action->wait;
 
 # Audio file
 $call->play(
-    media => [ { type => 'audio', params => { url => 'https://example.com/sound.mp3' } } ],
+    play => [ { type => 'audio', params => { url => 'https://example.com/sound.mp3' } } ],
 );
 
 # Silence
 $call->play(
-    media => [ { type => 'silence', params => { duration => 2 } } ],
+    play => [ { type => 'silence', params => { duration => 2 } } ],
 );
 
 # Ringtone
 $call->play(
-    media => [ { type => 'ringtone', params => { name => 'us' } } ],
+    play => [ { type => 'ringtone', params => { name => 'us' } } ],
 );
 
 # Control playback

--- a/relay/docs/client-reference.md
+++ b/relay/docs/client-reference.md
@@ -190,7 +190,7 @@ $client->unreceive(['old-context']);
 
 <!-- snippet: no-compile illustrative fragment with a list-literal yada-yada elision -->
 ```perl
-my $result = eval { $call->play(media => [ ... ]) };
+my $result = eval { $call->play(play => [ ... ]) };
 if (my $err = $@) {
     warn "play failed: $err";
 }

--- a/relay/docs/events.md
+++ b/relay/docs/events.md
@@ -47,7 +47,7 @@ until the operation completes and returns the terminal event:
 
 ```perl
 my $action = $call->play(
-    media => [ { type => 'tts', params => { text => 'Hello' } } ],
+    play => [ { type => 'tts', params => { text => 'Hello' } } ],
 );
 my $event = $action->wait(timeout => 30);
 # $event is the terminal SignalWire::Relay::Event

--- a/relay/docs/getting-started.md
+++ b/relay/docs/getting-started.md
@@ -56,7 +56,7 @@ $client->on_call(sub {
     my ($call) = @_;
     $call->answer;
     my $action = $call->play(
-        media => [ { type => 'tts', params => { text => 'Hello!' } } ],
+        play => [ { type => 'tts', params => { text => 'Hello!' } } ],
     );
     $action->wait;
     $call->hangup;
@@ -134,7 +134,7 @@ my $call = $client->dial(
 );
 
 my $action = $call->play(
-    media => [ { type => 'tts', params => { text => 'This is an outbound call.' } } ],
+    play => [ { type => 'tts', params => { text => 'This is an outbound call.' } } ],
 );
 $action->wait;
 $call->hangup;

--- a/relay/docs/messaging.md
+++ b/relay/docs/messaging.md
@@ -191,7 +191,7 @@ my $client = SignalWire::Relay::Client->new(
 $client->on_call(sub {
     my ($call) = @_;
     $call->answer;
-    $call->play(media => [ { type => 'tts', params => { text => 'Hello!' } } ]);
+    $call->play(play => [ { type => 'tts', params => { text => 'Hello!' } } ]);
     $call->hangup;
 });
 

--- a/relay/examples/quickstart_relay.pl
+++ b/relay/examples/quickstart_relay.pl
@@ -28,7 +28,7 @@ $client->on_call(
         my ($call) = @_;
         $call->answer;
         my $action =
-            $call->play( media => [ { type => 'tts', params => { text => 'Welcome!' } } ] );
+            $call->play( play => [ { type => 'tts', params => { text => 'Welcome!' } } ] );
         $action->wait;
         $call->hangup;
     }

--- a/relay/examples/relay_answer_and_welcome.pl
+++ b/relay/examples/relay_answer_and_welcome.pl
@@ -24,7 +24,7 @@ $client->on_call(sub {
     $call->answer;
 
     my $action = $call->play(
-        media => [{ type => 'tts', params => { text => 'Welcome to SignalWire!' } }],
+        play => [{ type => 'tts', params => { text => 'Welcome to SignalWire!' } }],
     );
     $action->wait;
 

--- a/relay/examples/relay_dial_and_play.pl
+++ b/relay/examples/relay_dial_and_play.pl
@@ -49,7 +49,7 @@ print "Call answered -- playing TTS\n";
 
 # Play TTS
 my $play_action = $call->play(
-    media => [{ type => 'tts', params => { text => 'Welcome to SignalWire' } }],
+    play => [{ type => 'tts', params => { text => 'Welcome to SignalWire' } }],
 );
 
 # Wait for playback to finish

--- a/relay/examples/relay_ivr_connect.pl
+++ b/relay/examples/relay_ivr_connect.pl
@@ -39,7 +39,7 @@ $client->on_call(sub {
 
     # Play greeting and collect a single digit
     my $collect_action = $call->play_and_collect(
-        media => [
+        play => [
             tts('Welcome to SignalWire!'),
             tts('Press 1 for sales. Press 2 for support. Press 0 to speak with an agent.'),
         ],
@@ -68,21 +68,21 @@ $client->on_call(sub {
     if ($result_type eq 'digit' && $digits eq '1') {
         # Sales
         my $action = $call->play(
-            media => [tts('Thank you for your interest! A sales representative will be with you shortly.')],
+            play => [tts('Thank you for your interest! A sales representative will be with you shortly.')],
         );
         $action->wait;
     }
     elsif ($result_type eq 'digit' && $digits eq '2') {
         # Support
         my $action = $call->play(
-            media => [tts('Please hold while we connect you to our support team.')],
+            play => [tts('Please hold while we connect you to our support team.')],
         );
         $action->wait;
     }
     elsif ($result_type eq 'digit' && $digits eq '0') {
         # Connect to live agent
         my $action = $call->play(
-            media => [tts('Connecting you to an agent now. Please hold.')],
+            play => [tts('Connecting you to an agent now. Please hold.')],
         );
         $action->wait;
 
@@ -111,7 +111,7 @@ $client->on_call(sub {
     else {
         # No input or invalid
         my $action = $call->play(
-            media => [tts("We didn't receive a valid selection.")],
+            play => [tts("We didn't receive a valid selection.")],
         );
         $action->wait;
     }

--- a/rest/README.md
+++ b/rest/README.md
@@ -21,11 +21,11 @@ my $agent = $client->fabric->ai_agents->create(
 );
 
 # Search for a phone number
-my $results = $client->phone_numbers->search(area_code => '512');
+my $results = $client->phone_numbers->search(areacode => '512');
 
 # Place a call via REST
 $client->calling->dial(
-    from_ => '+15559876543',
+    from  => '+15559876543',
     to    => '+15551234567',
     url   => 'https://example.com/call-handler',
 );

--- a/rest/docs/calling.md
+++ b/rest/docs/calling.md
@@ -71,7 +71,7 @@ Play audio, TTS, silence, or ringtone.
 
 ```perl
 $client->calling->play($call_id,
-    play   => [{ type => 'tts', text => 'Hello!' }],
+    play   => [{ type => 'tts', params => { text => 'Hello!' } }],
     volume => 5.0,
 );
 ```

--- a/rest/docs/namespaces.md
+++ b/rest/docs/namespaces.md
@@ -10,7 +10,7 @@ my $numbers = $client->phone_numbers->list;
 $numbers    = $client->phone_numbers->list(name => 'Main');
 
 # Search available numbers to purchase
-my $available = $client->phone_numbers->search(area_code => '512', number_type => 'local');
+my $available = $client->phone_numbers->search(areacode => '512', number_type => 'local');
 
 # Purchase a number
 my $number = $client->phone_numbers->create(number => '+15551234567');

--- a/rest/examples/quickstart_rest.pl
+++ b/rest/examples/quickstart_rest.pl
@@ -29,8 +29,8 @@ $client->fabric->ai_agents->create(
 );
 
 my $call_id = 'call-id-from-a-prior-request';
-$client->calling->play( $call_id, play => [ { type => 'tts', text => 'Hello!' } ] );
-$client->phone_numbers->search( area_code => '512' );
+$client->calling->play( $call_id, play => [ { type => 'tts', params => { text => 'Hello!' } } ] );
+$client->phone_numbers->search( areacode => '512' );
 $client->datasphere->documents->search( query_string => 'billing policy' );
 
 # endregion: construct

--- a/rest/examples/rest_calling_ivr_and_ai.pl
+++ b/rest/examples/rest_calling_ivr_and_ai.pl
@@ -40,7 +40,7 @@ safe('Collect', sub {
     $client->calling->collect(
         $CALL_ID,
         digits => { max => 4, terminators => '#' },
-        play   => [{ type => 'tts', text => 'Enter your PIN followed by pound.' }],
+        play   => [{ type => 'tts', params => { text => 'Enter your PIN followed by pound.' } }],
     );
 });
 safe('Start input timers', sub { $client->calling->collect_start_input_timers($CALL_ID) });

--- a/rest/examples/rest_calling_play_and_record.pl
+++ b/rest/examples/rest_calling_play_and_record.pl
@@ -35,7 +35,7 @@ sub safe {
 print "Dialing outbound call...\n";
 my $call = safe('Dial', sub {
     $client->calling->dial(
-        from_ => '+15559876543',
+        from  => '+15559876543',
         to    => '+15551234567',
         url   => 'https://example.com/call-handler',
     );
@@ -47,7 +47,7 @@ print "  Call initiated: $call_id\n";
 print "\nPlaying TTS on call...\n";
 safe('Play', sub {
     $client->calling->play($call_id,
-        play => [{ type => 'tts', text => 'Welcome to SignalWire.' }]);
+        play => [{ type => 'tts', params => { text => 'Welcome to SignalWire.' } }]);
 });
 
 # 3. Pause, resume, adjust volume, stop playback

--- a/rest/examples/rest_manage_resources.pl
+++ b/rest/examples/rest_manage_resources.pl
@@ -47,7 +47,7 @@ for my $a (@{ $agents->{data} // [] }) {
 # 3. Search for a phone number
 print "\nSearching for available phone numbers...\n";
 my $available = safe('Search numbers', sub {
-    $client->phone_numbers->search(area_code => '512', max_results => 3);
+    $client->phone_numbers->search(areacode => '512', max_results => 3);
 });
 if ($available) {
     for my $num (@{ $available->{data} // [] }) {
@@ -59,7 +59,7 @@ if ($available) {
 print "\nPlacing a test call...\n";
 safe('Dial', sub {
     $client->calling->dial(
-        from_ => '+15559876543',
+        from  => '+15559876543',
         to    => '+15551234567',
         url   => 'https://example.com/call-handler',
     );

--- a/rest/examples/rest_phone_number_management.pl
+++ b/rest/examples/rest_phone_number_management.pl
@@ -31,7 +31,7 @@ sub safe {
 # 1. Search for available phone numbers
 print "Searching available numbers...\n";
 my $available = safe('Search', sub {
-    $client->phone_numbers->search(area_code => '512', max_results => 3);
+    $client->phone_numbers->search(areacode => '512', max_results => 3);
 });
 if ($available) {
     for my $num (@{ $available->{data} // [] }) {

--- a/rest/examples/rest_queues_mfa_and_recordings.pl
+++ b/rest/examples/rest_queues_mfa_and_recordings.pl
@@ -106,7 +106,7 @@ my $request_id;
 safe('MFA SMS', sub {
     my $sms_result = $client->mfa->sms(
         to           => '+15551234567',
-        from_        => '+15559876543',
+        from         => '+15559876543',
         message      => 'Your code is {{code}}',
         token_length => 6,
     );
@@ -119,7 +119,7 @@ print "\nSending MFA voice code...\n";
 safe('MFA call', sub {
     my $voice_result = $client->mfa->call(
         to           => '+15551234567',
-        from_        => '+15559876543',
+        from         => '+15559876543',
         message      => 'Your verification code is {{code}}',
         token_length => 6,
     );

--- a/t/52_rest_phone_binding.t
+++ b/t/52_rest_phone_binding.t
@@ -108,12 +108,12 @@ subtest 'update uses PUT' => sub {
 
 subtest 'search -> /search' => sub {
     my ($pn, $http) = make_pn();
-    $pn->search(area_code => '512');
+    $pn->search(areacode => '512');
     my @calls = @{ $http->calls };
     is(scalar @calls, 1, 'one call');
     is($calls[0]{method}, 'GET',            'GET');
     is($calls[0]{path},   "$BASE/search",   'path');
-    is_deeply($calls[0]{params}, { area_code => '512' }, 'params');
+    is_deeply($calls[0]{params}, { areacode => '512' }, 'params');
 };
 
 # ============================================================

--- a/t/rest/05_small_namespaces.t
+++ b/t/rest/05_small_namespaces.t
@@ -178,11 +178,12 @@ subtest 'TestImportedNumbers' => sub {
 subtest 'TestMfa' => sub {
     subtest 'call' => sub {
         my $client = MockTest::client();
-        # Note Python's `from_=` becomes plain `from_` here; from is reserved
-        # in some languages but Perl is fine with from_.
+        # The wire field is `from` (MfaRequest schema). Python needs the
+        # `from_` escape for its keyword; Perl hash keys don't, so callers
+        # pass the wire name directly.
         my $body = $client->mfa->call(
             to       => '+15551234567',
-            from_    => '+15559876543',
+            from     => '+15559876543',
             message  => 'Your code is {code}',
         );
         is(ref $body, 'HASH', 'response is a hashref');
@@ -192,7 +193,7 @@ subtest 'TestMfa' => sub {
         is($j->{path},   '/api/relay/rest/mfa/call', 'path matches');
         my $sent = $j->{body} || {};
         is($sent->{to},      '+15551234567',          'to forwarded');
-        is($sent->{from_},   '+15559876543',          'from_ forwarded');
+        is($sent->{from},    '+15559876543',          'from forwarded');
         is($sent->{message}, 'Your code is {code}',    'message forwarded');
     };
 };


### PR DESCRIPTION
Wave-1 wire-truth burn for perl (GATE_ENFORCEMENT_PLAN §A1 red list). The SDK passes caller kwargs verbatim to the wire (Relay `Call::play` → `_start_action('calling.play', %opts)`; REST `Calling::_execute` wraps `%args` as `params`; generated resources send `%args` as body/query), so every snippet below shipped a key the server rejects or ignores.

## Fixes (4 classes, 25 files)

1. **RELAY play `media =>` → `play =>`** — the `calling.play` / `calling.play_and_collect` params key is `play` (RELAY_IMPLEMENTATION_GUIDE, Media[]). Fixed: README.md, CLAUDE.md, relay/README.md, relay/docs/{call-methods,getting-started,events,messaging,client-reference}.md, examples/relay_answer_and_welcome.pl, relay/examples/{quickstart_relay,relay_answer_and_welcome,relay_dial_and_play,relay_ivr_connect}.pl.
2. **Flat tts `{type=>'tts', text=>…}` → `{type=>'tts', params=>{text=>…}}`** — media objects carry fields under `params`. Fixed: README.md, rest/docs/calling.md, rest/examples/{quickstart_rest,rest_calling_ivr_and_ai,rest_calling_play_and_record}.pl.
3. **`from_ =>` → `from =>`** — wire field is `from` (calling dial + MfaRequest schemas); `from_` is Python's keyword escape, unneeded in Perl hash keys, so it shipped as a bogus body key. Fixed: rest/README.md, rest/examples/{rest_manage_resources,rest_queues_mfa_and_recordings,rest_calling_play_and_record}.pl; **t/rest/05_small_namespaces.t** asserted `from_` on the wire and now asserts `from`.
4. **`area_code =>` → `areacode =>`** — `search_available_phone_numbers` declares `areacode` (relay-rest openapi). Fixed: README.md, rest/README.md, rest/docs/namespaces.md, examples/rest_demo.pl, rest/examples/{quickstart_rest,rest_manage_resources,rest_phone_number_management}.pl; **t/52_rest_phone_binding.t** now asserts `areacode`.

## Wire proof (strict mock, porting-sdk feat/strict-mocks)

Drove the real `SignalWire::REST::RestClient` at a fresh `mock_signalwire` and read `/__mock__/journal`:
- Fixed shapes (`mfa->call(from=>…)`, `phone_numbers->search(areacode=>…)`, `dial(from=>…)`, `play(play=>[{type=>'tts',params=>{text}}])`): **4/4 entries, zero `wire_violations`**.
- Negative control with the old shapes: `unknown_body_key 'from_'` and `unknown_query_param 'area_code'` flagged — the strict mock catches exactly what these docs used to teach.

## Verification

- `perl -Ilib -c` clean on all 12 touched scripts
- Full suite: `bash scripts/run-tests.sh` — 134 files, 4283 tests, PASS
- `sw-verify perl --gates README-INCLUDE` PASS (README include blocks byte-identical to fixtures); DOC-AUDIT / DOC-LANG-PURITY / DOC-LINKS / PUBLIC-JARGON PASS
- `scripts/run-format.sh` applied pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DbkphxGZfj9bx9uyYDMFp
