### PR TITLE
docs(relay): mark receive/unreceive context snippet no-run (fix nightly SNIPPET-RUN)

### DIFF
--- a/relay/docs/getting-started.md
+++ b/relay/docs/getting-started.md
@@ -103,6 +103,7 @@ Contexts are topics your client subscribes to for receiving inbound calls.
 When a call arrives on a context you're subscribed to, the handler you
 registered with `on_call` is invoked.
 
+<!-- snippet: no-run calls client.receive/unreceive, which issue a live signalwire.receive RELAY request over a WebSocket to SIGNALWIRE_SPACE — cannot reach the loopback mock standalone -->
 ```perl
 use SignalWire::Relay::Client;
 # Subscribe at connect time


### PR DESCRIPTION
## Problem
The perl **Nightly (heavy doc gates)** run on main is RED on SNIPPET-RUN. Root cause: the context-subscription snippet in `relay/docs/getting-started.md` calls `$client->receive(['billing'])` / `->unreceive(['sales'])`, which issue a live `signalwire.receive` RELAY request over a WebSocket to `SIGNALWIRE_SPACE`. It can't reach the loopback mock standalone, so the gate fails it with `exit 255: RELAY error -1: Request timeout for signalwire.receive` (30s timeout).

## Fix
Add `<!-- snippet: no-run ... -->` above the fence — the exact mechanism the gate offers for a snippet that legitimately can't run standalone. This matches sibling-port precedent: **ruby** and **typescript** both mark the identical receive/unreceive context snippet no-run for the same reason. No code or behavior change; docs-only.

## Verification
SNIPPET-RUN locally: the `receive` snippet moves from the failed set into the suppressed set (64→65 suppressed) and no longer appears in failures. (Two unrelated `Plack::Builder` BEGIN-failures seen locally are a missing local dependency, not present on CI which has Plack installed — unaffected by this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)