### PR TITLE
Part 5 — wire the gate suites into run-ci

### DIFF
--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -11,18 +11,19 @@
 # GATE SCHEDULING (porting-sdk/scripts/gate_scheduler.sh — CI_PERF S1 + S2):
 #   Gates run CONCURRENTLY up to a cap (SW_CI_JOBS, default nproc), scheduled by
 #   their DATA dependencies:
-#     * S2 concurrent wave: the pure-Python side-effect-free gates (all GEN-FRESH*,
-#       DRIFT, NO-CHEAT, EMISSION, SKILL-CONTRACT, SWAIG-COVERAGE, SURFACE-DIFF,
-#       DOC-AUDIT, SWAIG-CLI) overlap — they share no mutable state.
-#     * S1 fail-fast: heavy gates (TEST, LINT, FMT, REST-COVERAGE, SPEC-PARITY) are
-#       deferred behind the cheap wave, so a trivial cheap-gate failure surfaces in
-#       seconds; --fail-fast aborts the run before TEST starts.
+#     * S2 concurrent wave: the pure-Python side-effect-free suites/gates overlap —
+#       they share no mutable state.
+#     * S1 fail-fast: heavy gates (TEST, LINT, FMT, and the BEHAVIORAL/GEN/PACKAGE
+#       suites) are deferred behind the cheap wave, so a trivial cheap-gate failure
+#       surfaces in seconds; --fail-fast aborts the run before TEST starts.
 #   HARD ordering is data-dependency ONLY:
-#     * DRIFT reads port_signatures.json that SIGNATURES writes → deps=SIGNATURES.
-#     * SURFACE-FRESH + SURFACE-DIFF regenerate port_surface.json in place (and
-#       restore it), DOC-AUDIT reads it, FMT rewrites lib/**/*.pm in place, and TEST
-#       loads lib/ + reads port_surface.json → all five share res=surface (the
-#       working-tree-mutation group) so no reader ever sees a half-written file.
+#     * The SIGNATURES→DRIFT→SEMVER data dep + the SURFACE-FRESH regenerate-then-
+#       restore now live INSIDE the SURFACE suite (enumerate-once, diff-many).
+#     * The SURFACE suite regenerates port_surface.json in place (and restores it),
+#       DOC-TRUTH's DOC-AUDIT reads it, STATUS-CLAIM reads it, FMT rewrites
+#       lib/**/*.pm in place, and TEST loads lib/ + reads port_surface.json → all
+#       share res=surface (the working-tree-mutation group) so no reader ever sees
+#       a half-written file.
 #   The shared _env.sh env (PERL5LIB / PATH / PERLTIDY) is exported before the gates
 #   are registered, so every scheduler worker subshell inherits it.
 #   Per-gate PASS/FAIL + the FAILED_GATES tally preserved exactly; each gate's output
@@ -93,7 +94,7 @@ cd "$PORT_ROOT"
 # every scheduler worker subshell.
 # shellcheck source=scripts/_env.sh
 source "$PORT_ROOT/scripts/_env.sh"
-# Bootstrap the FMT/LINT/TEST dev-deps up-front so GEN-FRESH (which shells out to
+# Bootstrap the FMT/LINT/TEST dev-deps up-front so the GEN suite (which shells out to
 # perltidy) and every gate below have them. Fail loud if they can't be resolved.
 _sw_ensure_perl_tools || exit 1
 
@@ -106,387 +107,156 @@ export SW_WAVE_A_REPORT_ONLY=0
 
 echo "==> running CI gates for $PORT_NAME (porting-sdk at $PORTING_SDK_DIR)"
 
-pick_free_port() {
-    python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'
-}
-
-# ARTIFACT-DENY (Day-one) — no porting-process artifact may ship inside the PUBLISHED
-# package. MANIFEST is the authoritative published listing: `make manifest` regenerates
-# it modulo MANIFEST.SKIP (which already excludes port_*.json, PORT_*.md, CHECKLIST.md,
-# audit_coverage*, tidy.err, .sw-tmp/, etc.), so feeding MANIFEST to --listing checks the
-# REAL shipped set (not the git-ls-files proxy). Restore the committed MANIFEST after —
-# `make manifest` rewrites it and would otherwise dirty the tree.
-dayone_artifact_deny() {
-    perl Makefile.PL >/dev/null 2>&1 || { echo "Makefile.PL failed" >&2; return 1; }
-    make manifest >/dev/null 2>&1 || { echo "make manifest failed" >&2; return 1; }
-    python3 "$PORTING_SDK_DIR/scripts/artifact_deny.py" --port perl --listing - <MANIFEST
-    local rc=$?
-    # Restore the committed MANIFEST and sweep the ExtUtils::MakeMaker byproducts
-    # (all .gitignore'd, but leave no scratch behind per the repo cleanup rule).
-    git checkout -- MANIFEST 2>/dev/null || true
-    rm -f MANIFEST.bak MYMETA.json MYMETA.yml Makefile Makefile.old pm_to_blib
-    return $rc
-}
-
-# SURFACE-FRESH — Layer B (the symbol-level surface) is NOT gated by DRIFT (Layer A
-# / signatures only), so port_surface.json can silently rot. Regenerate it IN PLACE
-# via the Perl surface enumerator, compare the committed copy modulo the volatile
-# generated_from git-sha, then always restore the working copy.
-surface_fresh_gate() {
-    if ! git show HEAD:port_surface.json > "$PORT_ROOT/.sw-tmp/committed_surface.json" 2>/dev/null; then
-        cp "$PORT_ROOT/port_surface.json" "$PORT_ROOT/.sw-tmp/committed_surface.json"
-    fi
-    perl scripts/enumerate_surface.pl >/dev/null || return $?
-    python3 "$PORTING_SDK_DIR/scripts/check_surface_freshness.py" \
-        --committed "$PORT_ROOT/.sw-tmp/committed_surface.json" \
-        --fresh "$PORT_ROOT/port_surface.json"
-    local rc=$?
-    git checkout -- port_surface.json 2>/dev/null
-    return $rc
-}
-
-# REST-COVERAGE — every implemented REST route covered success+error. Self-
-# contained: spins its own mock, runs t/rest/ serially, replays the journal.
-rest_coverage_gate() {
-    local port
-    port="$(pick_free_port)" || { echo "could not allocate a free port" >&2; return 1; }
-    local mock_pkg_parent="$PORTING_SDK_DIR/test_harness/mock_signalwire"
-    export PYTHONPATH="$mock_pkg_parent${PYTHONPATH:+:$PYTHONPATH}"
-    python3 -m mock_signalwire --host 127.0.0.1 --port "$port" --log-level error \
-        >"$PORT_ROOT/.sw-tmp/rest_cov_mock_perl.$$.log" 2>&1 &
-    local mock_pid=$!
-    # shellcheck disable=SC2064
-    trap "kill $mock_pid 2>/dev/null" RETURN
-    local i ready=0
-    for i in $(seq 1 60); do
-        if ! kill -0 "$mock_pid" 2>/dev/null; then
-            echo "mock_signalwire died on port $port — log:" >&2
-            cat "$PORT_ROOT/.sw-tmp/rest_cov_mock_perl.$$.log" >&2
-            return 1
-        fi
-        if python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:$port/__mock__/health',timeout=1)" 2>/dev/null; then
-            ready=1
-            break
-        fi
-        sleep 0.5
-    done
-    if [ "$ready" -ne 1 ]; then
-        echo "mock_signalwire on port $port not healthy within 30s" >&2
-        return 1
-    fi
-    python3 -c "import urllib.request; urllib.request.urlopen(urllib.request.Request('http://127.0.0.1:$port/__mock__/journal/reset',method='POST'),timeout=5).read()"
-    MOCK_SIGNALWIRE_PORT="$port" prove -Ilib -It/lib -j1 -r t/rest/ || return 1
-    python3 -m mock_signalwire.rest_coverage \
-        --mock-url "http://127.0.0.1:$port" \
-        --spec-root "$PORTING_SDK_DIR/rest-apis" \
-        --allowlist "$PORTING_SDK_DIR/REST_COVERAGE_BASELINE.md" \
-        --allowlist "$PORT_ROOT/REST_COVERAGE_GAPS.md" \
-        --gap-baseline "$PORTING_SDK_DIR/REST_COVERAGE_GAP_BASELINE.md"
-}
-
-# SPEC-PARITY — implemented routes == canonical spec. route_registry.pl drives the
-# live RestClient through a recording HttpClient and captures every dispatched route.
-spec_parity_gate() {
-    local mock_pkg_parent="$PORTING_SDK_DIR/test_harness/mock_signalwire"
-    export PYTHONPATH="$mock_pkg_parent${PYTHONPATH:+:$PYTHONPATH}"
-    local registry
-    registry="$(mktemp)"
-    perl -Ilib scripts/route_registry.pl >"$registry" 2>/dev/null || {
-        rm -f "$registry"
-        return 1
-    }
-    python3 "$PORTING_SDK_DIR/scripts/diff_spec_implementation.py" \
-        --registry-json "$registry" \
-        --gaps "$PORTING_SDK_DIR/SPEC_IMPLEMENTATION_GAPS.md"
-    local rc=$?
-    rm -f "$registry"
-    return $rc
-}
-
-# SURFACE-DIFF — diff the port's public surface against the Python reference.
-# Regenerate the surface in place, diff, restore unconditionally.
-surface_diff_gate() {
-    local committed="$PORT_ROOT/.sw-tmp/committed_surface_diff_${PORT_NAME}.$$"
-    git show HEAD:port_surface.json >"$committed" 2>/dev/null \
-        || cp port_surface.json "$committed"
-    perl scripts/enumerate_surface.pl --output port_surface.json
-    local regen_rc=$?
-    if [ "$regen_rc" -ne 0 ]; then
-        git checkout -- port_surface.json 2>/dev/null || true
-        rm -f "$committed"
-        echo "surface regen failed (exit $regen_rc)" >&2
-        return "$regen_rc"
-    fi
-    python3 "$PORTING_SDK_DIR/scripts/diff_port_surface.py" \
-        --reference "$PORTING_SDK_DIR/python_surface.json" \
-        --port-surface port_surface.json \
-        --omissions "$PORT_ROOT/PORT_OMISSIONS.md" \
-        --additions "$PORT_ROOT/PORT_ADDITIONS.md"
-    local rc=$?
-    git checkout -- port_surface.json 2>/dev/null || true
-    rm -f "$committed"
-    return $rc
-}
+# ---- Part 5: the per-gate --fn helpers are now DEAD — reproduced in the suites -
+# surface_fresh_gate (SURFACE-FRESH), rest_coverage_gate (REST-COVERAGE),
+# spec_parity_gate (SPEC-PARITY), and dayone_artifact_deny (ARTIFACT-DENY) used to
+# be defined here as `--fn` gate bodies. Those exact bodies — including the perl
+# specifics (Makefile.PL + make manifest → MANIFEST, prove -Ilib -It/lib t/rest/,
+# route_registry.pl capture, the MANIFEST restore + MakeMaker byproduct sweep) —
+# are now reproduced INSIDE the Part-5 suites (scripts/suites/_surface_fresh.py,
+# _rest_coverage.py, _spec_parity.py, _artifact_deny.py). pick_free_port() likewise
+# moved into the suites. (Byte-identity vs the old per-gate path is proven by
+# porting-sdk's tests/test_suite_parity*.py.)
 
 # ---- register gates ----------------------------------------------------------
 sched_init "$@"
 
-sched_gate GEN-FRESH desc="generate_rest.py --check (generated REST layer matches specs)" \
-    -- python3 scripts/generate_rest.py --check
-
-sched_gate GEN-FRESH-SWML desc="generate_swml_verbs.py --check (generated SWML-verb types match schema.json)" \
-    -- python3 scripts/generate_swml_verbs.py --check
-
-sched_gate GEN-FRESH-RELAY desc="generate_relay_protocol.py --check (generated RELAY types match relay-protocol)" \
-    -- python3 scripts/generate_relay_protocol.py --check
-
-sched_gate GEN-FRESH-SWAIG desc="generate_swaig_payloads.py --check (generated SWAIG payloads match swaig-specs)" \
-    -- python3 scripts/generate_swaig_payloads.py --check
-
-sched_gate GEN-FRESH-TESTS desc="generate_rest_tests.py --check (generated REST wire-test suite matches route-registry × spec oracle)" \
-    -- python3 scripts/generate_rest_tests.py --check
-
-# TEST joins res=surface — the working-tree-mutation group. FMT rewrites lib/**/*.pm
-# in place via `perltidy -b` when run locally; SURFACE-FRESH / SURFACE-DIFF rewrite
-# port_surface.json in place then `git checkout --` restore it. TEST `perl -c`-compiles
-# every bundled example and loads every SDK module for its 130+ test files, and
-# t/53/t/54 additionally read port_surface.json — so overlapping TEST with a gate
-# mid-rewrite makes a module/surface file load a transient/half-written copy and fail
-# nondeterministically (the moving `example parses:` / surface-audit failures). Sharing
-# the surface resource serializes TEST against those mutators; it still overlaps every
-# read-only gate (LINT, the differs, generators-in-check-mode).
+# HEAVY (deferred behind the cheap wave for S1 fail-fast). TEST joins res=surface —
+# the working-tree-mutation group. FMT rewrites lib/**/*.pm in place via `perltidy
+# -b` when run locally; the SURFACE suite rewrites port_surface.json in place then
+# restores it. TEST `perl -c`-compiles every bundled example and loads every SDK
+# module for its 130+ test files, and t/53/t/54 additionally read port_surface.json
+# — so overlapping TEST with a gate mid-rewrite makes a module/surface file load a
+# transient/half-written copy and fail nondeterministically. Sharing the surface
+# resource serializes TEST against those mutators; it still overlaps every read-only
+# gate (LINT, the differ suites in check mode).
 sched_gate TEST defer=1 res=surface desc="run-tests.sh (prove -Ilib -It/lib -r t/)" \
     -- bash scripts/run-tests.sh
 
-sched_gate SIGNATURES desc="regenerate port_signatures.json" \
-    -- python3 scripts/enumerate_signatures.py
+# ---- Part 5 gate SUITES ------------------------------------------------------
+# The former per-gate SIGNATURES/DRIFT/SURFACE-*/SEMVER-DIFF/GEN-TYPE-DEGENERACY/
+# GEN-IDIOM/GEN-FRESH*/BEHAVIORAL-*/EMISSION/ERROR-ENVELOPE/PAGINATION-WIRED/
+# DOC-WIRE/REST-COVERAGE/SPEC-PARITY/SKILL-CONTRACT/SWAIG-*/WAIT-LIVENESS/DOC-*/
+# COUNT-CLAIM/ACCESSOR-TRUTH/STATUS-CLAIM/README-INCLUDE/*-LEDGER/PACKAGE-SMOKE/
+# META-CONSISTENT/ARTIFACT-DENY/RELEASE-FRESH gates now run under 6 SUITE engines.
+# Each suite emits every original gate NAME as a `[SUITE:RULE] ... PASS/FAIL` rule
+# ID (failure identity + allowlists + finding output unchanged). A suite exits
+# nonzero iff any of its rules fails. Byte-identity vs the old per-gate path is
+# proven by porting-sdk/tests/test_suite_parity*.py.
+#
+# The `--fn` helpers the old gates used (surface_fresh_gate, rest_coverage_gate,
+# spec_parity_gate, dayone_artifact_deny, pick_free_port) are reproduced INSIDE the
+# suites, so they are no longer defined here.
+#
+# Former single-gate scheduler features preserved by the suites internally:
+#   * SIGNATURES→DRIFT ordering, the SEMVER-DIFF-reads-SIGNATURES data dep, and the
+#     SURFACE-FRESH regenerate-then-restore all live inside the SURFACE suite.
+#   * mixed tiers are split with --rules: PACKAGE + BEHAVIORAL each schedule a
+#     per-PR line and a nightly line (nightly members broken out below).
+# PERL-SPECIFIC vs the TS reference: perl's behavioral RELAY rule keeps perl's exact
+# spelling BEHAVIORAL-WIRE-RELAY (hyphen, same as ts). perl's SURFACE suite does NOT
+# carry ROUTE-COLLISION (route_collision.py has no default perl registry cmd and,
+# fed route_registry.pl, flags 2 un-approved ROUTE-SPLIT findings — a real
+# disposition held for a follow-up, NOT silenced here), matching perl's prior
+# standalone run-ci which likewise omitted it. DOC-AUDIT + STATUS-CLAIM read perl's
+# on-disk port_surface.json (POD-aware), which the SURFACE suite regenerates+restores
+# — so SURFACE and DOC-TRUTH share res=surface.
 
-sched_gate DRIFT deps=SIGNATURES desc="diff_port_signatures vs python reference" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_signatures.py" \
-        --reference "$PORTING_SDK_DIR/python_signatures.json" \
-        --port-signatures "$PORT_ROOT/port_signatures.json" \
-        --surface-omissions "$PORT_ROOT/PORT_OMISSIONS.md" \
-        --surface-additions "$PORT_ROOT/PORT_ADDITIONS.md" \
-        --omissions "$PORT_ROOT/PORT_SIGNATURE_OMISSIONS.md"
+# SURFACE (parity spine): SIGNATURES→DRIFT ordered, SURFACE-FRESH regen/restore,
+# SURFACE-DIFF, SEMVER-DIFF, GEN-TYPE-DEGENERACY, GEN-IDIOM — all read the one
+# enumeration. res=surface: SURFACE-FRESH regenerates port_surface.json in place
+# (and restores it), so it must not overlap DOC-TRUTH's DOC-AUDIT/STATUS-CLAIM read.
+sched_gate SURFACE res=surface desc="surface parity suite (SIGNATURES/DRIFT/SURFACE-FRESH/SURFACE-DIFF/SEMVER-DIFF/GEN-TYPE-DEGENERACY/GEN-IDIOM)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/surface.py" --port perl --repo "$PORT_ROOT"
 
-sched_gate SURFACE-FRESH res=surface desc="check_surface_freshness (regen port_surface.json)" \
-    --fn surface_fresh_gate
+# GEN (regen-from-specs family): the 5 GEN-FRESH rules. The perltidy backstop each
+# generator runs needs _env.sh (sourced above, exported into every worker subshell).
+sched_gate GEN defer=1 desc="generated-code freshness suite (GEN-FRESH/-TESTS/-RELAY/-SWAIG/-SWML)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/gen.py" --port perl --repo "$PORT_ROOT"
 
+# BEHAVIORAL (one Layer-D pass per rule): the per-PR rules. WAIT-LIVENESS (nightly)
+# is the separate line below. NOTE perl's hyphen spelling BEHAVIORAL-WIRE-RELAY.
+sched_gate BEHAVIORAL defer=1 desc="behavioral suite (BEHAVIORAL-*/EMISSION/ERROR-ENVELOPE/PAGINATION-WIRED/DOC-WIRE/REST-COVERAGE/SPEC-PARITY/SKILL-CONTRACT/SWAIG-COVERAGE/SWAIG-CLI)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/behavioral.py" --port perl --repo "$PORT_ROOT" \
+        --rules BEHAVIORAL-WIRE,BEHAVIORAL-SWML,BEHAVIORAL-STATE,BEHAVIORAL-HTTP,BEHAVIORAL-WIRE-RELAY,EMISSION,ERROR-ENVELOPE,PAGINATION-WIRED,DOC-WIRE,REST-COVERAGE,SPEC-PARITY,SKILL-CONTRACT,SWAIG-COVERAGE,SWAIG-CLI
+
+sched_gate BEHAVIORAL-NIGHTLY tier=nightly defer=1 desc="behavioral suite, nightly rules (WAIT-LIVENESS)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/behavioral.py" --port perl --repo "$PORT_ROOT" \
+        --rules WAIT-LIVENESS
+
+# DOC-TRUTH (one markdown+POD walk): DOC-AUDIT/DOC-LINKS/DOC-LANG-PURITY/DOC-ENV/
+# COUNT-CLAIM/ACCESSOR-TRUTH/STATUS-CLAIM/README-INCLUDE. POD-aware (perl's docs are
+# POD-first). res=surface: DOC-AUDIT + STATUS-CLAIM read perl's on-disk
+# port_surface.json, which the SURFACE suite regenerates+restores.
+sched_gate DOC-TRUTH res=surface desc="doc-truth suite (DOC-AUDIT/DOC-LINKS/DOC-LANG-PURITY/DOC-ENV/COUNT-CLAIM/ACCESSOR-TRUTH/STATUS-CLAIM/README-INCLUDE)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/doc_truth.py" --port perl --repo "$PORT_ROOT"
+
+# LEDGER: SUPPRESSION-LEDGER + IGNORE-LEDGER-VERIFY.
+sched_gate LEDGER res=dayone desc="ledger governance suite (SUPPRESSION-LEDGER/IGNORE-LEDGER-VERIFY)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/ledger.py" --port perl --repo "$PORT_ROOT"
+
+# PACKAGE: per-PR rules (ARTIFACT-DENY/RELEASE-FRESH); nightly rules (PACKAGE-SMOKE/
+# META-CONSISTENT) on the separate line below. ARTIFACT-DENY reproduces perl's
+# Makefile.PL + make manifest → MANIFEST listing + restore/sweep inside the suite.
+sched_gate PACKAGE res=dayone desc="package suite, per-PR rules (ARTIFACT-DENY/RELEASE-FRESH)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/package.py" --port perl --repo "$PORT_ROOT" \
+        --rules ARTIFACT-DENY,RELEASE-FRESH
+
+sched_gate PACKAGE-NIGHTLY tier=nightly defer=1 res=dayone desc="package suite, nightly rules (PACKAGE-SMOKE/META-CONSISTENT)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/package.py" --port perl --repo "$PORT_ROOT" \
+        --rules PACKAGE-SMOKE,META-CONSISTENT
+
+# ---- gates that stay standalone (native toolchains + singletons) -------------
 sched_gate NO-CHEAT desc="audit_no_cheat_tests" \
     -- python3 "$PORTING_SDK_DIR/scripts/audit_no_cheat_tests.py" --root "$PORT_ROOT"
 
-sched_gate REST-COVERAGE defer=1 desc="every implemented REST route covered success+error (parity + allowlist)" \
-    --fn rest_coverage_gate
-
-sched_gate SPEC-PARITY defer=1 desc="implemented routes == canonical spec (modulo SPEC_IMPLEMENTATION_GAPS.md)" \
-    --fn spec_parity_gate
-
-sched_gate EMISSION desc="diff_port_emission vs python to_dict()" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_emission.py" \
-        --dump-cmd "perl bin/emit-corpus.pl" \
-        --port-repo "$PORT_ROOT"
-
-# BEHAVIORAL-* (Layer D) — run the shared behavioral corpus through the port's
-# dump programs and structurally byte-compare against the signalwire-python oracle.
-# 2>/dev/null suppresses perl's experimental-feature warnings on stderr so ONLY JSON
-# reaches stdout; --python-sdk pins the oracle source (never the caller's CWD/env).
-sched_gate BEHAVIORAL-WIRE desc="diff_port_wire vs python oracle (Layer D)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_wire.py" \
-        --port perl --python-sdk "$PYTHON_SDK_DIR" \
-        --dump-cmd "perl -Ilib bin/wire-dump.pl 2>/dev/null"
-
-sched_gate BEHAVIORAL-SWML desc="diff_port_swml vs python oracle (Layer D)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_swml.py" \
-        --port perl --python-sdk "$PYTHON_SDK_DIR" \
-        --dump-cmd "perl -Ilib bin/swml-dump.pl 2>/dev/null"
-
-sched_gate BEHAVIORAL-STATE desc="diff_port_state vs python oracle (Layer D)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_state.py" \
-        --port perl --python-sdk "$PYTHON_SDK_DIR" \
-        --dump-cmd "perl -Ilib bin/state-dump.pl 2>/dev/null"
-
-sched_gate BEHAVIORAL-HTTP desc="diff_port_http vs python oracle (Layer D)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_http.py" \
-        --port perl --python-sdk "$PYTHON_SDK_DIR" \
-        --dump-cmd "perl -Ilib bin/http-dump.pl 2>/dev/null"
-
-sched_gate BEHAVIORAL-WIRE-RELAY desc="diff_port_wire_relay vs python oracle (Layer D)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_wire_relay.py" \
-        --port perl --python-sdk "$PYTHON_SDK_DIR" \
-        --dump-cmd "perl -Ilib bin/wire-relay-dump.pl 2>/dev/null"
-
 # FMT joins res=surface: run locally (no CI) it rewrites lib/**/*.pm in place via
-# `perltidy -b`, which a concurrent TEST (`perl -c` / module load) or surface-enumerator
-# (loads lib/) would otherwise read mid-write. Under CI (--check) it's read-only, but the
-# label is harmless there and keeps local and CI scheduling identical.
+# `perltidy -b`, which a concurrent TEST (`perl -c` / module load) or the surface
+# enumerator (loads lib/) would otherwise read mid-write. Under CI (--check) it's
+# read-only, but the label is harmless there and keeps local and CI scheduling
+# identical.
 sched_gate FMT defer=1 res=surface desc="run-format.sh (local: apply; CI: --check)" \
     -- bash scripts/run-format.sh ${CI:+--check}
 
 sched_gate LINT defer=1 desc="run-lint.sh (perlcritic severity 4, zero findings)" \
     -- bash scripts/run-lint.sh
 
-# ---- §C1 doc/example/CLI execution gates (mirrors python's run-ci.sh) ----
-# SNIPPET-COMPILE + DOC-CLI are cheap/blocking; EXAMPLES-RUN + SNIPPET-RUN are
-# defer=1 blocking. SNIPPET-RUN's residual was burned to zero (missing `use`
-# lines added, live-network/blocking-server/user-subclass snippets marked
-# `no-run`), so it now blocks like the other doc-execution gates.
+# ---- §C1 doc/example/CLI execution gates ------------------------------------
+# SNIPPET-COMPILE (documented code fences compile with lib/ on @INC) is HEAVY →
+# tier=nightly; DOC-CLI stays per-PR (cheap CLI-parse probe of documented swaig-test
+# invocations). EXAMPLES-RUN + SNIPPET-RUN execute/load the shipped examples + doc
+# snippets under STRICT-MOCKS on the nightly tier (MOCK_RELAY_STRICT=1: the mock_relay
+# REJECTS any inbound frame that violates the RELAY wire spec, so a wrong frame fails
+# LOUD instead of being silently journaled). `env VAR=val` (not a bare prefix) keeps
+# the command analyzable to the permission matcher.
 sched_gate SNIPPET-COMPILE tier=nightly desc="documented code snippets compile (perl -c with lib/ on @INC)" \
     -- python3 "$PORTING_SDK_DIR/scripts/snippet_compile.py" --port perl --repo .
 
 sched_gate DOC-CLI desc="documented swaig-test invocations parse against the real CLI" \
     -- python3 "$PORTING_SDK_DIR/scripts/doc_cli.py" --port perl --repo .
 
-# Wave-3 doc/API-truth gates — deterministic source/doc analysis (no build, no
-# mock, ~1.3s for all six). Per-PR tier: cheap enough to catch doc/API drift at
-# PR time rather than a day later in nightly.
-sched_gate ERROR-ENVELOPE desc="REST error carries the full (status,body,url,method) envelope + raised on >=400" \
-    -- python3 "$PORTING_SDK_DIR/scripts/error_envelope.py" --port perl --repo "$PORT_ROOT"
+# DEAD-PUBLIC-ERROR stays standalone (source analysis of exported error types — not
+# a doc-truth/behavioral rule). ERROR-ENVELOPE/PAGINATION-WIRED/DOC-WIRE run under
+# the BEHAVIORAL suite; DOC-ENV/COUNT-CLAIM/ACCESSOR-TRUTH/STATUS-CLAIM under
+# DOC-TRUTH.
 sched_gate DEAD-PUBLIC-ERROR desc="exported error types are raised/caught/user-signalled (no dead error surface)" \
     -- python3 "$PORTING_SDK_DIR/scripts/dead_public_error.py" --port perl --repo "$PORT_ROOT"
-sched_gate PAGINATION-WIRED desc="shipped iterator-protocol paginator is wired into list()" \
-    -- python3 "$PORTING_SDK_DIR/scripts/pagination_wired.py" --port perl --repo "$PORT_ROOT"
-sched_gate DOC-ENV desc="documented SIGNALWIRE_*/SWML_* env vars <=> code-read vars agree" \
-    -- python3 "$PORTING_SDK_DIR/scripts/doc_env.py" --port perl --repo "$PORT_ROOT"
-sched_gate COUNT-CLAIM desc="numeric doc claims (skills/namespaces) match reality" \
-    -- python3 "$PORTING_SDK_DIR/scripts/count_claim.py" --port perl --repo "$PORT_ROOT"
-sched_gate ACCESSOR-TRUTH desc="documented backtick method() refs exist in source" \
-    -- python3 "$PORTING_SDK_DIR/scripts/accessor_truth.py" --port perl --repo "$PORT_ROOT"
 
-# ---- gate-enforcement quartet (plan Parts A1/C2/2.4) ----
-# DOC-WIRE + STATUS-CLAIM are per-PR (POD-aware — perl's docs are POD-first).
-# WAIT-LIVENESS is nightly (spawns a dump program). GATE-INVENTORY is deliberately
-# NOT wired per-port: gen_gate_inventory.py resolves its reference as a sibling
-# signalwire-typescript checkout, absent in a port's CI layout (→ exit 2); it is
-# inherently porting-sdk-side and already runs in porting-sdk's own CI.
-#
-# DOC-WIRE (§A1) — the documented REST doc fixtures put the SPEC wire shape on the
-# wire (areacode not area_code, nested params:{text} not a flat item). doc_wire.py
-# spawns its OWN flag-mode mock (free port, self-cleaning) and replays the doc
-# fixtures via the runner, failing on any journaled wire_violations. Cheap/blocking.
-sched_gate DOC-WIRE desc="documented REST doc fixtures put the spec wire shape on the wire (areacode/params:{text})" \
-    -- python3 "$PORTING_SDK_DIR/scripts/doc_wire.py" --port perl --repo "$PORT_ROOT" \
-        --runner "perl $PORT_ROOT/scripts/doc_wire_runner.pl"
-
-# STATUS-CLAIM (§C2) — no false capability/status claims in docs OR POD (e.g. "not
-# yet implemented" next to a shipped method). POD-aware: scans lib/**/*.pm POD
-# blocks in addition to markdown. Deterministic source/doc analysis, cheap/blocking.
-sched_gate STATUS-CLAIM res=surface desc="doc/POD status/capability claims match the shipped surface" \
-    -- python3 "$PORTING_SDK_DIR/scripts/status_claim.py" --port perl --repo "$PORT_ROOT" \
-        --surface "$PORT_ROOT/port_surface.json"
-
-# WAIT-LIVENESS (§2.4) — the RELAY Action::wait() liveness contract: wait() BLOCKS
-# until the deferred completing event arrives, then returns (never a no-op early
-# return, never a hung wait). The corpus includes the NESTED wait case (wait inside
-# an on_completed callback → re-entrant _read_once). The port's dump classification
-# is diffed against the python-oracle golden. Nightly (spawns a dump program).
-sched_gate WAIT-LIVENESS tier=nightly defer=1 desc="wait() liveness corpus (incl. nested re-entrant wait) matches the python-oracle golden classification" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_wait_liveness.py" \
-        --port perl --python-sdk "$PYTHON_SDK_DIR" \
-        --dump-cmd "perl -Ilib $PORT_ROOT/bin/wait-liveness-dump.pl 2>/dev/null"
-
-# EXAMPLES-RUN + SNIPPET-RUN run under STRICT-MOCKS on the nightly tier
-# (MOCK_RELAY_STRICT=1): the mock_relay REJECTS any inbound frame that violates the
-# RELAY wire spec, so a shipped example / doc snippet that puts a wrong frame on the
-# wire fails LOUD instead of being silently ignored. `env VAR=val` (not a bare
-# prefix) keeps the command analyzable to the permission matcher.
 sched_gate EXAMPLES-RUN tier=nightly defer=1 desc="shipped examples load/start against the mock (modulo EXAMPLES_RUN_ALLOW.md; STRICT-MOCKS: MOCK_RELAY_STRICT=1)" \
     -- env MOCK_RELAY_STRICT=1 python3 "$PORTING_SDK_DIR/scripts/examples_run.py" --port perl --repo .
 
 sched_gate SNIPPET-RUN tier=nightly defer=1 desc="dynamic-port doc snippets run to a zero exit against the mock (STRICT-MOCKS: MOCK_RELAY_STRICT=1)" \
     -- env MOCK_RELAY_STRICT=1 python3 "$PORTING_SDK_DIR/scripts/snippet_run.py" --port perl --repo .
 
-# ---- §G anti-laundering ledger gate ----
-sched_gate SUPPRESSION-LEDGER res=dayone desc="no un-ledgered analyzer suppressions (perlcritic ## no critic etc.)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/suppression_ledger.py" --port perl --repo .
-
-# ---- §D1 packaging: build the real make-dist tarball, install clean, require it ----
-# Heavy (real per-port build) → defer=1, blocking (artifact builds/installs/imports).
-# package_smoke.py runs `perl Makefile.PL && make manifest && make dist` IN-TREE, so
-# (exactly like ARTIFACT-DENY) it rewrites the tracked MANIFEST and drops the dist
-# tarball. Wrap it so the tree is restored afterward — MANIFEST back to the committed
-# copy, MakeMaker byproducts + the tarball swept (tarball is .gitignore'd, but leave
-# no scratch behind per the repo cleanup rule).
-package_smoke_gate() {
-    python3 "$PORTING_SDK_DIR/scripts/package_smoke.py" --port perl --repo .
-    local rc=$?
-    git checkout -- MANIFEST 2>/dev/null || true
-    rm -f MANIFEST.bak MYMETA.json MYMETA.yml Makefile Makefile.old pm_to_blib \
-          SignalWire-*.tar SignalWire-*.tar.gz
-    return $rc
-}
-sched_gate PACKAGE-SMOKE tier=nightly defer=1 desc="real make-dist artifact builds, installs clean, and requires (MANIFEST completeness)" \
-    --fn package_smoke_gate
-
-sched_gate DOC-AUDIT res=surface desc="audit_docs vs port_surface.json" \
-    -- python3 "$PORTING_SDK_DIR/scripts/audit_docs.py" \
-        --root "$PORT_ROOT" \
-        --surface "$PORT_ROOT/port_surface.json" \
-        --ignore "$PORT_ROOT/DOC_AUDIT_IGNORE.md"
-
-sched_gate SURFACE-DIFF res=surface desc="diff_port_surface vs python reference" \
-    --fn surface_diff_gate
-
-sched_gate SKILL-CONTRACT desc="diff_skill_contracts vs python reference" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_skill_contracts.py" \
-        --dump-cmd "perl bin/emit-skills.pl" \
-        --port-repo "$PORT_ROOT"
-
-sched_gate SWAIG-CLI desc="swaig-test shared mini-contract (verbs/serverless-reject/default-action)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/audit_swaig_cli_contract.py" \
-        --port perl \
-        --cmd "perl -I$PORT_ROOT/lib $PORT_ROOT/bin/swaig-test" \
-        --require-url-model \
-        --default-action-argv='--url|http://user:pass@127.0.0.1:1/' \
-        --no-serverless-argv='--url|http://user:pass@127.0.0.1:1/|--simulate-serverless|lambda|--list-tools'
-
-sched_gate SWAIG-COVERAGE desc="every engine SWAIG action emittable by FunctionResult (or allowlisted)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/swaig_coverage.py" --check \
-        --emission "$PORT_ROOT/lib/SignalWire/SWAIG/FunctionResult.pm"
-
-sched_gate DOC-LANG-PURITY res=dayone desc="no python-verbatim docs in a non-python port" \
-    -- python3 "$PORTING_SDK_DIR/scripts/doc_lang_purity.py" --port perl --repo .
-
-sched_gate DOC-LINKS res=dayone desc="every relative markdown link resolves to a tracked file" \
-    -- python3 "$PORTING_SDK_DIR/scripts/doc_links.py" --port perl --repo .
-
-sched_gate README-INCLUDE res=dayone desc="doc code blocks are byte-identical to their gate-compiled fixture regions" \
-    -- python3 "$PORTING_SDK_DIR/scripts/readme_include.py" --port perl --repo .
-
+# ROOT-HYGIENE + PUBLIC-JARGON stay standalone (source/root analysis, not a suite
+# family).
 sched_gate ROOT-HYGIENE res=dayone desc="no audit/scratch clutter tracked at repo root (allowlist ROOT_HYGIENE_ALLOW.md)" \
     -- python3 "$PORTING_SDK_DIR/scripts/root_hygiene.py" --port perl --repo .
-
-sched_gate IGNORE-LEDGER-VERIFY res=dayone desc="no laundered false-absence entries in DOC_AUDIT_IGNORE.md (strict: reason/approver/date required)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/ignore_ledger_verify.py" --port perl --repo . --require-fields
-
-sched_gate SEMVER-DIFF res=dayone desc="version bump matches API surface change vs release floor (port_signatures.baseline.json)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/semver_diff.py" --port perl --repo .
-
-sched_gate META-CONSISTENT tier=nightly res=dayone desc="package metadata consistency" \
-    -- python3 "$PORTING_SDK_DIR/scripts/meta_consistent.py" --port perl --repo .
-
-sched_gate ARTIFACT-DENY res=dayone desc="no porting artifacts in the PUBLISHED package (authoritative listing)" \
-    --fn dayone_artifact_deny
-
-# ---- expansion gates (Tier 5, now BLOCKING — backlog burned + allowlists approved) ---
-# Wired the same way as the Day-one gates above: single approvable
-# `python3 "$PORTING_SDK_DIR/scripts/<gate>.py" --port perl --repo .` prefix, NO
-# --report-only. Each was verified to exit 0 enforcing before wiring.
-#   * ROUTE-COLLISION is NOT wired for perl: route_collision.py has no default
-#     registry command for perl and, fed perl's route_registry.pl, currently flags
-#     2 ROUTE-SPLIT findings (call_flows/conference_rooms list_addresses, singular-
-#     vs-plural fabric path) with no human-approved ROUTE_COLLISION_ALLOW.md — a
-#     real disposition, held for a follow-up, not silenced here.
-sched_gate GEN-TYPE-DEGENERACY res=dayone desc="no degenerate generated typed aliases (allowlist GEN_TYPE_DEGENERACY_ALLOW.md)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/gen_type_degeneracy.py" --port perl --repo .
 
 sched_gate PUBLIC-JARGON res=dayone desc="no porting/internal jargon leaked into the public surface" \
     -- python3 "$PORTING_SDK_DIR/scripts/public_jargon.py" --port perl --repo .
 
-sched_gate GEN-IDIOM res=dayone desc="generated code is not lint-excluded (holds to the same idiom bar)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/gen_idiom.py" --port perl --repo .
-
-sched_gate RELEASE-FRESH res=dayone desc="publish workflow runs the gates before publishing (publish.yml gated)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/release_fresh.py" --port perl --repo .
+# ---- summary ----------------------------------------------------------------
 
 sched_run
 rc=$?


### PR DESCRIPTION
## Part 5 — wire the gate suites into run-ci

Replaces this port's ~40 per-gate `sched_gate` lines with the **6 suite units** (SURFACE, GEN, BEHAVIORAL, DOC-TRUTH, LEDGER, PACKAGE) + the nightly split lines (BEHAVIORAL-NIGHTLY, PACKAGE-NIGHTLY), from the porting-sdk suite engines. The port's stay gates (TEST/LINT/FMT + singletons) are untouched.

**Verified:** the union of this port's stay gates + every rule ID the suites emit == the pre-wiring gate baseline exactly — **no gate lost or invented** (proven via the scheduler's `SW_CI_LIST` manifest). Dead `--fn` helper functions (now reproduced inside the suites) removed. run-ci passes.

**Depends on** signalwire/porting-sdk#100 (the suite engines + `scripts/suites/*`) — merge that first; this port resolves the suites from the adjacent porting-sdk at CI time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
