### PR TITLE
fix(relay): wait/wait_for must pump the event loop — documented pattern no longer hangs (W1.2 P0)

### DIFF
--- a/lib/SignalWire/Relay/Action.pm
+++ b/lib/SignalWire/Relay/Action.pm
@@ -58,12 +58,24 @@ sub is_done ($self) {
     return $self->completed;
 }
 
-# Blocking wait using select() polling loop
+# Blocking wait: PUMP the event loop until the action completes or the
+# deadline passes. The completion flag only flips when a frame is read and
+# dispatched, and dispatch happens inside the client's _read_once — so a bare
+# sleep here would never see the completing event and the documented pattern
+# (answer; play; $action->wait) would hang the full timeout and return undef.
+# _read_once select()s with its own 0.1s timeout, so this both waits and
+# advances the loop. (Fallback sleep only when no client is attached — e.g. a
+# detached/unit-constructed action — so it never hot-spins.)
 sub wait ( $self, %opts ) {
     my $timeout = $opts{timeout} || 30;
     my $start   = time();
+    my $client  = $self->_client;
     while ( !$self->completed && ( time() - $start ) < $timeout ) {
-        Time::HiRes::sleep(0.1);    # poll every 100ms
+        if ($client) {
+            $client->_read_once;
+        } else {
+            Time::HiRes::sleep(0.1);
+        }
     }
     return $self->result;
 }

--- a/lib/SignalWire/Relay/Call.pm
+++ b/lib/SignalWire/Relay/Call.pm
@@ -233,9 +233,19 @@ sub wait_for ( $self, %opts ) {
     };
     $self->on($listener);
 
-    my $start = time();
+    # PUMP the event loop while waiting: the listener only fires when a frame
+    # is read and dispatched (inside the client's _read_once), so a bare sleep
+    # here would never capture the awaited event and wait_for would hang the
+    # full timeout, returning undef. _read_once select()s with its own 0.1s
+    # timeout. (Fallback sleep only when no client is attached.)
+    my $client = $self->_client;
+    my $start  = time();
     while ( !defined $captured && ( time() - $start ) < $timeout ) {
-        Time::HiRes::sleep(0.05);
+        if ($client) {
+            $client->_read_once;
+        } else {
+            Time::HiRes::sleep(0.05);
+        }
     }
     return $captured;
 }

--- a/t/relay/wait_liveness_mock.t
+++ b/t/relay/wait_liveness_mock.t
@@ -1,0 +1,81 @@
+#!/usr/bin/env perl
+# WAIT-LIVENESS (GATE_ENFORCEMENT_PLAN §B1): the DOCUMENTED wait pattern must
+# COMPLETE, not hang. Before the pump fix, Action::wait / Call::wait_for slept
+# without driving the client's read loop, so the awaited event never arrived —
+# the documented `answer; play; $action->wait` hung the full timeout and
+# returned undef. This test drives the PUBLIC pattern verbatim (NO private
+# _pump_until helper) with a short deadline and asserts it resolves quickly.
+
+use strict;
+use warnings;
+use feature 'signatures';
+no warnings 'experimental::signatures';
+use Test::More;
+use FindBin ();
+use lib "$FindBin::Bin/../lib";
+use Time::HiRes qw(time);
+
+use RelayMockTest;
+use SignalWire::Relay::Client;
+
+my $client = RelayMockTest::client( contexts => ['default'] );
+$client->connect;
+
+my $captured;
+$client->on_call(
+    sub {
+        my ($call) = @_;
+        $captured = $call;
+    }
+);
+
+# Step 1 — deliver ONLY the created state so on_call fires and we get the call
+# object. The 'answered' transition is sent SEPARATELY (step 2) so it can't be
+# consumed before wait_for's listener is registered.
+RelayMockTest::inbound_call(
+    call_id     => 'wl-call-1',
+    auto_states => ['created'],
+);
+
+my $deadline = time() + 2;
+while ( !defined $captured && time() < $deadline ) {
+    $client->_read_once;
+}
+ok( defined $captured, 'on_call delivered the call object' )
+    or BAIL_OUT('no inbound call — mock harness problem, not the wait fix');
+
+# Step 2 — push the 'answered' state event AFTER we hold the call, then call
+# the DOCUMENTED public wait_for. With the pump fix it must resolve via its own
+# internal _read_once; without the fix (bare sleep) it hangs to the timeout and
+# returns undef.
+RelayMockTest::push_frame(
+    {   jsonrpc => '2.0',
+        id      => 'evt-wl-answered',
+        method  => 'signalwire.event',
+        params  => {
+            event_type => 'calling.call.state',
+            params     => {
+                call_id    => 'wl-call-1',
+                call_state => 'answered',
+            },
+        },
+    }
+);
+
+my $wf_start = time();
+my $event    = $captured->wait_for(
+    event_type => 'calling.call.state',
+    predicate  => sub ($e) {
+        my $s = $e->can('call_state') ? $e->call_state : '';
+        return defined $s && $s eq 'answered';
+    },
+    timeout => 3,
+);
+my $elapsed = time() - $wf_start;
+
+ok( defined $event, 'wait_for resolved the answered event (did not hang/undef)' );
+cmp_ok( $elapsed, '<', 2.5,
+    sprintf( 'wait_for completed in %.2fs, well under the 3s timeout', $elapsed ) );
+
+$client->disconnect;
+done_testing;


### PR DESCRIPTION
**Wave-1 §B1 — a real runtime P0 (the DX review's perl hang).**

`Action::wait` and `Call::wait_for` polled a completion flag with a bare `Time::HiRes::sleep` — but that flag only flips when a RELAY frame is **read and dispatched**, and reading happens inside the client's `_read_once`. So while `wait()` slept, no frames were read → the awaited event could never arrive → the documented pattern `answer; play; $action->wait` **hung the full timeout (~30s) and returned undef**. The suite had been dodging this via a private `_pump_until` helper — proof the public path was broken.

**Fix:** both wait loops now drive `$client->_read_once` (which `select()`s with its own 0.1s timeout — it both waits and advances the loop) instead of blank sleeping. Falls back to sleep only when no client is attached (detached/unit-constructed action), so it never hot-spins. Public API unchanged.

**TDD:** `t/relay/wait_liveness_mock.t` drives the **public** `wait_for` verbatim (no `_pump_until`) against mock_relay:
- **RED** on the old code — `wait_for` hangs to the timeout, 2/3 fail, elapsed 2.79s.
- **GREEN** with the fix — 3/3, resolves in <0.1s.

**Verified:** full suite 4286 tests pass · DRIFT + SURFACE-DIFF clean (surface unchanged) · FMT tidy · LINT clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DbkphxGZfj9bx9uyYDMFp