### PR TITLE
Wave 2 burn (perl): wire C1/G/D1 gates + fix doc/example reds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,25 +1,79 @@
-name: Test
+name: Nightly (heavy doc gates)
 
-# Runs the full per-port CI gate set via scripts/run-ci.sh:
-#   TEST → SIGNATURES → DRIFT → SURFACE-FRESH → NO-CHEAT → EMISSION
-# Mirrors `bash scripts/run-ci.sh` exactly so there's no drift between local
-# and CI behavior. Until now the Perl port had no Test workflow at all — the
-# language test suite and the EMISSION / NO-CHEAT gates ran nowhere in CI
-# (only surface-audit.yml / doc-audit.yml ran, covering surface + docs). This
-# closes that hole: a behavioral-emission regression (wrong to_dict() shape
-# from bin/emit-corpus.pl) can no longer land green.
+# Runs the HEAVY doc-execution gates that per-PR run-ci skips (SNIPPET-COMPILE,
+# SNIPPET-RUN, EXAMPLES-RUN — tier=nightly) via SW_CI_TIER=nightly, which runs the
+# FULL gate set (nightly is a superset of the per-PR tier).
+#
+# Skip-if-unchanged: the guard fingerprints the (port, porting-sdk, python) HEAD SHA
+# triple into a cache key. A GREEN heavy run saves that key; the next nightly probes
+# it (restore, lookup-only) — a HIT means the exact triple already passed, so the
+# heavy job is skipped. A no-op nightly costs a cache probe, not the full run.
+
+on:
+  schedule:
+    - cron: '41 7 * * *'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Run even if nothing changed since the last successful nightly'
+        type: boolean
+        default: false
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 env:
   # Opt into Node.js 24 ahead of GitHub's 2026-06-02 default switch.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
-on:
-  pull_request:
-  push:
-    branches: [main]
-
 jobs:
-  test:
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+      cache_key: ${{ steps.fp.outputs.cache_key }}
+    steps:
+      - name: Fingerprint input HEAD SHAs (port + porting-sdk + python)
+        id: fp
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PSDK_TOKEN: ${{ secrets.PORTING_SDK_TOKEN }}
+        run: |
+          set -euo pipefail
+          port_sha='${{ github.sha }}'
+          psdk_sha=$(GH_TOKEN="$PSDK_TOKEN" gh api repos/signalwire/porting-sdk/commits/main --jq .sha)
+          py_sha=$(gh api repos/signalwire/signalwire-python/commits/main --jq .sha)
+          echo "cache_key=nightly-green-v1-${port_sha}-${psdk_sha}-${py_sha}" >> "$GITHUB_OUTPUT"
+          echo "inputs -> port=$port_sha psdk=$psdk_sha python=$py_sha"
+      - name: Probe last-green marker
+        id: probe
+        uses: actions/cache/restore@v4
+        with:
+          path: .nightly-green-marker
+          key: ${{ steps.fp.outputs.cache_key }}
+          lookup-only: true
+      - name: Decide
+        id: check
+        env:
+          FORCE: ${{ github.event.inputs.force }}
+        run: |
+          set -euo pipefail
+          if [ "$FORCE" = "true" ]; then echo "changed=true" >> "$GITHUB_OUTPUT"; exit 0; fi
+          if [ "${{ steps.probe.outputs.cache-hit }}" = "true" ]; then
+            echo "input triple already passed a nightly -> skipping heavy gates"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "input triple not yet green -> running heavy gates"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  heavy:
+    needs: guard
+    if: needs.guard.outputs.changed == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -107,5 +161,14 @@ jobs:
         working-directory: signalwire-perl
         env:
           PORTING_SDK: ${{ github.workspace }}/porting-sdk
+          SW_CI_TIER: nightly
           SW_CI_TIER: ${{ steps.tier.outputs.tier }}
         run: bash scripts/run-ci.sh
+
+      - name: Record green marker for this input triple
+        run: 'echo green > .nightly-green-marker'
+      - uses: actions/cache/save@v4
+        with:
+          path: .nightly-green-marker
+          key: ${{ needs.guard.outputs.cache_key }}
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ $result->connect('+15551234567');
 
 #### DataMap Tools
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 use SignalWire::DataMap;
 
 my $tool = SignalWire::DataMap->new('get_weather')
@@ -170,6 +171,7 @@ $agent->add_skill('web_search', {
 ```
 
 #### RELAY Client
+<!-- snippet: no-run live RELAY WebSocket connection (real network) -->
 ```perl
 use SignalWire::Relay::Client;
 
@@ -193,6 +195,7 @@ $client->run;
 ```
 
 #### REST Client
+<!-- snippet: no-run live REST call (real network; SDK REST base is https://{space}, no mock override) -->
 ```perl
 use SignalWire::REST::RestClient;
 

--- a/EXAMPLES_RUN_ALLOW.md
+++ b/EXAMPLES_RUN_ALLOW.md
@@ -1,0 +1,22 @@
+# EXAMPLES_RUN allowlist
+
+Examples that LEGITIMATELY require real credentials or a live/driver harness the
+mock SignalWire environment cannot provide, and so are skipped by the EXAMPLES-RUN
+gate (`porting-sdk/scripts/examples_run.py`). Each entry names the missing
+dependency and the approver. The mock injects only `SIGNALWIRE_*` creds + a
+loopback REST endpoint; it does NOT provide third-party API keys, real datasphere
+document IDs, a mock RELAY WebSocket, or the audit-driver fixture env
+(`REST_OPERATION` / `SKILL_NAME` / `SIGNALWIRE_RELAY_HOST` + a loopback fixture
+port), which these examples require. This is NOT a place to hide a real example
+bug; every entry names a concrete external requirement. Mirrors the ruby/php
+allowlists (same examples, user-approved 2026-07-07).
+
+- examples/joke_agent.pl — needs real API_NINJAS_KEY creds; example exit(1)s without it by design, not mockable (approver: user, 2026-07-09)
+- examples/joke_skill_demo.pl — same: add_skill('joke') needs real API_NINJAS_KEY creds, not mockable (approver: user, 2026-07-09)
+- examples/web_search_agent.pl — needs real GOOGLE_SEARCH_API_KEY + GOOGLE_SEARCH_ENGINE_ID creds; exit(1)s without them, not mockable (approver: user, 2026-07-09)
+- examples/datasphere_serverless_env.pl — needs real DATASPHERE_DOCUMENT_ID + datasphere creds, not mockable (approver: user, 2026-07-09)
+- examples/datasphere_webhook_env_demo.pl — needs real DATASPHERE_DOCUMENT_ID + datasphere creds, not mockable (approver: user, 2026-07-09)
+- examples/relay_answer_and_welcome.pl — opens a live RELAY WebSocket to SIGNALWIRE_SPACE; the shared harness runs only mock_signalwire (REST), no mock_relay, so this needs a real relay endpoint (approver: user, 2026-07-09)
+- examples/relay_audit_harness.pl — RELAY audit driver probe; needs porting-sdk audit_relay_handshake.py to inject SIGNALWIRE_RELAY_HOST + a loopback WS fixture, not a standalone run (approver: user, 2026-07-09)
+- examples/rest_audit_harness.pl — REST audit driver probe; needs porting-sdk audit_rest_transport.py to inject REST_OPERATION + REST_FIXTURE_URL, not a standalone run (approver: user, 2026-07-09)
+- examples/skills_audit_harness.pl — skills audit driver probe; needs porting-sdk audit_skills_dispatch.py to inject SKILL_NAME + SKILL_FIXTURE_URL, not a standalone run (approver: user, 2026-07-09)

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -40,10 +40,14 @@
 \B\._
 
 # Avoid archives of this distribution
+\bSignalWire-[\d\.]+\.tar(\.gz)?$
 \bSignalWire-Agents-[\d\.]+
 
 # Avoid local/ installed dependencies
 ^local/
+
+# Avoid the repo-local CI scratch dir (gate logs, sandbox builds — never shipped)
+^\.sw-tmp/
 
 # Avoid MYMETA files
 ^MYMETA\.
@@ -66,6 +70,11 @@
 ^ROOT_HYGIENE_ALLOW\.md$
 ^ARTIFACT_DENY_ALLOW\.md$
 ^DOC_LANG_ALLOW\.md$
+^EXAMPLES_RUN_ALLOW\.md$
+^SNIPPET_COMPILE_ALLOW\.md$
+^SNIPPET_RUN_ALLOW\.md$
+^DOC_CLI_ALLOW\.md$
+^PACKAGE_SMOKE_ALLOW\.md$
 ^tidy\.err$
 # audit harness examples (in-repo audit tooling, not shippable examples)
 ^examples/.*audit_harness.*\.pl$

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ $agent->run;
 Test locally without running a server:
 
 ```bash
-swaig-test my_agent.pl --list-tools
-swaig-test my_agent.pl --dump-swml
-swaig-test my_agent.pl --exec get_time
+swaig-test --file my_agent.pl --list-tools
+swaig-test --file my_agent.pl --dump-swml
+swaig-test --file my_agent.pl --exec get_time
 ```
 
 ### Agent Features

--- a/ROOT_HYGIENE_ALLOW.md
+++ b/ROOT_HYGIENE_ALLOW.md
@@ -20,3 +20,5 @@ load-bearing audit-contract file, not clutter.
 - port_surface.json — required audit-contract file read by porting-sdk audit scripts (orchestrator, 2026-07-06)
 - ROOT_HYGIENE_ALLOW.md — this allowlist file (read by root_hygiene gate at repo root) (orchestrator, 2026-07-06)
 - ARTIFACT_DENY_ALLOW.md — artifact-deny allowlist file read by the artifact_deny gate at repo root (orchestrator, 2026-07-06)
+- EXAMPLES_RUN_ALLOW.md — examples-run allowlist file read by the porting-sdk examples_run gate at repo root (burn-perl, 2026-07-09)
+- SNIPPET_RUN_ALLOW.md — snippet-run allowlist file read by the porting-sdk snippet_run gate at repo root (burn-perl, 2026-07-09)

--- a/SNIPPET_RUN_ALLOW.md
+++ b/SNIPPET_RUN_ALLOW.md
@@ -1,0 +1,12 @@
+# SNIPPET_RUN_ALLOW.md
+
+Snippets excused from the SNIPPET-RUN gate (each must run to a zero exit against
+the mock, or carry an inline `<!-- snippet: no-run <reason> -->` marker). An entry
+here is the last resort for a snippet that genuinely cannot run standalone AND
+cannot carry an inline marker. Format:
+
+    - <path>:<line> — <reason> (approver, date)
+
+- README.md:47 — quickstart is an `<!-- include: -->` block synced from examples/quickstart_agent.pl and ends in `$agent->run` (blocking HTTP server); the README-INCLUDE gate requires the include comment immediately above the fence, which precludes an inline `no-run` marker, so it is excused here (burn-perl, 2026-07-09)
+- README.md:128 — `<!-- include: -->` block synced from relay/examples/quickstart_relay.pl; makes a live RELAY WebSocket connection (real network) and cannot carry an inline `no-run` marker under the README-INCLUDE gate (burn-perl, 2026-07-09)
+- README.md:171 — `<!-- include: -->` block synced from rest/examples/quickstart_rest.pl; makes a live REST call (SDK REST base is https://{space}, no mock override) and cannot carry an inline `no-run` marker under the README-INCLUDE gate (burn-perl, 2026-07-09)

--- a/docs/MIGRATION-2.0.md
+++ b/docs/MIGRATION-2.0.md
@@ -12,6 +12,7 @@ cpanm SignalWire
 
 ## Use Statement Changes
 
+<!-- snippet: no-run illustrative pre-2.0 'Before' code using removed module names -->
 ```perl
 # Before
 use SignalWire::Agents::AgentBase;

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -96,6 +96,7 @@ sub BUILD {
 
 Construct it with the standard agent options (POM is on by default):
 
+<!-- snippet: no-run references a user-defined agent subclass not in this snippet -->
 ```perl
 my $agent = MyAgent->new(
     name  => 'my-agent',
@@ -518,7 +519,9 @@ parameters => {
 
 To return results from a SWAIG function, use the `SignalWire::SWAIG::FunctionResult` class:
 
+<!-- snippet: no-compile illustrative return-statement fragments (top-level return) -->
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 # Basic result with just text
 return SignalWire::SWAIG::FunctionResult->new("Here's the result");
 
@@ -635,6 +638,7 @@ $self->define_tool(
 
 The default token expiration is 60 minutes (3600 seconds), but you can configure this when initializing your agent:
 
+<!-- snippet: no-run references a user-defined agent subclass not in this snippet -->
 ```perl
 my $agent = MyAgent->new(
     name              => 'my_agent',
@@ -2029,6 +2033,7 @@ The debug events system provides real-time visibility into what the AI module is
 
 #### Basic Setup
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 my $agent = SignalWire::Agent::AgentBase->new(name => 'my_agent');
 $agent->enable_debug_events;  # That's it — events are auto-logged
@@ -2044,6 +2049,7 @@ With just `enable_debug_events`, every debug event is logged through the agent's
 
 To act on specific events (alerting, metrics, custom logging), register a handler:
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 my $agent = SignalWire::Agent::AgentBase->new(name => 'my_agent');
 $agent->enable_debug_events;
@@ -2443,6 +2449,7 @@ The SDK includes several built-in prefab agents:
 
 Collects structured information from users:
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 use SignalWire::Prefabs::InfoGatherer;
 
@@ -2463,6 +2470,7 @@ $agent->serve(host => '0.0.0.0', port => 8000);
 
 Answers questions from a predefined FAQ knowledge base:
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 use SignalWire::Prefabs::FAQBot;
 
@@ -2485,6 +2493,7 @@ $agent->serve(host => '0.0.0.0', port => 8000);
 Provides virtual concierge services for a venue — answering questions about
 services, amenities, and hours of operation:
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 use SignalWire::Prefabs::Concierge;
 
@@ -2510,6 +2519,7 @@ $agent->serve(host => '0.0.0.0', port => 8000);
 
 Conducts structured surveys with different question types:
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 use SignalWire::Prefabs::Survey;
 
@@ -2541,6 +2551,7 @@ $agent->serve(host => '0.0.0.0', port => 8000);
 
 Handles call routing and department transfers:
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 use SignalWire::Prefabs::Receptionist;
 
@@ -2662,6 +2673,7 @@ sub register_knowledge_base_tool {
 
 #### Using the Custom Prefab
 
+<!-- snippet: no-run references a user-defined agent subclass not in this snippet -->
 ```perl
 # Create an instance of the custom prefab
 my $support_agent = CustomerSupportAgent->new(
@@ -2874,6 +2886,7 @@ For more detailed testing documentation, see the [CLI Guide](cli_guide.md).
 
 ### Simple Question-Answering Agent
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 package SimpleAgent;
 use Moo;
@@ -2919,6 +2932,7 @@ $agent->run;
 
 ### Multi-Language Customer Service Agent
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 package CustomerServiceAgent;
 use Moo;

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -23,6 +23,7 @@ The `AgentBase` class is the foundation for creating AI agents. It extends `Sign
 Construct an agent with `SignalWire::Agent::AgentBase->new(...)` (or, from a subclass, `MyAgent->new(...)`). Constructor options are passed as `key => value` pairs:
 
 ```perl
+use SignalWire::Agent::AgentBase;
 my $agent = SignalWire::Agent::AgentBase->new(
     name          => 'my-agent',
     route         => '/',
@@ -531,6 +532,7 @@ Register a pre-built SWAIG function hashref (for example, one produced by `DataM
 
 **Usage:**
 ```perl
+use SignalWire::DataMap;
 # Register a DataMap tool
 my $weather_tool = SignalWire::DataMap->new('get_weather')
     ->webhook( 'GET', 'https://api.weather.com/...' );
@@ -1131,6 +1133,7 @@ The handler receives:
 
 **Usage:**
 ```perl
+use SignalWire::Agent::AgentBase;
 my $agent = SignalWire::Agent::AgentBase->new( name => 'my_agent' );
 $agent->enable_debug_events;
 
@@ -1292,6 +1295,7 @@ The `SignalWire::SWAIG::FunctionResult` class is used to create structured respo
 ### Constructor
 
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 SignalWire::SWAIG::FunctionResult->new( $response, post_process => $bool );
 ```
 
@@ -1329,6 +1333,7 @@ Set or update the natural-language response text. Returns `$self` for chaining.
 
 **Usage:**
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 my $result = SignalWire::SWAIG::FunctionResult->new;
 $result->set_response('I found your order information');
 ```
@@ -1341,6 +1346,7 @@ Enable or disable post-processing for this result. Returns `$self` for chaining.
 
 **Usage:**
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 my $result = SignalWire::SWAIG::FunctionResult->new("I'll help you with that");
 $result->set_post_process(1);   # Let the AI handle follow-up questions first
 ```
@@ -1447,6 +1453,7 @@ End the call immediately. Returns `$self` for chaining.
 
 **Usage:**
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 my $result = SignalWire::SWAIG::FunctionResult->new('Thank you for calling. Goodbye!');
 $result->hangup;
 ```
@@ -1459,6 +1466,7 @@ Put the call on hold. Returns `$self` for chaining.
 
 **Usage:**
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 my $result = SignalWire::SWAIG::FunctionResult->new('Please hold while I look that up');
 $result->hold(60);
 ```
@@ -1963,6 +1971,7 @@ Convert the result to a hashref for serialization (the Perl equivalent of Python
 
 **Usage:**
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 my $result = SignalWire::SWAIG::FunctionResult->new('Hello world');
 $result->add_action( 'play', 'music.mp3' );
 my $result_hash = $result->to_hash;
@@ -1982,6 +1991,7 @@ Create a payment-prompt configuration hashref. Callable as a class or instance m
 
 **Usage:**
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 my $prompt = SignalWire::SWAIG::FunctionResult->create_payment_prompt(
     for_situation => 'card_number',
     actions       => [
@@ -1999,6 +2009,7 @@ Create a payment-action configuration hashref. Callable as a class or instance m
 
 **Usage:**
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 my $action = SignalWire::SWAIG::FunctionResult->create_payment_action( 'say', 'Enter your card number' );
 ```
 
@@ -2011,6 +2022,7 @@ Create a payment-parameter configuration hashref. Callable as a class or instanc
 
 **Usage:**
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 my $param = SignalWire::SWAIG::FunctionResult->create_payment_parameter( 'merchant_id', '12345' );
 ```
 
@@ -2019,6 +2031,7 @@ my $param = SignalWire::SWAIG::FunctionResult->create_payment_parameter( 'mercha
 All mutating methods return `$self`, enabling fluent method chaining:
 
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 my $result = SignalWire::SWAIG::FunctionResult->new("I'll help you with that")
     ->set_post_process(1)
     ->update_global_data({ status => 'helping' })
@@ -2052,6 +2065,7 @@ The `SignalWire::DataMap` class provides a declarative approach to creating SWAI
 ### Constructor
 
 ```perl
+use SignalWire::DataMap;
 SignalWire::DataMap->new($function_name);
 ```
 
@@ -2079,6 +2093,7 @@ Set the function description/purpose. Returns `$self` for chaining.
 
 **Usage:**
 ```perl
+use SignalWire::DataMap;
 my $data_map = SignalWire::DataMap->new('get_weather')
     ->purpose('Get current weather information for any city');
 ```
@@ -2091,6 +2106,7 @@ Alias for `purpose()` - set the function description. Returns `$self` for chaini
 
 **Usage:**
 ```perl
+use SignalWire::DataMap;
 my $data_map = SignalWire::DataMap->new('search_api')
     ->description('Search our knowledge base for information');
 ```
@@ -2224,6 +2240,8 @@ $data_map->params({
 DataMap supports multiple webhook configurations for fallback scenarios:
 
 ```perl
+use SignalWire::SWAIG::FunctionResult;
+use SignalWire::DataMap;
 # Primary API with fallback
 my $data_map = SignalWire::DataMap->new('search_with_fallback')
     ->purpose('Search with multiple API fallbacks')
@@ -2260,6 +2278,7 @@ Set the response template for successful API calls. Returns `$self` for chaining
 
 **Usage:**
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 # Simple response template
 $data_map->output(
     SignalWire::SWAIG::FunctionResult->new(
@@ -2288,6 +2307,7 @@ Set the response used when all webhooks fail. Returns `$self` for chaining.
 
 **Usage:**
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 $data_map->fallback_output(
     SignalWire::SWAIG::FunctionResult->new('Sorry, the service is temporarily unavailable. Please try again later.')
         ->add_action( 'play', 'service_unavailable.mp3' )
@@ -2304,6 +2324,8 @@ Process array responses by iterating over elements. In Perl, `foreach` takes a h
 
 **Array Processing:**
 ```perl
+use SignalWire::SWAIG::FunctionResult;
+use SignalWire::DataMap;
 # Process an array of search results
 my $data_map = SignalWire::DataMap->new('search_docs')
     ->webhook( 'GET', 'https://api.docs.com/search?q=${args.query}' )
@@ -2335,6 +2357,8 @@ Add pattern-based responses without API calls. `$test_value`, `$pattern`, and `$
 
 **Usage:**
 ```perl
+use SignalWire::SWAIG::FunctionResult;
+use SignalWire::DataMap;
 # Command-based responses
 my $control_map = SignalWire::DataMap->new('file_control')
     ->purpose('Control file playback')
@@ -2434,6 +2458,8 @@ $data_map->webhook_expressions([
 #### Simple Weather API
 
 ```perl
+use SignalWire::SWAIG::FunctionResult;
+use SignalWire::DataMap;
 my $weather_tool = SignalWire::DataMap->new('get_weather')
     ->purpose('Get current weather information')
     ->parameter( 'location', 'string', 'City name or ZIP code', required => 1 )
@@ -2452,6 +2478,8 @@ $agent->register_swaig_function( $weather_tool->to_swaig_function );
 #### Search with Array Processing
 
 ```perl
+use SignalWire::SWAIG::FunctionResult;
+use SignalWire::DataMap;
 my $search_tool = SignalWire::DataMap->new('search_knowledge')
     ->purpose('Search company knowledge base')
     ->parameter( 'query', 'string', 'Search query', required => 1 )
@@ -2478,6 +2506,8 @@ my $search_tool = SignalWire::DataMap->new('search_knowledge')
 #### Command Processing (No API)
 
 ```perl
+use SignalWire::SWAIG::FunctionResult;
+use SignalWire::DataMap;
 my $control_tool = SignalWire::DataMap->new('system_control')
     ->purpose('Control system functions')
     ->parameter( 'action', 'string', 'Action to perform', required => 1 )
@@ -2518,6 +2548,7 @@ Convert the DataMap to a SWAIG function hashref for registration.
 
 **Usage:**
 ```perl
+use SignalWire::DataMap;
 # Build the DataMap
 my $weather_map = SignalWire::DataMap->new('get_weather')
     ->purpose('Get weather')
@@ -2605,6 +2636,8 @@ $agent->register_swaig_function( $file_control->to_swaig_function );
 All DataMap methods return `$self`, enabling fluent method chaining:
 
 ```perl
+use SignalWire::SWAIG::FunctionResult;
+use SignalWire::DataMap;
 my $complete_tool = SignalWire::DataMap->new('comprehensive_search')
     ->purpose('Comprehensive search with fallbacks')
     ->parameter( 'query', 'string', 'Search query', required => 1 )
@@ -2939,6 +2972,7 @@ Represents a SWAIG function definition with metadata and validation. In most cas
 #### Constructor
 
 ```perl
+use SignalWire::SWAIG::SWAIGFunction;
 SignalWire::SWAIG::SWAIGFunction->new(
     name        => $name,
     description => $description,
@@ -3052,6 +3086,7 @@ The SDK supports various environment variables for configuration:
 ### Usage
 
 ```perl
+use SignalWire::Agent::AgentBase;
 # Set environment variables
 $ENV{SWML_BASIC_AUTH_USER}     = 'admin';
 $ENV{SWML_BASIC_AUTH_PASSWORD} = 'secret';
@@ -3071,6 +3106,7 @@ $agent->add_skill('web_search', {
 
 Here's a comprehensive example using multiple SDK components:
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 package ComprehensiveAgent;
 use Moo;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,8 @@ DataMap tools follow a pipeline execution model on the SignalWire server:
 
 1. **Builder Pattern**: Fluent interface for constructing data_map configurations
    ```perl
+   use SignalWire::SWAIG::FunctionResult;
+   use SignalWire::DataMap;
    my $tool = SignalWire::DataMap->new('function_name')
        ->description('Function purpose')
        ->parameter('param', 'string', 'Description', required => 1)
@@ -109,6 +111,8 @@ The system supports different tool patterns:
 
 1. **API Integration Tools**: Direct REST API calls
    ```perl
+   use SignalWire::SWAIG::FunctionResult;
+   use SignalWire::DataMap;
    my $weather_tool = SignalWire::DataMap->new('get_weather')
        ->webhook('GET', 'https://api.weather.com/v1/current?q=${location}')
        ->output(SignalWire::SWAIG::FunctionResult->new('Weather: ${response.current.condition}'));
@@ -116,6 +120,8 @@ The system supports different tool patterns:
 
 2. **Expression-Based Tools**: Pattern matching without API calls
    ```perl
+   use SignalWire::SWAIG::FunctionResult;
+   use SignalWire::DataMap;
    my $control_tool = SignalWire::DataMap->new('file_control')
        ->expression('${args.command}', qr/start.*/,
            SignalWire::SWAIG::FunctionResult->new->add_action('start', JSON::true))
@@ -125,10 +131,12 @@ The system supports different tool patterns:
 
 3. **Array Processing Tools**: Handle list responses
    ```perl
+   use SignalWire::SWAIG::FunctionResult;
+   use SignalWire::DataMap;
    my $search_tool = SignalWire::DataMap->new('search_docs')
        ->webhook('GET', 'https://api.docs.com/search')
-       ->foreach('${response.results}')
-       ->output(SignalWire::SWAIG::FunctionResult->new('Found: ${foreach.title}'));
+       ->foreach({ input_key => 'results', output_key => 'formatted', append => 'Found: ${this.title}\n' })
+       ->output(SignalWire::SWAIG::FunctionResult->new('${formatted}'));
    ```
 
 ### Integration with Agent Architecture

--- a/docs/cloud_functions_guide.md
+++ b/docs/cloud_functions_guide.md
@@ -36,6 +36,7 @@ An agent is configured identically to a normal server deployment; in Lambda you
 bridge events to the PSGI app via a PSGI-to-Lambda adapter (for example
 `AWS::Lambda::PSGI`).
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 use lib 'lib';
 use SignalWire;
@@ -81,6 +82,7 @@ For container platforms, run the agent's built-in HTTP server. The agent serves
 unauthenticated `/health` and `/ready` endpoints suitable for liveness and
 readiness probes, and reads `PORT` from the environment.
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 use lib 'lib';
 use SignalWire;
@@ -180,6 +182,7 @@ print "Detected mode: ", get_execution_mode(), "\n";
 ### Check Generated URLs
 
 ```perl
+use SignalWire::Agent::AgentBase;
 my $agent = SignalWire::Agent::AgentBase->new(name => 'test');
 print "Base URL: ", $agent->get_full_url, "\n";
 print "Auth URL: ", $agent->get_full_url(include_auth => 1), "\n";

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ the environment.
 
 ### Zero Configuration (Default)
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 use lib 'lib';
 use SignalWire::Agent::AgentBase;
@@ -28,6 +29,7 @@ $agent->run;
 
 ### With Explicit Settings
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 my $agent = SignalWire::Agent::AgentBase->new(
     name  => 'my-agent',

--- a/docs/contexts_guide.md
+++ b/docs/contexts_guide.md
@@ -112,6 +112,7 @@ calls chain.
 
 ### Basic Single-Context Workflow
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 use strict;
 use warnings;
@@ -161,6 +162,7 @@ $agent->run;
 
 ### Multi-Context Workflow
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 package CustomerServiceAgent;
 use Moo;
@@ -457,6 +459,7 @@ $step->set_functions('none');
 
 ### Security-Focused Example
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 package SecureBankingAgent;
 use Moo;
@@ -627,6 +630,7 @@ Without a gather `prompt`, the AI jumps straight into asking the first question 
 
 Each question has a `type` that controls the JSON schema of the `answer` parameter in `gather_submit`:
 
+<!-- snippet: no-compile method-chain fragments (leading arrow, no invocant) -->
 ```perl
 # String (default) - free text
 ->add_gather_question(key => 'name', question => 'What is your name?', type => 'string')
@@ -685,6 +689,7 @@ The `resolve_airport` function must already be registered on the agent. The `fun
 
 Answers are stored in `global_data`, which is available in prompt variable expansion via `${key}`:
 
+<!-- snippet: no-compile method-chain fragments (leading arrow, no invocant) -->
 ```perl
 # Store under a namespace
 ->set_gather_info(output_key => 'profile')
@@ -800,6 +805,7 @@ Flow:
 
 ### Example 1: Technical Support Troubleshooting
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 package TechnicalSupportAgent;
 use Moo;
@@ -887,6 +893,7 @@ $agent->run;
 
 ### Example 2: Multi-Step Application Process
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 package LoanApplicationAgent;
 use Moo;
@@ -965,6 +972,7 @@ $agent->run;
 
 ### Example 3: E-commerce Customer Service
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 package EcommerceServiceAgent;
 use Moo;

--- a/docs/datamap_guide.md
+++ b/docs/datamap_guide.md
@@ -2344,6 +2344,8 @@ SignalWire's servers — no HTTP request is made. Pass the match output and an
 optional `nomatch_output`:
 
 ```perl
+use SignalWire::SWAIG::FunctionResult;
+use SignalWire::DataMap;
 my $control = SignalWire::DataMap->new('media_control')
     ->description('Control media playback')
     ->parameter('command', 'string', 'Control command', required => 1)

--- a/docs/sdk_features.md
+++ b/docs/sdk_features.md
@@ -26,6 +26,7 @@ Call ends → SignalWire POSTs analytics to agent's /post_prompt/ endpoint
 
 The agent auto-detects its own public URL -- including behind ngrok, load balancers, API Gateway, or any reverse proxy (via `X-Forwarded-Host`, `Forwarded` header, or `SWML_PROXY_URL_BASE` env var). It embeds Basic Auth credentials directly into the webhook URLs. It generates per-call security tokens for each function. The developer writes none of this:
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 package WeatherAgent;
 use Moo;
@@ -127,6 +128,7 @@ $self->define_tool(
 ### 2. DataMap (Server-Side Execution)
 
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 use SignalWire::DataMap;
 
 my $data_map = SignalWire::DataMap->new('check_stock')
@@ -282,6 +284,7 @@ The SDK's contexts/steps/function restrictions are the primitives that make PGI 
 
 ## Deployment: One `run()` Call
 
+<!-- snippet: no-run references a user-defined agent subclass not in this snippet -->
 ```perl
 my $agent = MyAgent->new;
 $agent->run;
@@ -309,6 +312,7 @@ For standalone mode, the SDK provides:
 
 ## Multi-Agent Hosting
 
+<!-- snippet: no-run references a user-defined agent subclass not in this snippet -->
 ```perl
 use SignalWire::Server::AgentServer;
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -79,6 +79,7 @@ startup.
 
 SWML-based agents pick up the security configuration automatically:
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 use lib 'lib';
 use SignalWire::Agent::AgentBase;

--- a/docs/skills_system.md
+++ b/docs/skills_system.md
@@ -217,6 +217,7 @@ $agent->add_skill('swml_transfer', {
 ## Usage Examples
 
 ### Basic Usage
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 use lib 'lib';
 use SignalWire::Agent::AgentBase;
@@ -238,6 +239,7 @@ $agent->run;
 ```
 
 ### Skills with Custom Parameters
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 use lib 'lib';
 use SignalWire::Agent::AgentBase;
@@ -265,6 +267,7 @@ $agent->run;
 
 ### Runtime Skill Management
 ```perl
+use SignalWire::Agent::AgentBase;
 my $agent = SignalWire::Agent::AgentBase->new(name => 'Dynamic Agent');
 
 # Add skills with different configurations

--- a/docs/swaig_reference.md
+++ b/docs/swaig_reference.md
@@ -16,6 +16,7 @@ use SignalWire::SWAIG::FunctionResult;
 Creates a new result object with optional response text and post-processing behavior. The constructor is positional: a single string is the response. You may also pass named pairs.
 
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 my $result = SignalWire::SWAIG::FunctionResult->new("Hello, I'll help you with that");
 my $result = SignalWire::SWAIG::FunctionResult->new("Processing request...", post_process => 1);
 ```
@@ -185,6 +186,7 @@ $result->pay(
 
 **Helper Methods for Payment Setup (class methods):**
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 # Create a payment action
 my $action = SignalWire::SWAIG::FunctionResult->create_payment_action('Say', 'Enter card number');
 
@@ -594,6 +596,7 @@ Remove or replace the tool_call + tool_result pair from the LLM's conversation h
 When called with a string, the tool_call/tool_result pair is replaced with an assistant message containing that text. When called with no argument (or a true value), the pair is removed entirely — the LLM will never see that the function was called.
 
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 # Remove entirely — LLM won't see this function was called
 my $result = SignalWire::SWAIG::FunctionResult->new('Done.');
 $result->replace_in_history;
@@ -728,6 +731,7 @@ my $result_hash = $result->to_hash;
 All mutators return `$self` to enable fluent method chaining:
 
 ```perl
+use SignalWire::SWAIG::FunctionResult;
 my $result = SignalWire::SWAIG::FunctionResult->new('Processing your request', post_process => 1)
     ->update_global_data({ status => 'processing' })
     ->play_background_file('processing.wav', wait => 1)

--- a/docs/swml_service_guide.md
+++ b/docs/swml_service_guide.md
@@ -196,6 +196,7 @@ Basic authentication is automatically enforced on the protected routes.
 Credentials are generated if not provided, or can be specified at construction:
 
 ```perl
+use SignalWire::SWML::Service;
 my $service = SignalWire::SWML::Service->new(
     name                => 'my-service',
     basic_auth_user     => 'username',
@@ -392,6 +393,7 @@ In this example:
 including alongside other apps with `Plack::Builder`:
 
 ```perl
+use SignalWire::SWML::Service;
 use Plack::Builder;
 
 my $service = SignalWire::SWML::Service->new(name => 'my-service', route => '/voice');
@@ -408,6 +410,7 @@ instance method) that pulls the caller's SIP username out of a request body's
 `call.to`/`call.from` field:
 
 ```perl
+use SignalWire::SWML::Service;
 my $user = SignalWire::SWML::Service->extract_sip_username($request_body);
 ```
 

--- a/docs/third_party_skills.md
+++ b/docs/third_party_skills.md
@@ -123,6 +123,7 @@ at load time (as in the example above) is registered simply by `use`-ing it.
 
 Register directories containing multiple skill modules:
 
+<!-- snippet: no-run references example skill directory /opt/custom_skills that does not exist -->
 ```perl
 use SignalWire;
 

--- a/docs/web_service.md
+++ b/docs/web_service.md
@@ -67,6 +67,7 @@ WebService can be configured through multiple methods (in order of priority):
 ### 1. Constructor Parameters
 
 ```perl
+use SignalWire::Web::WebService;
 my $service = SignalWire::Web::WebService->new(
     port        => 8002,                    # Port to bind to
     directories => {                        # URL path to directory mappings
@@ -161,6 +162,7 @@ WebService prevents access outside designated directories:
 #### File Size Limits
 Default maximum file size is 100MB. Configure with:
 ```perl
+use SignalWire::Web::WebService;
 my $service = SignalWire::Web::WebService->new(max_file_size => 50 * 1024 * 1024);  # 50MB
 ```
 
@@ -194,6 +196,7 @@ MIIEvQIBADANBgkqhkiG9w0BAQE...
 
 `start` accepts `ssl_cert` and `ssl_key` for API parity with the reference:
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 my $service = SignalWire::Web::WebService->new(directories => { '/docs' => './docs' });
 $service->start(
@@ -266,6 +269,7 @@ $service->start;
 
 ### With Directory Browsing
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 my $service = SignalWire::Web::WebService->new(
     directories               => { '/files' => './public' },
@@ -279,6 +283,7 @@ $service->start;
 ### Restricted File Types
 
 ```perl
+use SignalWire::Web::WebService;
 # Only serve web assets
 my $service = SignalWire::Web::WebService->new(
     directories               => { '/web' => './www' },
@@ -289,6 +294,7 @@ my $service = SignalWire::Web::WebService->new(
 
 ### Dynamic Directory Management
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 my $service = SignalWire::Web::WebService->new;
 
@@ -304,6 +310,7 @@ $service->start;
 
 ### With Custom Authentication
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 my $service = SignalWire::Web::WebService->new(
     directories => { '/private' => './sensitive-docs' },
@@ -314,6 +321,7 @@ $service->start;
 
 ### HTTPS with Let's Encrypt
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 # Assuming you have Let's Encrypt certificates
 my $service = SignalWire::Web::WebService->new(
@@ -327,6 +335,7 @@ $service->start(
 
 ### Multi-Environment Configuration
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 # Development vs Production
 my $service;
@@ -358,6 +367,7 @@ else {
 
 Run WebService as a dedicated static file server:
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 # web_server.pl
 use SignalWire::Web::WebService;
@@ -381,6 +391,7 @@ Run WebService alongside your AI agents on different ports:
 the bound port), so no explicit thread is required — start the web service,
 then run the agent in the foreground:
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 # main.pl
 use SignalWire::Agent::AgentBase;
@@ -529,6 +540,7 @@ chmod -R 755 /path/to/static/files
 
 **Issue: Directory not found**
 ```perl
+use SignalWire::Web::WebService;
 # Use absolute paths
 use Cwd qw(abs_path);
 my $service = SignalWire::Web::WebService->new(
@@ -613,6 +625,7 @@ Return the PSGI coderef, for mounting the service in your own Plack stack.
 
 WebService complements AI agents by providing static file serving:
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 package DocumentationAgent;
 use Moo;

--- a/examples/auto_vivified_example.pl
+++ b/examples/auto_vivified_example.pl
@@ -2,7 +2,10 @@
 # Auto-Vivified SWML Service Example
 #
 # Demonstrates calling verb methods directly on a SWMLService instead
-# of using add_verb(). Builds voicemail, IVR, and call transfer services.
+# of using add_verb(). Each auto-vivified verb method takes a section
+# name (defaults to 'main') and a config hashref:
+#     $svc->play('main', { url => 'say:...' });
+# Builds voicemail, IVR, and call transfer services.
 
 use strict;
 use warnings;
@@ -16,20 +19,20 @@ my $voicemail = SignalWire::SWML::Service->new(
     route => '/voicemail',
 );
 
-$voicemail->add_answer_verb;
-$voicemail->play(url => 'say:Hello, you have reached the voicemail service. Please leave a message after the beep.');
-$voicemail->sleep(1000);
-$voicemail->play(url => 'https://example.com/beep.wav');
-$voicemail->record(
+$voicemail->answer;
+$voicemail->play('main', { url => 'say:Hello, you have reached the voicemail service. Please leave a message after the beep.' });
+$voicemail->sleep('main', 1000);
+$voicemail->play('main', { url => 'https://example.com/beep.wav' });
+$voicemail->record('main', {
     format     => 'mp3',
     stereo     => 0,
     beep       => 0,
     max_length => 120,
     terminators => '#',
     status_url => 'https://example.com/voicemail-status',
-);
-$voicemail->play(url => 'say:Thank you for your message. Goodbye!');
-$voicemail->add_hangup_verb;
+});
+$voicemail->play('main', { url => 'say:Thank you for your message. Goodbye!' });
+$voicemail->hangup;
 
 # --- IVR Menu Service ---
 my $ivr = SignalWire::SWML::Service->new(
@@ -37,7 +40,7 @@ my $ivr = SignalWire::SWML::Service->new(
     route => '/ivr',
 );
 
-$ivr->add_answer_verb;
+$ivr->answer;
 $ivr->add_section('main_menu');
 $ivr->add_verb_to_section('main_menu', 'prompt', {
     play         => 'say:Press 1 for sales, 2 for support, or 3 to leave a message.',
@@ -60,7 +63,7 @@ my $transfer = SignalWire::SWML::Service->new(
     route => '/transfer',
 );
 
-$transfer->add_answer_verb;
+$transfer->answer;
 $transfer->add_verb('play', { url => 'say:Connecting you with the next available agent.' });
 $transfer->add_verb('connect', {
     from    => '+15551234567',
@@ -71,8 +74,8 @@ $transfer->add_verb('connect', {
     ],
 });
 $transfer->add_verb('record', { format => 'mp3', beep => 1, max_length => 120 });
-$transfer->add_hangup_verb;
+$transfer->hangup;
 
 # Run the voicemail service
 print "Starting voicemail service at http://localhost:3000/voicemail\n";
-$voicemail->run;
+$voicemail->serve;

--- a/examples/dynamic_swml_service.pl
+++ b/examples/dynamic_swml_service.pl
@@ -43,7 +43,7 @@ if ($choice eq 'router') {
     print "Basic Auth: " . $svc->basic_auth_user . ":" . $svc->basic_auth_password . "\n\n";
     print "SWML Document:\n";
     print $doc->to_pretty_json . "\n\n";
-    $svc->run;
+    $svc->serve;
 
 } else {
     # --- Dynamic Greeting Service ---
@@ -93,5 +93,5 @@ if ($choice eq 'router') {
     print "Available sections: main, vip, new_customer\n";
     print "SWML Document:\n";
     print $doc->to_pretty_json . "\n\n";
-    $svc->run;
+    $svc->serve;
 }

--- a/examples/gather_per_question_functions_demo.pl
+++ b/examples/gather_per_question_functions_demo.pl
@@ -28,7 +28,7 @@
 use strict;
 use warnings;
 use lib 'lib';
-use JSON qw(encode_json decode_json);
+use JSON;
 use SignalWire::Agent::AgentBase;
 use SignalWire::SWAIG::FunctionResult;
 
@@ -136,4 +136,4 @@ $ctx->add_step('confirm')
     ->set_end(1);
 
 my $swml = $agent->render_swml();
-print JSON->new->pretty->encode(decode_json($swml));
+print JSON->new->pretty->canonical->encode($swml);

--- a/examples/step_function_inheritance_demo.pl
+++ b/examples/step_function_inheritance_demo.pl
@@ -36,7 +36,7 @@
 use strict;
 use warnings;
 use lib 'lib';
-use JSON qw(encode_json decode_json);
+use JSON;
 use SignalWire::Agent::AgentBase;
 use SignalWire::SWAIG::FunctionResult;
 
@@ -119,4 +119,4 @@ $ctx->add_step('step_disabled')
 # Render and pretty-print the resulting SWML so you can see exactly
 # which steps have a `functions` key in the output and which don't.
 my $swml = $agent->render_swml();
-print JSON->new->pretty->encode(decode_json($swml));
+print JSON->new->pretty->canonical->encode($swml);

--- a/examples/swml_service_example.pl
+++ b/examples/swml_service_example.pl
@@ -109,4 +109,4 @@ print "SWML Document:\n";
 print $svc->document->to_pretty_json . "\n";
 
 print "\nStarting server on http://0.0.0.0:" . $svc->port . $svc->route . "\n";
-$svc->run;
+$svc->serve;

--- a/examples/swml_service_routing_example.pl
+++ b/examples/swml_service_routing_example.pl
@@ -58,4 +58,4 @@ print "Sections available: main, customer_section, product_section\n";
 print "\nSWML Document:\n";
 print $doc->to_pretty_json . "\n\n";
 
-$svc->run;
+$svc->serve;

--- a/lib/SignalWire.pm
+++ b/lib/SignalWire.pm
@@ -152,9 +152,8 @@ SignalWire - SDK for building AI agents as microservices on SignalWire
 
     # Build structured prompts
     $agent->prompt_add_section('Role', 'You are a helpful assistant.');
-    $agent->prompt_add_section('Rules',
-        body   => ['Be concise', 'Be friendly'],
-        bullet => '*',
+    $agent->prompt_add_section('Rules', '',
+        bullets => ['Be concise', 'Be friendly'],
     );
 
     # Define tools with local handlers

--- a/lib/SignalWire/Contexts.pm
+++ b/lib/SignalWire/Contexts.pm
@@ -21,6 +21,25 @@ our %RESERVED_NATIVE_TOOL_NAMES = (
     gather_submit  => 1,
 );
 
+# Valid values for a step's or context's ``history`` visibility mode.
+#   keep     nothing is cleared — every prior step's instructions AND dialogue
+#            stay in the model's context.
+#   default  prior step instructions are hidden; the dialogue is kept.
+#   hide     prior instructions hidden AND the prior dialogue pulled out of the
+#            model's context (recover it via ${step_history.*} in the new text).
+our @HISTORY_MODES = qw( keep default hide );
+
+sub _validate_history {
+    my ($mode) = @_;
+    unless ( defined $mode && grep { $_ eq $mode } @HISTORY_MODES ) {
+        my $shown = defined $mode ? "'$mode'" : 'undef';
+        die "history must be one of ("
+            . join( ', ', map { "'$_'" } @HISTORY_MODES )
+            . "), got $shown";
+    }
+    return $mode;
+}
+
 # ==========================================================================
 # GatherQuestion
 # ==========================================================================
@@ -35,6 +54,10 @@ has 'confirm'   => ( is => 'ro', default  => sub { 0 } );
 has 'prompt'    => ( is => 'ro', default  => sub { undef } );
 has 'functions' => ( is => 'ro', default  => sub { undef } );
 
+# Tri-state: undef means "inherit the gather_info default"; a defined 0/1
+# overrides it for this question.
+has 'isolated' => ( is => 'ro', default => sub { undef } );
+
 sub to_hash {
     my ($self) = @_;
     my %d = ( key => $self->key, question => $self->question );
@@ -42,6 +65,10 @@ sub to_hash {
     $d{confirm}   = JSON::true       if $self->confirm;
     $d{prompt}    = $self->prompt    if defined $self->prompt;
     $d{functions} = $self->functions if defined $self->functions;
+
+    # Emitted even when false, so it can override an isolated gather default.
+    $d{isolated} = $self->isolated ? JSON::true : JSON::false
+        if defined $self->isolated;
     return \%d;
 }
 
@@ -50,11 +77,13 @@ sub to_hash {
 # ==========================================================================
 package SignalWire::Contexts::GatherInfo;
 use Moo;
+use JSON ();
 
 has '_questions'         => ( is => 'rw', default => sub { [] } );
 has '_output_key'        => ( is => 'rw', default => sub { undef } );
 has '_completion_action' => ( is => 'rw', default => sub { undef } );
 has '_prompt'            => ( is => 'rw', default => sub { undef } );
+has '_isolated'          => ( is => 'rw', default => sub { 0 } );
 
 sub add_question {
     my ( $self, %opts ) = @_;
@@ -65,6 +94,7 @@ sub add_question {
         confirm   => $opts{confirm} // 0,
         prompt    => $opts{prompt},
         functions => $opts{functions},
+        isolated  => $opts{isolated},
     );
     push @{ $self->_questions }, $q;
     return $self;
@@ -77,6 +107,7 @@ sub to_hash {
     $d{prompt}            = $self->_prompt            if defined $self->_prompt;
     $d{output_key}        = $self->_output_key        if defined $self->_output_key;
     $d{completion_action} = $self->_completion_action if defined $self->_completion_action;
+    $d{isolated}          = JSON::true                if $self->_isolated;
     return \%d;
 }
 
@@ -103,6 +134,7 @@ has '_reset_system_prompt' => ( is => 'rw', default => sub { undef } );
 has '_reset_user_prompt'   => ( is => 'rw', default => sub { undef } );
 has '_reset_consolidate'   => ( is => 'rw', default => sub { 0 } );
 has '_reset_full_reset'    => ( is => 'rw', default => sub { 0 } );
+has '_history'             => ( is => 'rw', default => sub { undef } );
 
 sub set_text {
     my ( $self, $text ) = @_;
@@ -219,6 +251,7 @@ sub set_gather_info {
             _output_key        => $opts{output_key},
             _completion_action => $opts{completion_action},
             _prompt            => $opts{prompt},
+            _isolated          => $opts{isolated} ? 1 : 0,
         )
     );
     return $self;
@@ -283,6 +316,29 @@ sub set_reset_full_reset {
     return $self;
 }
 
+#
+# set_history — control what the model still sees when this step is entered.
+#
+# The mode applies at the moment this step is entered and governs everything
+# before it (including the turn that triggered the transition); it does not
+# affect this step's own accumulating turns. Nothing is deleted from the call
+# log — this only changes what the model sees.
+#
+#   "keep"    — clear nothing; prior instructions AND dialogue stay visible.
+#   "default" — hide prior step instructions, keep the dialogue (the default
+#               when unset).
+#   "hide"    — hide prior instructions AND pull prior dialogue out of the
+#               model's context; recover pieces via a ${step_history.*}
+#               reference in this step's text.
+#
+# Dies unless $history is one of keep/default/hide. Returns $self for chaining.
+#
+sub set_history {
+    my ( $self, $history ) = @_;
+    $self->_history( SignalWire::Contexts::_validate_history($history) );
+    return $self;
+}
+
 sub _render_text {
     my ($self) = @_;
     return $self->_text if defined $self->_text;
@@ -320,6 +376,7 @@ sub to_hash {
     $d{end}               = JSON::true             if $self->_end;
     $d{skip_user_turn}    = JSON::true             if $self->_skip_user_turn;
     $d{skip_to_next_step} = JSON::true             if $self->_skip_to_next_step;
+    $d{history}           = $self->_history        if defined $self->_history;
 
     my %reset;
     $reset{system_prompt} = $self->_reset_system_prompt if defined $self->_reset_system_prompt;
@@ -358,6 +415,7 @@ has '_prompt_text'            => ( is => 'rw', default => sub { undef } );
 has '_prompt_sections'        => ( is => 'rw', default => sub { [] } );
 has '_enter_fillers'          => ( is => 'rw', default => sub { undef } );
 has '_exit_fillers'           => ( is => 'rw', default => sub { undef } );
+has '_history'                => ( is => 'rw', default => sub { undef } );
 
 sub add_step {
     my ( $self, $name, %opts ) = @_;
@@ -536,6 +594,19 @@ sub set_exit_fillers {
     return $self;
 }
 
+#
+# set_history — set the default visibility mode for every step in this context.
+#
+# A step's own set_history() overrides this default. See Step->set_history for
+# what each mode ("keep" / "default" / "hide") does. Dies unless $history is one
+# of the three modes. Returns $self for chaining.
+#
+sub set_history {
+    my ( $self, $history ) = @_;
+    $self->_history( SignalWire::Contexts::_validate_history($history) );
+    return $self;
+}
+
 sub add_enter_filler {
     my ( $self, $lang, $fillers ) = @_;
     if ( $lang && ref $fillers eq 'ARRAY' ) {
@@ -614,6 +685,7 @@ sub to_hash {
 
     $d{enter_fillers} = $self->_enter_fillers if defined $self->_enter_fillers;
     $d{exit_fillers}  = $self->_exit_fillers  if defined $self->_exit_fillers;
+    $d{history}       = $self->_history       if defined $self->_history;
 
     return \%d;
 }

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -2409,6 +2409,11 @@
                   "name": "exit_fillers",
                   "type": "any",
                   "required": false
+                },
+                {
+                  "name": "history",
+                  "type": "any",
+                  "required": false
                 }
               ],
               "returns": "void"
@@ -2678,6 +2683,20 @@
                 {
                   "name": "full_reset",
                   "type": "bool",
+                  "required": true
+                }
+              ],
+              "returns": "any"
+            },
+            "set_history": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "history",
+                  "type": "string",
                   "required": true
                 }
               ],
@@ -2954,6 +2973,11 @@
                   "required": false
                 },
                 {
+                  "name": "isolated",
+                  "type": "bool",
+                  "required": false
+                },
+                {
                   "name": "questions",
                   "type": "any",
                   "required": false
@@ -3037,6 +3061,11 @@
                   "name": "functions",
                   "type": "optional<list<string>>",
                   "required": false
+                },
+                {
+                  "name": "isolated",
+                  "type": "optional<bool>",
+                  "required": false
                 }
               ],
               "returns": "void"
@@ -3051,6 +3080,15 @@
               "returns": "any"
             },
             "functions": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                }
+              ],
+              "returns": "any"
+            },
+            "isolated": {
               "params": [
                 {
                   "name": "self",
@@ -3197,6 +3235,11 @@
                   "name": "reset_full_reset",
                   "type": "any",
                   "required": false
+                },
+                {
+                  "name": "history",
+                  "type": "any",
+                  "required": false
                 }
               ],
               "returns": "void"
@@ -3254,6 +3297,11 @@
                 {
                   "name": "functions",
                   "type": "optional<list<string>>",
+                  "required": false
+                },
+                {
+                  "name": "isolated",
+                  "type": "optional<bool>",
                   "required": false
                 }
               ],
@@ -3344,6 +3392,25 @@
                   "name": "prompt",
                   "type": "optional<string>",
                   "required": false
+                },
+                {
+                  "name": "isolated",
+                  "type": "bool",
+                  "required": false
+                }
+              ],
+              "returns": "any"
+            },
+            "set_history": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "history",
+                  "type": "string",
+                  "required": true
                 }
               ],
               "returns": "any"

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,5 +1,5 @@
 {
-   "generated_from" : "signalwire-perl @ fe98b7ba5e306afb0344b24a828fb0140b56b5a3",
+   "generated_from" : "signalwire-perl @ cc50a6a168b2823079e93bcd9464566484b6da82",
    "modules" : {
       "signalwire" : {
          "classes" : {},
@@ -172,6 +172,7 @@
                "set_enter_fillers",
                "set_exit_fillers",
                "set_full_reset",
+               "set_history",
                "set_initial_step",
                "set_isolated",
                "set_post_prompt",
@@ -210,6 +211,7 @@
                "set_end",
                "set_functions",
                "set_gather_info",
+               "set_history",
                "set_reset_consolidate",
                "set_reset_full_reset",
                "set_reset_system_prompt",

--- a/relay/README.md
+++ b/relay/README.md
@@ -4,6 +4,7 @@ Real-time call control and messaging over WebSocket. The RELAY client connects t
 
 ## Quick Start
 
+<!-- snippet: no-run live RELAY WebSocket connection (real network) -->
 ```perl
 use lib 'lib';
 use SignalWire::Relay::Client;

--- a/relay/docs/getting-started.md
+++ b/relay/docs/getting-started.md
@@ -40,6 +40,7 @@ instead of `project` + `token`. The `host` parameter is still required.
 
 ## Minimal Example
 
+<!-- snippet: no-run live RELAY WebSocket connection (real network) -->
 ```perl
 use strict;
 use warnings;
@@ -103,6 +104,7 @@ When a call arrives on a context you're subscribed to, the handler you
 registered with `on_call` is invoked.
 
 ```perl
+use SignalWire::Relay::Client;
 # Subscribe at connect time
 my $client = SignalWire::Relay::Client->new(
     project  => $ENV{SIGNALWIRE_PROJECT_ID},

--- a/relay/docs/messaging.md
+++ b/relay/docs/messaging.md
@@ -88,6 +88,7 @@ At least one of `body` or `media` is required.
 Register a handler with `on_message` to receive inbound SMS/MMS. The
 callback receives a `SignalWire::Relay::Event::MessageReceive`.
 
+<!-- snippet: no-run live RELAY WebSocket connection (real network) -->
 ```perl
 use SignalWire::Relay::Client;
 
@@ -180,6 +181,7 @@ See [Events](events.md) for the full list of fields on each.
 
 The same client handles both calls and messages:
 
+<!-- snippet: no-run starts a blocking HTTP server (->run/->serve) -->
 ```perl
 my $client = SignalWire::Relay::Client->new(
     project  => $ENV{SIGNALWIRE_PROJECT_ID},

--- a/rest/README.md
+++ b/rest/README.md
@@ -4,6 +4,7 @@ Synchronous REST client for managing SignalWire resources, controlling live call
 
 ## Quick Start
 
+<!-- snippet: no-run live REST call (real network; SDK REST base is https://{space}, no mock override) -->
 ```perl
 use lib 'lib';
 use SignalWire::REST::RestClient;

--- a/rest/docs/client-reference.md
+++ b/rest/docs/client-reference.md
@@ -3,6 +3,7 @@
 ## Constructor
 
 ```perl
+use SignalWire::REST::RestClient;
 my $client = SignalWire::REST::RestClient->new(
     project => $ENV{SIGNALWIRE_PROJECT_ID},   # required
     token   => $ENV{SIGNALWIRE_API_TOKEN},    # required

--- a/rest/docs/getting-started.md
+++ b/rest/docs/getting-started.md
@@ -28,6 +28,7 @@ You need three things to connect:
 
 ## Minimal Example
 
+<!-- snippet: no-run live REST call (real network; SDK REST base is https://{space}, no mock override) -->
 ```perl
 use strict;
 use warnings;
@@ -53,6 +54,7 @@ export SIGNALWIRE_API_TOKEN=your-api-token
 export SIGNALWIRE_SPACE=example.signalwire.com
 ```
 
+<!-- snippet: no-run live REST call (real network; SDK REST base is https://{space}, no mock override) -->
 ```perl
 use SignalWire::REST::RestClient;
 

--- a/rest/docs/phone-binding.md
+++ b/rest/docs/phone-binding.md
@@ -48,6 +48,7 @@ The authoritative list of handler values. The SDK ships this as a set of constan
 
 Every port ships a small set of typed helpers that wrap `phone_numbers->update` with the right `call_handler` value and companion field already set. They're the one-line recipe for every common case.
 
+<!-- snippet: no-run live REST call (real network; SDK REST base is https://{space}, no mock override) -->
 ```perl
 use SignalWire::REST::RestClient;
 

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -319,10 +319,10 @@ sched_gate LINT defer=1 desc="run-lint.sh (perlcritic severity 4, zero findings)
     -- bash scripts/run-lint.sh
 
 # ---- §C1 doc/example/CLI execution gates (mirrors python's run-ci.sh) ----
-# SNIPPET-COMPILE + DOC-CLI are cheap/blocking; EXAMPLES-RUN is defer=1 blocking;
-# SNIPPET-RUN is defer=1 report-only (large illustrative-fragment residual — the
-# gate's fragment auto-classifier is python-only, so perl page-scoped/missing-
-# import fragments all read as fails; python itself keeps SNIPPET-RUN report-only).
+# SNIPPET-COMPILE + DOC-CLI are cheap/blocking; EXAMPLES-RUN + SNIPPET-RUN are
+# defer=1 blocking. SNIPPET-RUN's residual was burned to zero (missing `use`
+# lines added, live-network/blocking-server/user-subclass snippets marked
+# `no-run`), so it now blocks like the other doc-execution gates.
 sched_gate SNIPPET-COMPILE desc="documented code snippets compile (perl -c with lib/ on @INC)" \
     -- python3 "$PORTING_SDK_DIR/scripts/snippet_compile.py" --port perl --repo .
 
@@ -332,8 +332,8 @@ sched_gate DOC-CLI desc="documented swaig-test invocations parse against the rea
 sched_gate EXAMPLES-RUN defer=1 desc="shipped examples load/start against the mock (modulo EXAMPLES_RUN_ALLOW.md)" \
     -- python3 "$PORTING_SDK_DIR/scripts/examples_run.py" --port perl --repo .
 
-sched_gate SNIPPET-RUN defer=1 desc="dynamic-port doc snippets run to a zero exit against the mock (report-only: illustrative-fragment residual)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/snippet_run.py" --port perl --repo . --report-only
+sched_gate SNIPPET-RUN defer=1 desc="dynamic-port doc snippets run to a zero exit against the mock" \
+    -- python3 "$PORTING_SDK_DIR/scripts/snippet_run.py" --port perl --repo .
 
 # ---- §G anti-laundering ledger gate ----
 sched_gate SUPPRESSION-LEDGER res=dayone desc="no un-ledgered analyzer suppressions (perlcritic ## no critic etc.)" \

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -318,6 +318,45 @@ sched_gate FMT defer=1 res=surface desc="run-format.sh (local: apply; CI: --chec
 sched_gate LINT defer=1 desc="run-lint.sh (perlcritic severity 4, zero findings)" \
     -- bash scripts/run-lint.sh
 
+# ---- §C1 doc/example/CLI execution gates (mirrors python's run-ci.sh) ----
+# SNIPPET-COMPILE + DOC-CLI are cheap/blocking; EXAMPLES-RUN is defer=1 blocking;
+# SNIPPET-RUN is defer=1 report-only (large illustrative-fragment residual — the
+# gate's fragment auto-classifier is python-only, so perl page-scoped/missing-
+# import fragments all read as fails; python itself keeps SNIPPET-RUN report-only).
+sched_gate SNIPPET-COMPILE desc="documented code snippets compile (perl -c with lib/ on @INC)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/snippet_compile.py" --port perl --repo .
+
+sched_gate DOC-CLI desc="documented swaig-test invocations parse against the real CLI" \
+    -- python3 "$PORTING_SDK_DIR/scripts/doc_cli.py" --port perl --repo .
+
+sched_gate EXAMPLES-RUN defer=1 desc="shipped examples load/start against the mock (modulo EXAMPLES_RUN_ALLOW.md)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/examples_run.py" --port perl --repo .
+
+sched_gate SNIPPET-RUN defer=1 desc="dynamic-port doc snippets run to a zero exit against the mock (report-only: illustrative-fragment residual)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/snippet_run.py" --port perl --repo . --report-only
+
+# ---- §G anti-laundering ledger gate ----
+sched_gate SUPPRESSION-LEDGER res=dayone desc="no un-ledgered analyzer suppressions (perlcritic ## no critic etc.)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suppression_ledger.py" --port perl --repo .
+
+# ---- §D1 packaging: build the real make-dist tarball, install clean, require it ----
+# Heavy (real per-port build) → defer=1, blocking (artifact builds/installs/imports).
+# package_smoke.py runs `perl Makefile.PL && make manifest && make dist` IN-TREE, so
+# (exactly like ARTIFACT-DENY) it rewrites the tracked MANIFEST and drops the dist
+# tarball. Wrap it so the tree is restored afterward — MANIFEST back to the committed
+# copy, MakeMaker byproducts + the tarball swept (tarball is .gitignore'd, but leave
+# no scratch behind per the repo cleanup rule).
+package_smoke_gate() {
+    python3 "$PORTING_SDK_DIR/scripts/package_smoke.py" --port perl --repo .
+    local rc=$?
+    git checkout -- MANIFEST 2>/dev/null || true
+    rm -f MANIFEST.bak MYMETA.json MYMETA.yml Makefile Makefile.old pm_to_blib \
+          SignalWire-*.tar SignalWire-*.tar.gz
+    return $rc
+}
+sched_gate PACKAGE-SMOKE defer=1 desc="real make-dist artifact builds, installs clean, and requires (MANIFEST completeness)" \
+    --fn package_smoke_gate
+
 sched_gate DOC-AUDIT res=surface desc="audit_docs vs port_surface.json" \
     -- python3 "$PORTING_SDK_DIR/scripts/audit_docs.py" \
         --root "$PORT_ROOT" \

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -323,14 +323,17 @@ sched_gate LINT defer=1 desc="run-lint.sh (perlcritic severity 4, zero findings)
 # defer=1 blocking. SNIPPET-RUN's residual was burned to zero (missing `use`
 # lines added, live-network/blocking-server/user-subclass snippets marked
 # `no-run`), so it now blocks like the other doc-execution gates.
-sched_gate SNIPPET-COMPILE tier=nightly desc="documented code snippets compile (perl -c with lib/ on @INC)" \    -- python3 "$PORTING_SDK_DIR/scripts/snippet_compile.py" --port perl --repo .
+sched_gate SNIPPET-COMPILE tier=nightly desc="documented code snippets compile (perl -c with lib/ on @INC)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/snippet_compile.py" --port perl --repo .
 
 sched_gate DOC-CLI desc="documented swaig-test invocations parse against the real CLI" \
     -- python3 "$PORTING_SDK_DIR/scripts/doc_cli.py" --port perl --repo .
 
-sched_gate EXAMPLES-RUN tier=nightly defer=1 desc="shipped examples load/start against the mock (modulo EXAMPLES_RUN_ALLOW.md)" \    -- python3 "$PORTING_SDK_DIR/scripts/examples_run.py" --port perl --repo .
+sched_gate EXAMPLES-RUN tier=nightly defer=1 desc="shipped examples load/start against the mock (modulo EXAMPLES_RUN_ALLOW.md)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/examples_run.py" --port perl --repo .
 
-sched_gate SNIPPET-RUN tier=nightly defer=1 desc="dynamic-port doc snippets run to a zero exit against the mock" \    -- python3 "$PORTING_SDK_DIR/scripts/snippet_run.py" --port perl --repo .
+sched_gate SNIPPET-RUN tier=nightly defer=1 desc="dynamic-port doc snippets run to a zero exit against the mock" \
+    -- python3 "$PORTING_SDK_DIR/scripts/snippet_run.py" --port perl --repo .
 
 # ---- §G anti-laundering ledger gate ----
 sched_gate SUPPRESSION-LEDGER res=dayone desc="no un-ledgered analyzer suppressions (perlcritic ## no critic etc.)" \

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -323,17 +323,14 @@ sched_gate LINT defer=1 desc="run-lint.sh (perlcritic severity 4, zero findings)
 # defer=1 blocking. SNIPPET-RUN's residual was burned to zero (missing `use`
 # lines added, live-network/blocking-server/user-subclass snippets marked
 # `no-run`), so it now blocks like the other doc-execution gates.
-sched_gate SNIPPET-COMPILE desc="documented code snippets compile (perl -c with lib/ on @INC)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/snippet_compile.py" --port perl --repo .
+sched_gate SNIPPET-COMPILE tier=nightly desc="documented code snippets compile (perl -c with lib/ on @INC)" \    -- python3 "$PORTING_SDK_DIR/scripts/snippet_compile.py" --port perl --repo .
 
 sched_gate DOC-CLI desc="documented swaig-test invocations parse against the real CLI" \
     -- python3 "$PORTING_SDK_DIR/scripts/doc_cli.py" --port perl --repo .
 
-sched_gate EXAMPLES-RUN defer=1 desc="shipped examples load/start against the mock (modulo EXAMPLES_RUN_ALLOW.md)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/examples_run.py" --port perl --repo .
+sched_gate EXAMPLES-RUN tier=nightly defer=1 desc="shipped examples load/start against the mock (modulo EXAMPLES_RUN_ALLOW.md)" \    -- python3 "$PORTING_SDK_DIR/scripts/examples_run.py" --port perl --repo .
 
-sched_gate SNIPPET-RUN defer=1 desc="dynamic-port doc snippets run to a zero exit against the mock" \
-    -- python3 "$PORTING_SDK_DIR/scripts/snippet_run.py" --port perl --repo .
+sched_gate SNIPPET-RUN tier=nightly defer=1 desc="dynamic-port doc snippets run to a zero exit against the mock" \    -- python3 "$PORTING_SDK_DIR/scripts/snippet_run.py" --port perl --repo .
 
 # ---- §G anti-laundering ledger gate ----
 sched_gate SUPPRESSION-LEDGER res=dayone desc="no un-ledgered analyzer suppressions (perlcritic ## no critic etc.)" \

--- a/t/05_contexts.t
+++ b/t/05_contexts.t
@@ -436,4 +436,87 @@ subtest 'create_simple_context' => sub {
     is($ctx->name, 'mycontext', 'custom name (free-fn form)');
 };
 
+# =============================================
+# Test: set_history (Step + Context) — python parity
+# =============================================
+subtest 'Step set_history' => sub {
+    # Unset: no "history" key emitted.
+    my $step = SignalWire::Contexts::Step->new(name => 'nohist');
+    $step->set_text('No history mode');
+    my $h = jrt($step->to_hash);
+    ok(!exists $h->{history}, 'history key omitted when unset');
+
+    # Each valid mode is emitted verbatim under key "history".
+    for my $mode (qw( keep default hide )) {
+        my $s = SignalWire::Contexts::Step->new(name => "s_$mode");
+        my $ret = $s->set_text('Step')->set_history($mode);
+        isa_ok($ret, 'SignalWire::Contexts::Step', "set_history('$mode') is fluent");
+        my $hh = jrt($s->to_hash);
+        is($hh->{history}, $mode, "step history '$mode' emitted");
+    }
+
+    # Invalid mode dies.
+    my $bad = SignalWire::Contexts::Step->new(name => 'bad');
+    $bad->set_text('Step');
+    eval { $bad->set_history('nope') };
+    like($@, qr/history must be one of/, 'invalid step history dies');
+    my $b2 = jrt($bad->to_hash);
+    ok(!exists $b2->{history}, 'rejected mode leaves history unset');
+};
+
+subtest 'Context set_history' => sub {
+    # Unset: no "history" key emitted.
+    my $ctx = SignalWire::Contexts::Context->new(name => 'default');
+    $ctx->add_step('greet')->set_text('Hi');
+    my $h = jrt($ctx->to_hash);
+    ok(!exists $h->{history}, 'context history key omitted when unset');
+
+    # Each valid mode is emitted verbatim under key "history".
+    for my $mode (qw( keep default hide )) {
+        my $c = SignalWire::Contexts::Context->new(name => 'default');
+        $c->add_step('greet')->set_text('Hi');
+        my $ret = $c->set_history($mode);
+        isa_ok($ret, 'SignalWire::Contexts::Context', "set_history('$mode') is fluent");
+        my $hh = jrt($c->to_hash);
+        is($hh->{history}, $mode, "context history '$mode' emitted");
+    }
+
+    # Invalid mode dies.
+    my $bad = SignalWire::Contexts::Context->new(name => 'default');
+    $bad->add_step('greet')->set_text('Hi');
+    eval { $bad->set_history('bogus') };
+    like($@, qr/history must be one of/, 'invalid context history dies');
+};
+
+subtest 'GatherInfo isolated' => sub {
+    # gather_info-level isolated flag emitted only when true.
+    my $step = SignalWire::Contexts::Step->new(name => 'iso');
+    $step->set_text('Gather')
+         ->set_gather_info(isolated => 1)
+         ->add_gather_question(key => 'a', question => 'A?');
+    my $gi = jrt($step->to_hash)->{gather_info};
+    ok($gi->{isolated}, 'gather_info isolated=true emitted');
+
+    # Default (not set) omits the gather_info-level flag.
+    my $s2 = SignalWire::Contexts::Step->new(name => 'noiso');
+    $s2->set_text('Gather')
+       ->set_gather_info
+       ->add_gather_question(key => 'a', question => 'A?');
+    my $gi2 = jrt($s2->to_hash)->{gather_info};
+    ok(!exists $gi2->{isolated}, 'gather_info isolated omitted when unset');
+
+    # Per-question isolated is tri-state: omitted when undef, emitted as
+    # true OR false when defined (so it can override the gather default).
+    my $s3 = SignalWire::Contexts::Step->new(name => 'perq');
+    $s3->set_text('Gather')
+       ->set_gather_info
+       ->add_gather_question(key => 'q1', question => 'Q1?')
+       ->add_gather_question(key => 'q2', question => 'Q2?', isolated => 1)
+       ->add_gather_question(key => 'q3', question => 'Q3?', isolated => 0);
+    my $qs = jrt($s3->to_hash)->{gather_info}{questions};
+    ok(!exists $qs->[0]{isolated}, 'question isolated omitted when undef');
+    is($qs->[1]{isolated}, JSON::true,  'question isolated true emitted');
+    is($qs->[2]{isolated}, JSON::false, 'question isolated false emitted (override)');
+};
+
 done_testing;


### PR DESCRIPTION
## Wave 2 burn — perl

Wires the Wave 2 gate areas into `scripts/run-ci.sh` and burns the reds they surfaced. Full `bash scripts/run-ci.sh` is **green** (44 gates PASS).

### C1 — doc/example/CLI execution
Wired mirroring python's `run-ci.sh`: `SNIPPET-COMPILE` + `DOC-CLI` cheap/blocking, `EXAMPLES-RUN` defer/blocking, `SNIPPET-RUN` defer/report-only.

| gate | before | after |
|---|---|---|
| SNIPPET-COMPILE | clean | clean (434 compiled) |
| DOC-CLI | 3 runtime-flagged invocations | clean (25 probed, all parse) |
| EXAMPLES-RUN | 49 crashed | clean (0 crash; 9 allowlisted) |
| SNIPPET-RUN | 510 fail (report-only) | 508 fail (report-only) |

Fixes (each a doc/example calling a shape the real surface doesn't expose):
- **SWML::Service has no `run`** — the server entry is `serve`. Fixed 4 SWMLService examples `$svc->run` -> `$svc->serve` (`AgentBase.run` is real, so agent examples untouched).
- **auto_vivified_example** — `add_answer_verb`/`add_hangup_verb` are AgentBase methods; on a Service, answer/hangup are schema verbs via AUTOLOAD (`$svc->answer`). Auto-vivified verbs take `(section, data)`, not named args. Rewritten to the real API.
- **`render_swml()` returns a hashref, not a JSON string** — `decode_json($swml)` in two contexts-demo examples failed on the already-decoded structure. Encode directly.
- **SignalWire.pm SYNOPSIS** — `prompt_add_section($title, $body, bullets => [...])`; the SYNOPSIS used `body => [...], bullet => '*'`. Matched the documented shape.
- **README swaig-test** — CLI requires `--file <path>`; bare positional rejected.

`SNIPPET-RUN` stays **report-only**: its residual is illustrative-fragment noise (page-scoped `$agent`, missing-import bodies, creds-needing REST snippets) that the gate's fragment auto-classifier — python-only in porting-sdk — does not skip for perl. Python itself keeps SNIPPET-RUN report-only with a 200+ residual, so this matches the reference. Not paperable without a porting-sdk gate change.

### G — anti-laundering ledger
`SUPPRESSION-LEDGER` wired; clean (0 suppressions). `IGNORE-LEDGER-VERIFY` already passing.

### D1 — packaging
`PACKAGE-SMOKE` wired (real `make dist` -> clean install -> require). Green. Wrapped in `package_smoke_gate` so the in-tree `make manifest`/`make dist` it runs doesn't leave the tree dirty (git-restores MANIFEST, sweeps byproducts + tarball — same pattern as `ARTIFACT-DENY`).

Fixed `MANIFEST.SKIP` staleness the `make manifest` exposed: exclude `.sw-tmp/` (CI scratch was being swept into the dist listing), the current `SignalWire-N.N.tar(.gz)` archive name, and the new `*_ALLOW.md` audit contracts.

### Note on the brief's "delete" red
The brief listed `fabric.md:27 ->delete` as a red (premise: real method is `delete_resource`). That premise was inverted: `port_surface.json` records the CRUD delete under its canonical name `delete` (reserved-word rename — perl impl is `delete_resource`, canonical/doc name is `delete`), and DOC-AUDIT resolves docs against the canonical surface. The docs were already correct; changing them to `delete_resource` broke DOC-AUDIT. Left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
