### PR TITLE
docs(relay): stop naming phantom SIGNALWIRE_JWT_TOKEN env var (widened DOC-ENV perimeter)

### DIFF
--- a/relay/docs/client-reference.md
+++ b/relay/docs/client-reference.md
@@ -13,7 +13,7 @@ use SignalWire::Relay::Client;
 my $client = SignalWire::Relay::Client->new(
     project   => $ENV{SIGNALWIRE_PROJECT_ID},   # legacy auth
     token     => $ENV{SIGNALWIRE_API_TOKEN},    # legacy auth
-    jwt_token => $ENV{SIGNALWIRE_JWT_TOKEN},    # alternative auth
+    jwt_token => $my_jwt,                        # alternative auth (pass your own JWT)
     host      => $ENV{SIGNALWIRE_SPACE},        # REQUIRED
     contexts  => ['default'],                   # topics to subscribe to
 );


### PR DESCRIPTION
## What

Reconcile perl's newly-surfaced doc drift so porting-sdk hygiene PR #99 (which widens the DOC-ENV / ACCESSOR-TRUTH perimeter to **all tracked markdown**) can land green.

The widened DOC-ENV gate flags `SIGNALWIRE_JWT_TOKEN` as **documented-but-never-read**: a doc that promises an env knob the SDK ignores.

## Truth in source

`SignalWire::Relay::Client`'s `jwt_token` attribute is:

```perl
has 'jwt_token' => ( is => 'ro', default => sub { '' } );
```

No env fallback. Grepping the SDK, `$ENV{SIGNALWIRE_JWT_TOKEN}` is read **nowhere**. Contrast the three vars the SDK genuinely honors as attribute defaults (`RestClient.pm`):

- `project` ← `$ENV{SIGNALWIRE_PROJECT_ID}`
- `token`   ← `$ENV{SIGNALWIRE_API_TOKEN}`
- `host`    ← `$ENV{SIGNALWIRE_SPACE}`

The constructor example in `relay/docs/client-reference.md` presented `SIGNALWIRE_JWT_TOKEN` in the same `$ENV{...}` shape as those three, implying the SDK reads it. It does not — the caller supplies their own JWT.

## Fix

Show `jwt_token` receiving a plain caller-supplied scalar (`$my_jwt`) instead of a phantom SDK-read env var. This is the truth (caller passes their own JWT) and removes the only tracked-markdown reference to the phantom var.

Not a rename (no differently-named JWT env knob exists to rename to) and not an allowlist entry (no genuine exception — the doc was simply wrong). Fixed the doc to match source.

## Verify

- `python3 porting-sdk/scripts/doc_env.py --port perl --repo .` → **clean** (was 1 doc-only finding)
- `python3 porting-sdk/scripts/accessor_truth.py --port perl --repo .` → clean
- `bash scripts/run-ci.sh` (pr tier) → **CI PASS** (all gates green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
