### PR TITLE
Gate enforcement (consolidated): strict-mocks + part5 suites + RELAY action-wrap

### DIFF
--- a/ROOT_HYGIENE_ALLOW.md
+++ b/ROOT_HYGIENE_ALLOW.md
@@ -23,3 +23,4 @@ load-bearing audit-contract file, not clutter.
 - ARTIFACT_DENY_ALLOW.md — artifact-deny allowlist file read by the artifact_deny gate at repo root (orchestrator, 2026-07-06)
 - EXAMPLES_RUN_ALLOW.md — examples-run allowlist file read by the porting-sdk examples_run gate at repo root (burn-perl, 2026-07-09)
 - SNIPPET_RUN_ALLOW.md — snippet-run allowlist file read by the porting-sdk snippet_run gate at repo root (burn-perl, 2026-07-09)
+- WIRE_VIOLATIONS_ALLOW.md — STRICT-MOCKS signed-exception ledger read by porting-sdk assert_no_wire_violations.py / examples_run.py / snippet_run.py at repo root (mike@signalwire.com, 2026-07-18)

--- a/WIRE_VIOLATIONS_ALLOW.md
+++ b/WIRE_VIOLATIONS_ALLOW.md
@@ -1,0 +1,29 @@
+# WIRE_VIOLATIONS_ALLOW.md — signed exceptions to the STRICT-MOCKS wire-truth gate
+
+The STRICT-MOCKS consumer (`porting-sdk/scripts/assert_no_wire_violations.py`, wired
+into REST-COVERAGE) reads the mock journal after a run and fails on ANY
+`wire_violation` — a request/frame that put a shape on the wire the OpenAPI/RELAY
+spec does not declare (an undeclared query param, an unknown body key, an unknown
+frame field). A wire violation is a spec bug or a real defect; the fix is to make
+the wire match the spec, NOT to allowlist it.
+
+This file exists for the rare, genuinely-justified exception, and each entry needs a
+human-signed reason. Format (one per line):
+
+    - <kind>:<name> — reason (approver, date)
+
+where `<kind>` is the violation kind (`unknown_query_param`, `unknown_body_key`,
+`unknown_frame_field`, `duplicate_command_id`) and `<name>` is the offending
+key/param name. A bare `kind:name` with no ` — reason` is NOT matched, so it cannot
+silently widen the allowlist.
+
+## Currently empty
+
+No entries. The wired gate (REST-COVERAGE) runs wire-clean against the reference.
+
+The `page_token`/`page_size` pagination params are declared on the relevant
+`list_*` operations in the spec this port builds against (fabric addresses,
+relay-rest recordings, etc.), so the pagination test fixture
+(`t/rest/16_pagination_mock.t`) uses the real `page_token` cursor param — no parked
+gap here (unlike ports pinned to an older porting-sdk spec revision that still
+lacks that declaration).

--- a/bin/emit-envelope.pl
+++ b/bin/emit-envelope.pl
@@ -1,0 +1,364 @@
+#!/usr/bin/env perl
+# Copyright (c) 2025 SignalWire
+# Licensed under the MIT License.
+#
+# emit-envelope.pl — the Perl port's REST error-ENVELOPE dump program for the
+# cross-port envelope differ (porting-sdk/scripts/diff_port_envelope.py).
+#
+# It runs the shared error-envelope corpus
+# (porting-sdk/scripts/envelope_corpus.py — the single source of truth) against
+# the Perl SDK's REAL REST client driven at a live mock_signalwire server, and
+# prints ONE JSON object mapping
+#
+#     case-id -> reduced-artifact
+#
+# to stdout. The differ builds the golden Python oracle the same way and
+# byte-compares each artifact. Only stdout carries the JSON object; logs and
+# diagnostics go to stderr.
+#
+# The reduced artifact is the shared cross-port denominator (see the
+# envelope_corpus module docstring):
+#
+#     {
+#       "raised":          <bool>,       # a typed error was raised (vs a success)
+#       "error_kind":      "typed" | "bare:<Class>" | null,
+#       "status_code":     <int|null>,   # the HTTP status the client decoded, or
+#                                        # null for a TRANSPORT failure (no status)
+#       "body_error_code": <str|null>,   # decoded errors[0].code, or null
+#       "request_count":   <int>         # journal hits for this route (1 == no retry)
+#     }
+#
+# CONTRACT (why this file looks the way it does):
+#   - The corpus is read at runtime from the shared spec
+#     (porting-sdk/scripts/envelope_corpus.py's CORPUS, data-only — it does NOT
+#     import signalwire-python), so the id/case set is IDENTICAL to the oracle by
+#     construction.
+#   - Each non-transport case ARMS a one-shot scenario on the mock
+#     (`POST /__mock__/scenarios/<endpoint>?session_id=<auth>`), scoped to THIS
+#     process's Authorization header so a concurrent test can't consume it, then
+#     runs the real client and reduces the raised SignalWireRestError.
+#   - A `transport` case points the client at a DEAD port (a free port bound then
+#     released, so nothing is listening) — the connection-refused path. A correct
+#     client raises its TYPED transport error (SignalWireRestTransportError, a
+#     SignalWireRestError-family member, status_code => undef) => error_kind
+#     "typed", status_code null, request_count 0. A client leaking a bare
+#     HTTP::Tiny synthetic-599 error would report bare:<Class> and FAIL.
+#   - request_count is read from the mock JOURNAL (auth-scoped to this process),
+#     counting entries whose path matches the call — 1 proves NO retry, 0 proves
+#     nothing reached a server (transport).
+#
+# Run from the signalwire-perl repo root:
+#
+#     perl bin/emit-envelope.pl
+#
+# (the differ invokes exactly this; see PORT_DUMP_CMDS / --dump-cmd).
+
+use strict;
+use warnings;
+use feature 'signatures';
+no warnings 'experimental::signatures';
+
+use FindBin qw($RealBin);
+use File::Spec;
+use JSON ();
+use HTTP::Tiny ();
+use IO::Socket::INET ();
+use Scalar::Util ();
+use POSIX ();
+
+# Make the SDK importable when run from the repo root (bin/.. = repo root; lib/
+# and t/lib are siblings of bin/).
+use lib File::Spec->catdir( $RealBin, File::Spec->updir, 'lib' );
+use lib File::Spec->catdir( $RealBin, File::Spec->updir, 't', 'lib' );
+
+use SignalWire::REST::HttpClient;
+use SignalWire::REST::RestClient;
+use MockTest ();
+
+# The mock child pid we spawn (if any), torn down on exit.
+my $OUR_MOCK_PID;
+
+# --------------------------------------------------------------------------- #
+# Locate + load the shared corpus spec.
+# --------------------------------------------------------------------------- #
+# The corpus is the SINGLE source of truth (porting-sdk/scripts/envelope_corpus.py's
+# CORPUS list — data-only; it does NOT import signalwire-python). It has no CLI
+# dumper, so we import the module and print CORPUS as JSON via a tiny python
+# invocation. We locate the scripts/ dir by walking up from this file to an
+# adjacent porting-sdk/ checkout (the same adjacency contract MockTest uses).
+sub find_corpus_dir {
+    if ( my $p = $ENV{ENVELOPE_CORPUS_DIR} ) {
+        return $p if -d $p;
+        die "emit-envelope: ENVELOPE_CORPUS_DIR=$p is not a directory\n";
+    }
+    my $dir = $RealBin;
+    for ( 1 .. 8 ) {
+        my $cand = File::Spec->catdir( $dir, File::Spec->updir, 'porting-sdk', 'scripts' );
+        return File::Spec->rel2abs($cand)
+            if -f File::Spec->catfile( $cand, 'envelope_corpus.py' );
+        my $parent = File::Spec->catdir( $dir, File::Spec->updir );
+        last if File::Spec->rel2abs($parent) eq File::Spec->rel2abs($dir);
+        $dir = $parent;
+    }
+    my $home = $ENV{HOME} // '';
+    if ($home) {
+        my $cand = File::Spec->catdir( $home, 'src', 'porting-sdk', 'scripts' );
+        return File::Spec->rel2abs($cand)
+            if -f File::Spec->catfile( $cand, 'envelope_corpus.py' );
+    }
+    die "emit-envelope: cannot locate porting-sdk/scripts/envelope_corpus.py "
+        . "(clone porting-sdk adjacent to this repo, or set ENVELOPE_CORPUS_DIR).\n";
+}
+
+sub load_corpus {
+    my $dir = find_corpus_dir();
+    local $ENV{ENVELOPE_CORPUS_SCRIPTS} = $dir;
+    my $py =
+          'import os,sys,json; sys.path.insert(0, os.environ["ENVELOPE_CORPUS_SCRIPTS"]); '
+        . 'import envelope_corpus as ec; sys.stdout.write(json.dumps(ec.CORPUS))';
+    my $json = qx{python3 -c '$py'};
+    die "emit-envelope: failed to load envelope_corpus from $dir (exit $?)\n" if $? != 0;
+    die "emit-envelope: empty corpus from $dir\n" unless length $json;
+    return JSON->new->decode($json);
+}
+
+# --------------------------------------------------------------------------- #
+# Mock control-plane helpers (arm scenario / reset / journal), auth-scoped to
+# THIS process so a concurrent test on the shared mock can't cross-contaminate.
+# --------------------------------------------------------------------------- #
+my $UA = HTTP::Tiny->new( timeout => 10 );
+
+sub scope_query {
+    ( my $enc = $MockTest::ACTIVE_AUTH ) =~ s/([^A-Za-z0-9_.~-])/sprintf('%%%02X', ord($1))/ge;
+    return "?session_id=$enc";
+}
+
+sub reset_journal {
+    $UA->post("$MockTest::BASE_URL/__mock__/journal/reset");
+    return;
+}
+
+sub reset_scenarios {
+    $UA->post( "$MockTest::BASE_URL/__mock__/scenarios/reset" . scope_query() );
+    return;
+}
+
+# Arm the FULL scenario JSON (status / response / headers? / delay_ms?) — unlike
+# MockTest::scenario_set, which only forwards {status,response}, the corpus needs
+# headers (Retry-After) + delay_ms passed through verbatim.
+sub arm_scenario ( $endpoint, $scenario ) {
+    my $payload = JSON->new->canonical->encode($scenario);
+    my $resp    = $UA->post(
+        "$MockTest::BASE_URL/__mock__/scenarios/$endpoint" . scope_query(),
+        { content => $payload, headers => { 'Content-Type' => 'application/json' } },
+    );
+    die "emit-envelope: arm_scenario($endpoint) failed: $resp->{status} $resp->{content}\n"
+        unless $resp->{success};
+    return;
+}
+
+# Count journal entries (auth-scoped by MockTest::journal_all) whose path matches
+# the call path — the retry check (1 == no retry, 0 == nothing reached a server).
+sub request_count ($path) {
+    my $entries = MockTest::journal_all();
+    return scalar grep { ( $_->{path} // '' ) eq $path } @$entries;
+}
+
+# --------------------------------------------------------------------------- #
+# Dead-port picker for the transport (connection-refused) case: bind an ephemeral
+# port then release it, so nothing is listening on it.
+# --------------------------------------------------------------------------- #
+sub dead_port {
+    my $s = IO::Socket::INET->new(
+        LocalAddr => '127.0.0.1',
+        LocalPort => 0,
+        Proto     => 'tcp',
+        Listen    => 1,
+    ) or die "emit-envelope: cannot bind a probe port: $!\n";
+    my $port = $s->sockport;
+    $s->close;
+    return $port;
+}
+
+# --------------------------------------------------------------------------- #
+# Decode errors[0].code out of a raised error's body (string or hashref), or
+# undef — mirrors the oracle's _decode_body_error_code so the denominator is the
+# same shape on both sides.
+# --------------------------------------------------------------------------- #
+sub decode_body_error_code ($body) {
+    return undef unless defined $body;
+    my $decoded = $body;
+    if ( !ref $body ) {
+        $decoded = eval { JSON::decode_json($body) };
+        return undef if $@ || !defined $decoded;
+    }
+    return undef unless ref $decoded eq 'HASH';
+    my $errs = $decoded->{errors};
+    return undef unless ref $errs eq 'ARRAY' && @$errs && ref $errs->[0] eq 'HASH';
+    my $code = $errs->[0]{code};
+    return ( defined $code && !ref $code ) ? $code : undef;
+}
+
+# --------------------------------------------------------------------------- #
+# Run one corpus case, return the reduced artifact hashref.
+# --------------------------------------------------------------------------- #
+sub run_case ($case) {
+    my $call = $case->{call};
+    my $path = $call->{path};
+
+    my %artifact = (
+        raised          => JSON::false,
+        error_kind      => undef,
+        status_code     => undef,
+        body_error_code => undef,
+        request_count   => 0,
+    );
+
+    # Fresh journal + scenarios per case so request_count is exact.
+    reset_journal();
+    reset_scenarios();
+
+    my $scen = $case->{scenario};
+    arm_scenario( $case->{endpoint}, $scen ) if defined $scen;
+
+    # Build the client. For a transport case, point it at a DEAD port so the
+    # connection is refused; otherwise at the live mock.
+    my $host = $MockTest::BASE_URL;
+    if ( $case->{transport} ) {
+        $host = 'http://127.0.0.1:' . dead_port();
+    }
+    my $client = SignalWire::REST::RestClient->new(
+        project => $MockTest::PROJECT,
+        token   => $MockTest::TOKEN,
+        host    => $host,
+    );
+    my $http = $client->_http;
+
+    eval {
+        if ( $call->{method} eq 'GET' ) {
+            $http->get($path);
+        } else {
+            $http->_request( $call->{method}, $path );
+        }
+        1;
+    } or do {
+        my $err = $@;
+        $artifact{raised} = JSON::true;
+        if ( Scalar::Util::blessed($err) && $err->isa('SignalWireRestError') ) {
+            $artifact{error_kind} = 'typed';
+
+            # NUMIFY the status so JSON renders it as an integer (404), matching the
+            # oracle — HTTP::Tiny's status is a string scalar, which JSON would emit
+            # as "404". A transport error's status_code is undef and stays null.
+            my $sc = $err->status_code;
+            $artifact{status_code} = defined $sc ? ( $sc + 0 ) : undef;
+            $artifact{body_error_code} = decode_body_error_code( $err->body );
+        } else {
+            # A BARE error (string die or a non-family object) — the contract
+            # violation the differ flags as bare:<Class>.
+            my $cls = Scalar::Util::blessed($err) ? ref($err) : 'string';
+            $artifact{error_kind} = "bare:$cls";
+        }
+    };
+
+    # request_count: 0 for the transport case (nothing reached a server); else
+    # the journal hits for this route.
+    $artifact{request_count} = $case->{transport} ? 0 : request_count($path);
+
+    return \%artifact;
+}
+
+# --------------------------------------------------------------------------- #
+# Bring up the mock_signalwire server and point MockTest's journal/scope helpers
+# at it. Three modes, in order:
+#   1. MOCK_SIGNALWIRE_PORT set (the CI gate pre-spawned one) -> probe + reuse.
+#   2. A server already answering on MockTest's chosen BASE_URL -> reuse.
+#   3. Otherwise spawn `python -m mock_signalwire` OURSELVES, redirecting the
+#      child's stdout/stderr to a log FILE (not closing them — closing the pipe
+#      makes the mock take a SIGPIPE on its startup banner and die, which is the
+#      failure MockTest's own open3 spawn hits when it has to spawn).
+# We drive MockTest's journal/auth/scope helpers by setting its BASE_URL and
+# marking it ensured, so its per-process auth scoping (request_count) still works.
+# --------------------------------------------------------------------------- #
+sub _probe_health ($base) {
+    my $r = HTTP::Tiny->new( timeout => 3 )->get("$base/__mock__/health");
+    return 0 unless $r->{success};
+    my $p = eval { JSON::decode_json( $r->{content} || '{}' ) };
+    return ( !$@ && ref $p eq 'HASH' && exists $p->{specs_loaded} ) ? 1 : 0;
+}
+
+sub ensure_mock {
+    # Already answering (pre-spawned via MOCK_SIGNALWIRE_PORT, or a reused one)?
+    return if _probe_health($MockTest::BASE_URL);
+
+    # Spawn our own. Locate the mock package via the adjacency walk MockTest uses.
+    my $pkg = MockTest::discover_porting_sdk_package('mock_signalwire');
+    if ( defined $pkg ) {
+        my $sep = ':';
+        $ENV{PYTHONPATH} =
+            defined $ENV{PYTHONPATH} && length $ENV{PYTHONPATH}
+            ? "$pkg$sep$ENV{PYTHONPATH}"
+            : $pkg;
+    }
+
+    my $logdir = $ENV{TMPDIR} || File::Spec->catdir( $RealBin, File::Spec->updir, '.sw-tmp' );
+    mkdir $logdir unless -d $logdir;
+    my $log = File::Spec->catfile( $logdir, "emit-envelope-mock.$$.log" );
+
+    my $pid = fork();
+    die "emit-envelope: fork failed: $!\n" unless defined $pid;
+    if ( $pid == 0 ) {
+
+        # Child: redirect stdout+stderr to the log FILE (so the mock's startup
+        # banner writes succeed — a closed pipe would SIGPIPE it dead), then exec.
+        open( STDOUT, '>', $log ) or POSIX::_exit(127);
+        open( STDERR, '>&', \*STDOUT ) or POSIX::_exit(127);
+        exec( 'python', '-m', 'mock_signalwire',
+            '--host', $MockTest::HOST, '--port', $MockTest::PORT, '--log-level', 'error' )
+            or POSIX::_exit(127);
+    }
+    $OUR_MOCK_PID = $pid;
+
+    my $deadline = time + 30;
+    while ( time < $deadline ) {
+        return if _probe_health($MockTest::BASE_URL);
+
+        # Fail loud if the child died (don't hang the full 30s on a dead mock).
+        if ( waitpid( $pid, 1 ) == $pid ) {    # 1 == WNOHANG
+            my $tail = -f $log ? do { local ( @ARGV, $/ ) = $log; <> } : '';
+            die "emit-envelope: mock_signalwire died on startup (log $log):\n$tail\n";
+        }
+        select( undef, undef, undef, 0.2 );
+    }
+    die "emit-envelope: mock_signalwire did not become ready on $MockTest::BASE_URL "
+        . "within 30s (log $log)\n";
+}
+
+END {
+    if ($OUR_MOCK_PID) {
+        kill 'TERM', $OUR_MOCK_PID;
+        waitpid( $OUR_MOCK_PID, 0 );
+    }
+}
+
+# --------------------------------------------------------------------------- #
+# main: emit one JSON object { id => artifact }.
+# --------------------------------------------------------------------------- #
+sub main {
+    my $corpus = load_corpus();
+
+    ensure_mock();
+
+    my %out;
+    my %seen;
+    for my $case (@$corpus) {
+        my $id = $case->{id};
+        die "emit-envelope: duplicate corpus id '$id'\n" if $seen{$id}++;
+        $out{$id} = run_case($case);
+    }
+
+    print JSON->new->canonical->encode( \%out ), "\n";
+    return 0;
+}
+
+exit main();

--- a/bin/wire-relay-dump.pl
+++ b/bin/wire-relay-dump.pl
@@ -195,6 +195,20 @@ sub capture_verbs ($out) {
     );
     $out->{relay_send_fax} = $c->last_frame;
 
+    # relay_live_transcribe: caller's action MUST land as params.action (the
+    # authoritative wire schema requires it -- relay-protocol/calling.live_transcribe.params.json).
+    $c = new_client();
+    new_call($c)->live_transcribe( { start => { lang => 'en' } } );
+    $out->{relay_live_transcribe} = $c->last_frame;
+
+    # relay_live_translate: same contract, plus optional sibling status_url.
+    $c = new_client();
+    new_call($c)->live_translate(
+        { start => { from_lang => 'en', to_lang => 'es' } },
+        status_url => 'https://x/cb',
+    );
+    $out->{relay_live_translate} = $c->last_frame;
+
     # ---- control-ops (Action methods) ----
     # relay_play_stop
     $c = new_client();

--- a/lib/SignalWire/REST/HttpClient.pm
+++ b/lib/SignalWire/REST/HttpClient.pm
@@ -104,6 +104,26 @@ sub _request {
     my $response = $self->_ua->request( $method, $url, \%request_opts );
 
     unless ( $response->{success} ) {
+
+        # Distinguish a TRANSPORT failure (the request never reached the server --
+        # connection refused, DNS failure, connection reset, TLS error) from a real
+        # HTTP >= 400 response. HTTP::Tiny does NOT throw on a transport failure; it
+        # SYNTHESISES a response with status 599 / reason "Internal Exception" (599 is
+        # reserved by HTTP::Tiny for its own internal exceptions -- no real server
+        # sends it). Map that synthetic 599 to the TYPED transport error
+        # (SignalWireRestTransportError, status_code => undef), a member of the
+        # SignalWireRestError family, so a caller catching SignalWireRestError handles
+        # every REST failure (HTTP + transport) with one eval -- instead of a raw 599
+        # leaking through as if the server had answered. Python parity:
+        # signalwire.rest._base.SignalWireRestTransportError (plan 1.3b).
+        if ( _is_transport_failure($response) ) {
+            die SignalWireRestTransportError->new(
+                body   => $response->{content} // '',
+                url    => $path,
+                method => $method,
+            );
+        }
+
         my $body = $response->{content} // '';
         my $parsed;
         eval { $parsed = decode_json($body) };
@@ -154,6 +174,25 @@ sub delete_request {
     return $self->_request( 'DELETE', $path );
 }
 
+# Detect an HTTP::Tiny TRANSPORT failure vs a real HTTP error response.
+#
+# On a connection-level failure (connect refused, DNS failure, connection reset,
+# TLS handshake error, read timeout) HTTP::Tiny does NOT die; it returns a
+# SYNTHETIC response hashref with status => 599 and reason => "Internal Exception"
+# (documented behaviour: 599 is reserved by HTTP::Tiny for its own internal
+# exceptions, and no real HTTP server issues a 599). That synthetic 599 is the
+# ONLY transport signal we treat specially -- a genuine >= 400 from the server
+# (400/404/422/429/500/503/...) stays on the normal HTTP-error path and keeps its
+# real status_code. Guard on both status 599 AND the "Internal Exception" reason so
+# an (impossible-but-defensive) real 599 from a server would not be misclassified.
+sub _is_transport_failure {
+    my ($response) = @_;
+    return 0 unless ref $response eq 'HASH';
+    return 0 unless defined $response->{status} && $response->{status} == 599;
+    my $reason = $response->{reason} // '';
+    return $reason eq 'Internal Exception' ? 1 : 0;
+}
+
 # Simple URI encoding
 sub _uri_encode {
     my ($str) = @_;
@@ -182,6 +221,12 @@ has 'method'      => ( is => 'ro', default  => sub { 'GET' } );
 use overload '""' => sub {
     my ($self) = @_;
     my $body = ref $self->body ? encode_json( $self->body ) : ( $self->body // '' );
+
+    # A TRANSPORT failure carries no HTTP status (status_code is undef): render
+    # "failed to reach the server" instead of "returned : ..." (Python parity).
+    if ( !defined $self->status_code ) {
+        return sprintf( '%s %s failed to reach the server: %s', $self->method, $self->url, $body );
+    }
     return sprintf( '%s %s returned %s: %s', $self->method, $self->url, $self->status_code, $body );
 };
 
@@ -190,6 +235,24 @@ use overload '""' => sub {
 # SignalWireRestError's so the two names are the SAME class — an instance
 # ->isa() both, and existing `isa_ok($e, 'SignalWire::REST::HttpClient::Error')`
 # checks keep passing without re-blessing.
+# --- Typed transport error ---
+#
+# SignalWireRestTransportError is raised when a REST request never reached a
+# response -- a transport-level failure (connection refused, DNS failure,
+# connection reset, TLS error). It is a SUBCLASS of SignalWireRestError (an
+# instance ->isa('SignalWireRestError')), so a caller catching the base family
+# handles both HTTP-error and transport-error failures with one eval, instead of a
+# bare HTTP::Tiny synthetic 599 leaking through as if the server had answered. Its
+# status_code is undef (there was no HTTP status) and body carries the underlying
+# transport message. Python parity: signalwire.rest._base.SignalWireRestTransportError.
+package SignalWireRestTransportError;    ## no critic (ProhibitMultiplePackages)
+use Moo;
+extends 'SignalWireRestError';
+
+# status_code is required on the base but is undef for a transport failure (no HTTP
+# status ever arrived). Override to default to undef so callers may omit it.
+has '+status_code' => ( is => 'ro', required => 0, default => sub { undef } );
+
 package SignalWire::REST::HttpClient::Error;    ## no critic (ProhibitMultiplePackages)
 BEGIN { *SignalWire::REST::HttpClient::Error:: = *SignalWireRestError:: }
 

--- a/lib/SignalWire/Relay/Call.pm
+++ b/lib/SignalWire/Relay/Call.pm
@@ -355,12 +355,12 @@ sub clear_digit_bindings ( $self, %opts ) {
     return $self->_execute( 'calling.clear_digit_bindings', %opts );
 }
 
-sub live_transcribe ( $self, %opts ) {
-    return $self->_execute( 'calling.live_transcribe', %opts );
+sub live_transcribe ( $self, $action, %opts ) {
+    return $self->_execute( 'calling.live_transcribe', action => $action, %opts );
 }
 
-sub live_translate ( $self, %opts ) {
-    return $self->_execute( 'calling.live_translate', %opts );
+sub live_translate ( $self, $action, %opts ) {
+    return $self->_execute( 'calling.live_translate', action => $action, %opts );
 }
 
 sub join_room ( $self, %opts ) {

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -27746,7 +27746,7 @@
                 },
                 {
                   "name": "status_code",
-                  "type": "int",
+                  "type": "optional<int>",
                   "required": false
                 },
                 {
@@ -27795,6 +27795,48 @@
               "returns": "any"
             },
             "url": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                }
+              ],
+              "returns": "any"
+            }
+          }
+        },
+        "SignalWireRestTransportError": {
+          "methods": {
+            "__init__": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "body",
+                  "type": "any",
+                  "required": false
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false
+                },
+                {
+                  "name": "method",
+                  "type": "string",
+                  "required": false
+                },
+                {
+                  "name": "status_code",
+                  "type": "any",
+                  "required": false
+                }
+              ],
+              "returns": "void"
+            },
+            "status_code": {
               "params": [
                 {
                   "name": "self",

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,5 +1,5 @@
 {
-   "generated_from" : "signalwire-perl @ 2a5209a49f57a4008b25a794375ef634f6f7374f",
+   "generated_from" : "signalwire-perl @ 82d9361cdae1e64b46bda560816d05d4576b5e50",
    "modules" : {
       "signalwire" : {
          "classes" : {},
@@ -1360,6 +1360,9 @@
                "paginate"
             ],
             "SignalWireRestError" : [
+               "__init__"
+            ],
+            "SignalWireRestTransportError" : [
                "__init__"
             ]
          },

--- a/relay/docs/call-methods.md
+++ b/relay/docs/call-methods.md
@@ -400,11 +400,11 @@ $action->stop;
 
 ## Live Transcribe / Translate
 
-### `live_transcribe(%opts)` / `live_translate(%opts)`
+### `live_transcribe($action, %opts)` / `live_translate($action, %opts)`
 
 ```perl
-$call->live_transcribe(action => { start => { lang => 'en-US' } });
-$call->live_translate(action => { start => { from_lang => 'en-US', to_lang => 'es' } });
+$call->live_transcribe({ start => { lang => 'en-US' } });
+$call->live_translate({ start => { from_lang => 'en-US', to_lang => 'es' } });
 ```
 
 ## Echo

--- a/relay/docs/call-methods.md
+++ b/relay/docs/call-methods.md
@@ -403,8 +403,8 @@ $action->stop;
 ### `live_transcribe(%opts)` / `live_translate(%opts)`
 
 ```perl
-$call->live_transcribe(start => { language => 'en-US' });
-$call->live_translate(start => { source => 'en-US', target => 'es' });
+$call->live_transcribe(action => { start => { lang => 'en-US' } });
+$call->live_translate(action => { start => { from_lang => 'en-US', to_lang => 'es' } });
 ```
 
 ## Echo

--- a/rest/docs/calling.md
+++ b/rest/docs/calling.md
@@ -209,8 +209,14 @@ $client->calling->ai_stop($call_id, control_id => 'ai-1');
 ## Live Transcribe & Translate
 
 ```perl
-$client->calling->live_transcribe($call_id, action => 'start', lang => 'en');
-$client->calling->live_translate($call_id, action => 'start', from_lang => 'en', to_lang => 'es');
+$client->calling->live_transcribe(
+    $call_id,
+    action => { start => { lang => 'en', direction => ['local-caller', 'remote-caller'] } },
+);
+$client->calling->live_translate(
+    $call_id,
+    action => { start => { from_lang => 'en', to_lang => 'es', direction => ['local-caller', 'remote-caller'] } },
+);
 ```
 
 ## Fax

--- a/rest/examples/rest_calling_ivr_and_ai.pl
+++ b/rest/examples/rest_calling_ivr_and_ai.pl
@@ -64,10 +64,22 @@ safe('AI stop',   sub { $client->calling->ai_stop($CALL_ID) });
 # 4. Live transcription and translation
 print "\nLive transcription and translation...\n";
 safe('Live transcribe', sub {
-    $client->calling->live_transcribe($CALL_ID, language => 'en-US');
+    $client->calling->live_transcribe(
+        $CALL_ID,
+        action => { start => { lang => 'en-US', direction => ['local-caller', 'remote-caller'] } },
+    );
 });
 safe('Live translate', sub {
-    $client->calling->live_translate($CALL_ID, language => 'es');
+    $client->calling->live_translate(
+        $CALL_ID,
+        action => {
+            start => {
+                from_lang => 'en-US',
+                to_lang   => 'es',
+                direction => ['local-caller', 'remote-caller'],
+            },
+        },
+    );
 });
 
 # 5. Tap (media fork)

--- a/scripts/enumerate_surface.pl
+++ b/scripts/enumerate_surface.pl
@@ -300,6 +300,12 @@ my %PACKAGE_TO_PY = (
     'SignalWireRestError' => { module => 'signalwire.rest._base', class => 'SignalWireRestError' },
     'SignalWire::REST::HttpClient::Error' =>
         { module => 'signalwire.rest._base', class => 'SignalWireRestError' },
+
+    # Transport-error subclass (plan 1.3b): `package SignalWireRestTransportError` in
+    # HttpClient.pm, a member of the SignalWireRestError family (status_code => undef).
+    # Python parity: signalwire.rest._base.SignalWireRestTransportError.
+    'SignalWireRestTransportError' =>
+        { module => 'signalwire.rest._base', class => 'SignalWireRestTransportError' },
     'SignalWire::REST::Namespaces::Base' =>
         { module => 'signalwire.rest._base', class => 'BaseResource' },
     'SignalWire::REST::Namespaces::CrudResource' =>
@@ -1209,6 +1215,13 @@ my %FORCE_IMPLICIT_INIT = map { $_ => 1 } (
     'SignalWireRestError',
     'SignalWire::REST::HttpClient::Error',
     'SignalWire::REST::Namespaces::Base',
+
+    # SignalWireRestTransportError (plan 1.3b) extends SignalWireRestError and
+    # only overrides the status_code attr default (no own `sub new`), so
+    # is_moo_root is false and it would otherwise surface with zero methods.
+    # The reference oracle records SignalWireRestTransportError.__init__
+    # (inherited-constructor surfacing, matching TS/PHP parity) — force it.
+    'SignalWireRestTransportError',
 
     # REST namespaces whose top-level class or resource declares __init__
     'SignalWire::REST::Namespaces::Calling',

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -181,7 +181,17 @@ rest_coverage_gate() {
         --spec-root "$PORTING_SDK_DIR/rest-apis" \
         --allowlist "$PORTING_SDK_DIR/REST_COVERAGE_BASELINE.md" \
         --allowlist "$PORT_ROOT/REST_COVERAGE_GAPS.md" \
-        --gap-baseline "$PORTING_SDK_DIR/REST_COVERAGE_GAP_BASELINE.md"
+        --gap-baseline "$PORTING_SDK_DIR/REST_COVERAGE_GAP_BASELINE.md" || return 1
+    # STRICT-MOCKS §2.2a — fail the gate on ANY journaled wire_violation. The shared
+    # helper reads the same live mock journal (already populated by the t/rest/ run
+    # above) and exits non-zero on any offender (see
+    # porting-sdk/scripts/assert_no_wire_violations.py). WIRE_VIOLATIONS_ALLOW.md
+    # holds ONLY owner-signed spec-gap parks (currently empty for perl — every
+    # hand-authored t/rest/ fixture was fixed to the real spec wire shape rather
+    # than parked).
+    python3 "$PORTING_SDK_DIR/scripts/assert_no_wire_violations.py" \
+        --rest-mock-url "http://127.0.0.1:$port" \
+        --allowlist "$PORT_ROOT/WIRE_VIOLATIONS_ALLOW.md"
 }
 
 # SPEC-PARITY — implemented routes == canonical spec. route_registry.pl drives the
@@ -255,8 +265,13 @@ sched_gate GEN-FRESH-TESTS desc="generate_rest_tests.py --check (generated REST 
 # nondeterministically (the moving `example parses:` / surface-audit failures). Sharing
 # the surface resource serializes TEST against those mutators; it still overlaps every
 # read-only gate (LINT, the differs, generators-in-check-mode).
-sched_gate TEST defer=1 res=surface desc="run-tests.sh (prove -Ilib -It/lib -r t/)" \
-    -- bash scripts/run-tests.sh
+#
+# STRICT-MOCKS §2.2b — run the suite (incl. RELAY tests, which probe-or-spawn their
+# own mock_relay) under MOCK_RELAY_STRICT=1: any unknown top-level frame field /
+# duplicate command-id is rejected with an error frame, so a wrong RELAY wire shape
+# fails the test rather than being silently accepted.
+sched_gate TEST defer=1 res=surface desc="run-tests.sh (prove -Ilib -It/lib -r t/) (STRICT-MOCKS: MOCK_RELAY_STRICT=1)" \
+    -- env MOCK_RELAY_STRICT=1 bash scripts/run-tests.sh
 
 sched_gate SIGNATURES desc="regenerate port_signatures.json" \
     -- python3 scripts/enumerate_signatures.py

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -315,6 +315,18 @@ sched_gate BEHAVIORAL-WIRE-RELAY desc="diff_port_wire_relay vs python oracle (La
         --port perl --python-sdk "$PYTHON_SDK_DIR" \
         --dump-cmd "perl -Ilib bin/wire-relay-dump.pl 2>/dev/null"
 
+# ERROR-ENVELOPE behavior (Layer D): run the shared error-envelope corpus through
+# the port's REST client at a live mock and byte-compare the reduced artifact
+# (raised / error_kind / status_code / body_error_code / request_count) against the
+# python oracle. Pins the TYPED transport error on connection-refused (status None,
+# request_count 0) alongside the HTTP-error decoding. bin/emit-envelope.pl spawns
+# its own mock_signalwire, so no gate-level mock pre-spawn is needed; 2>/dev/null
+# keeps only the JSON object on stdout.
+sched_gate BEHAVIORAL-ENVELOPE desc="diff_port_envelope vs python oracle (Layer D): typed error incl transport" \
+    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_envelope.py" \
+        --port perl --python-sdk "$PYTHON_SDK_DIR" \
+        --dump-cmd "perl bin/emit-envelope.pl 2>/dev/null"
+
 # FMT joins res=surface: run locally (no CI) it rewrites lib/**/*.pm in place via
 # `perltidy -b`, which a concurrent TEST (`perl -c` / module load) or surface-enumerator
 # (loads lib/) would otherwise read mid-write. Under CI (--check) it's read-only, but the

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -34,6 +34,10 @@
 set -u
 set -o pipefail
 
+# STRICT-MOCKS 400-mode (plan §2.2c): strict is the default now.
+export MOCK_SIGNALWIRE_STRICT="${MOCK_SIGNALWIRE_STRICT:-1}"
+export MOCK_RELAY_STRICT="${MOCK_RELAY_STRICT:-1}"
+
 PORT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 mkdir -p "$PORT_ROOT/.sw-tmp"  # repo-local CI scratch (never /tmp)
 PORT_NAME="signalwire-perl"

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -11,18 +11,19 @@
 # GATE SCHEDULING (porting-sdk/scripts/gate_scheduler.sh — CI_PERF S1 + S2):
 #   Gates run CONCURRENTLY up to a cap (SW_CI_JOBS, default nproc), scheduled by
 #   their DATA dependencies:
-#     * S2 concurrent wave: the pure-Python side-effect-free gates (all GEN-FRESH*,
-#       DRIFT, NO-CHEAT, EMISSION, SKILL-CONTRACT, SWAIG-COVERAGE, SURFACE-DIFF,
-#       DOC-AUDIT, SWAIG-CLI) overlap — they share no mutable state.
-#     * S1 fail-fast: heavy gates (TEST, LINT, FMT, REST-COVERAGE, SPEC-PARITY) are
-#       deferred behind the cheap wave, so a trivial cheap-gate failure surfaces in
-#       seconds; --fail-fast aborts the run before TEST starts.
+#     * S2 concurrent wave: the pure-Python side-effect-free suites/gates overlap —
+#       they share no mutable state.
+#     * S1 fail-fast: heavy gates (TEST, LINT, FMT, and the BEHAVIORAL/GEN/PACKAGE
+#       suites) are deferred behind the cheap wave, so a trivial cheap-gate failure
+#       surfaces in seconds; --fail-fast aborts the run before TEST starts.
 #   HARD ordering is data-dependency ONLY:
-#     * DRIFT reads port_signatures.json that SIGNATURES writes → deps=SIGNATURES.
-#     * SURFACE-FRESH + SURFACE-DIFF regenerate port_surface.json in place (and
-#       restore it), DOC-AUDIT reads it, FMT rewrites lib/**/*.pm in place, and TEST
-#       loads lib/ + reads port_surface.json → all five share res=surface (the
-#       working-tree-mutation group) so no reader ever sees a half-written file.
+#     * The SIGNATURES→DRIFT→SEMVER data dep + the SURFACE-FRESH regenerate-then-
+#       restore now live INSIDE the SURFACE suite (enumerate-once, diff-many).
+#     * The SURFACE suite regenerates port_surface.json in place (and restores it),
+#       DOC-TRUTH's DOC-AUDIT reads it, STATUS-CLAIM reads it, FMT rewrites
+#       lib/**/*.pm in place, and TEST loads lib/ + reads port_surface.json → all
+#       share res=surface (the working-tree-mutation group) so no reader ever sees
+#       a half-written file.
 #   The shared _env.sh env (PERL5LIB / PATH / PERLTIDY) is exported before the gates
 #   are registered, so every scheduler worker subshell inherits it.
 #   Per-gate PASS/FAIL + the FAILED_GATES tally preserved exactly; each gate's output
@@ -93,7 +94,7 @@ cd "$PORT_ROOT"
 # every scheduler worker subshell.
 # shellcheck source=scripts/_env.sh
 source "$PORT_ROOT/scripts/_env.sh"
-# Bootstrap the FMT/LINT/TEST dev-deps up-front so GEN-FRESH (which shells out to
+# Bootstrap the FMT/LINT/TEST dev-deps up-front so the GEN suite (which shells out to
 # perltidy) and every gate below have them. Fail loud if they can't be resolved.
 _sw_ensure_perl_tools || exit 1
 
@@ -106,387 +107,156 @@ export SW_WAVE_A_REPORT_ONLY=0
 
 echo "==> running CI gates for $PORT_NAME (porting-sdk at $PORTING_SDK_DIR)"
 
-pick_free_port() {
-    python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'
-}
-
-# ARTIFACT-DENY (Day-one) — no porting-process artifact may ship inside the PUBLISHED
-# package. MANIFEST is the authoritative published listing: `make manifest` regenerates
-# it modulo MANIFEST.SKIP (which already excludes port_*.json, PORT_*.md, CHECKLIST.md,
-# audit_coverage*, tidy.err, .sw-tmp/, etc.), so feeding MANIFEST to --listing checks the
-# REAL shipped set (not the git-ls-files proxy). Restore the committed MANIFEST after —
-# `make manifest` rewrites it and would otherwise dirty the tree.
-dayone_artifact_deny() {
-    perl Makefile.PL >/dev/null 2>&1 || { echo "Makefile.PL failed" >&2; return 1; }
-    make manifest >/dev/null 2>&1 || { echo "make manifest failed" >&2; return 1; }
-    python3 "$PORTING_SDK_DIR/scripts/artifact_deny.py" --port perl --listing - <MANIFEST
-    local rc=$?
-    # Restore the committed MANIFEST and sweep the ExtUtils::MakeMaker byproducts
-    # (all .gitignore'd, but leave no scratch behind per the repo cleanup rule).
-    git checkout -- MANIFEST 2>/dev/null || true
-    rm -f MANIFEST.bak MYMETA.json MYMETA.yml Makefile Makefile.old pm_to_blib
-    return $rc
-}
-
-# SURFACE-FRESH — Layer B (the symbol-level surface) is NOT gated by DRIFT (Layer A
-# / signatures only), so port_surface.json can silently rot. Regenerate it IN PLACE
-# via the Perl surface enumerator, compare the committed copy modulo the volatile
-# generated_from git-sha, then always restore the working copy.
-surface_fresh_gate() {
-    if ! git show HEAD:port_surface.json > "$PORT_ROOT/.sw-tmp/committed_surface.json" 2>/dev/null; then
-        cp "$PORT_ROOT/port_surface.json" "$PORT_ROOT/.sw-tmp/committed_surface.json"
-    fi
-    perl scripts/enumerate_surface.pl >/dev/null || return $?
-    python3 "$PORTING_SDK_DIR/scripts/check_surface_freshness.py" \
-        --committed "$PORT_ROOT/.sw-tmp/committed_surface.json" \
-        --fresh "$PORT_ROOT/port_surface.json"
-    local rc=$?
-    git checkout -- port_surface.json 2>/dev/null
-    return $rc
-}
-
-# REST-COVERAGE — every implemented REST route covered success+error. Self-
-# contained: spins its own mock, runs t/rest/ serially, replays the journal.
-rest_coverage_gate() {
-    local port
-    port="$(pick_free_port)" || { echo "could not allocate a free port" >&2; return 1; }
-    local mock_pkg_parent="$PORTING_SDK_DIR/test_harness/mock_signalwire"
-    export PYTHONPATH="$mock_pkg_parent${PYTHONPATH:+:$PYTHONPATH}"
-    python3 -m mock_signalwire --host 127.0.0.1 --port "$port" --log-level error \
-        >"$PORT_ROOT/.sw-tmp/rest_cov_mock_perl.$$.log" 2>&1 &
-    local mock_pid=$!
-    # shellcheck disable=SC2064
-    trap "kill $mock_pid 2>/dev/null" RETURN
-    local i ready=0
-    for i in $(seq 1 60); do
-        if ! kill -0 "$mock_pid" 2>/dev/null; then
-            echo "mock_signalwire died on port $port — log:" >&2
-            cat "$PORT_ROOT/.sw-tmp/rest_cov_mock_perl.$$.log" >&2
-            return 1
-        fi
-        if python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:$port/__mock__/health',timeout=1)" 2>/dev/null; then
-            ready=1
-            break
-        fi
-        sleep 0.5
-    done
-    if [ "$ready" -ne 1 ]; then
-        echo "mock_signalwire on port $port not healthy within 30s" >&2
-        return 1
-    fi
-    python3 -c "import urllib.request; urllib.request.urlopen(urllib.request.Request('http://127.0.0.1:$port/__mock__/journal/reset',method='POST'),timeout=5).read()"
-    MOCK_SIGNALWIRE_PORT="$port" prove -Ilib -It/lib -j1 -r t/rest/ || return 1
-    python3 -m mock_signalwire.rest_coverage \
-        --mock-url "http://127.0.0.1:$port" \
-        --spec-root "$PORTING_SDK_DIR/rest-apis" \
-        --allowlist "$PORTING_SDK_DIR/REST_COVERAGE_BASELINE.md" \
-        --allowlist "$PORT_ROOT/REST_COVERAGE_GAPS.md" \
-        --gap-baseline "$PORTING_SDK_DIR/REST_COVERAGE_GAP_BASELINE.md"
-}
-
-# SPEC-PARITY — implemented routes == canonical spec. route_registry.pl drives the
-# live RestClient through a recording HttpClient and captures every dispatched route.
-spec_parity_gate() {
-    local mock_pkg_parent="$PORTING_SDK_DIR/test_harness/mock_signalwire"
-    export PYTHONPATH="$mock_pkg_parent${PYTHONPATH:+:$PYTHONPATH}"
-    local registry
-    registry="$(mktemp)"
-    perl -Ilib scripts/route_registry.pl >"$registry" 2>/dev/null || {
-        rm -f "$registry"
-        return 1
-    }
-    python3 "$PORTING_SDK_DIR/scripts/diff_spec_implementation.py" \
-        --registry-json "$registry" \
-        --gaps "$PORTING_SDK_DIR/SPEC_IMPLEMENTATION_GAPS.md"
-    local rc=$?
-    rm -f "$registry"
-    return $rc
-}
-
-# SURFACE-DIFF — diff the port's public surface against the Python reference.
-# Regenerate the surface in place, diff, restore unconditionally.
-surface_diff_gate() {
-    local committed="$PORT_ROOT/.sw-tmp/committed_surface_diff_${PORT_NAME}.$$"
-    git show HEAD:port_surface.json >"$committed" 2>/dev/null \
-        || cp port_surface.json "$committed"
-    perl scripts/enumerate_surface.pl --output port_surface.json
-    local regen_rc=$?
-    if [ "$regen_rc" -ne 0 ]; then
-        git checkout -- port_surface.json 2>/dev/null || true
-        rm -f "$committed"
-        echo "surface regen failed (exit $regen_rc)" >&2
-        return "$regen_rc"
-    fi
-    python3 "$PORTING_SDK_DIR/scripts/diff_port_surface.py" \
-        --reference "$PORTING_SDK_DIR/python_surface.json" \
-        --port-surface port_surface.json \
-        --omissions "$PORT_ROOT/PORT_OMISSIONS.md" \
-        --additions "$PORT_ROOT/PORT_ADDITIONS.md"
-    local rc=$?
-    git checkout -- port_surface.json 2>/dev/null || true
-    rm -f "$committed"
-    return $rc
-}
+# ---- Part 5: the per-gate --fn helpers are now DEAD — reproduced in the suites -
+# surface_fresh_gate (SURFACE-FRESH), rest_coverage_gate (REST-COVERAGE),
+# spec_parity_gate (SPEC-PARITY), and dayone_artifact_deny (ARTIFACT-DENY) used to
+# be defined here as `--fn` gate bodies. Those exact bodies — including the perl
+# specifics (Makefile.PL + make manifest → MANIFEST, prove -Ilib -It/lib t/rest/,
+# route_registry.pl capture, the MANIFEST restore + MakeMaker byproduct sweep) —
+# are now reproduced INSIDE the Part-5 suites (scripts/suites/_surface_fresh.py,
+# _rest_coverage.py, _spec_parity.py, _artifact_deny.py). pick_free_port() likewise
+# moved into the suites. (Byte-identity vs the old per-gate path is proven by
+# porting-sdk's tests/test_suite_parity*.py.)
 
 # ---- register gates ----------------------------------------------------------
 sched_init "$@"
 
-sched_gate GEN-FRESH desc="generate_rest.py --check (generated REST layer matches specs)" \
-    -- python3 scripts/generate_rest.py --check
-
-sched_gate GEN-FRESH-SWML desc="generate_swml_verbs.py --check (generated SWML-verb types match schema.json)" \
-    -- python3 scripts/generate_swml_verbs.py --check
-
-sched_gate GEN-FRESH-RELAY desc="generate_relay_protocol.py --check (generated RELAY types match relay-protocol)" \
-    -- python3 scripts/generate_relay_protocol.py --check
-
-sched_gate GEN-FRESH-SWAIG desc="generate_swaig_payloads.py --check (generated SWAIG payloads match swaig-specs)" \
-    -- python3 scripts/generate_swaig_payloads.py --check
-
-sched_gate GEN-FRESH-TESTS desc="generate_rest_tests.py --check (generated REST wire-test suite matches route-registry × spec oracle)" \
-    -- python3 scripts/generate_rest_tests.py --check
-
-# TEST joins res=surface — the working-tree-mutation group. FMT rewrites lib/**/*.pm
-# in place via `perltidy -b` when run locally; SURFACE-FRESH / SURFACE-DIFF rewrite
-# port_surface.json in place then `git checkout --` restore it. TEST `perl -c`-compiles
-# every bundled example and loads every SDK module for its 130+ test files, and
-# t/53/t/54 additionally read port_surface.json — so overlapping TEST with a gate
-# mid-rewrite makes a module/surface file load a transient/half-written copy and fail
-# nondeterministically (the moving `example parses:` / surface-audit failures). Sharing
-# the surface resource serializes TEST against those mutators; it still overlaps every
-# read-only gate (LINT, the differs, generators-in-check-mode).
+# HEAVY (deferred behind the cheap wave for S1 fail-fast). TEST joins res=surface —
+# the working-tree-mutation group. FMT rewrites lib/**/*.pm in place via `perltidy
+# -b` when run locally; the SURFACE suite rewrites port_surface.json in place then
+# restores it. TEST `perl -c`-compiles every bundled example and loads every SDK
+# module for its 130+ test files, and t/53/t/54 additionally read port_surface.json
+# — so overlapping TEST with a gate mid-rewrite makes a module/surface file load a
+# transient/half-written copy and fail nondeterministically. Sharing the surface
+# resource serializes TEST against those mutators; it still overlaps every read-only
+# gate (LINT, the differ suites in check mode).
 sched_gate TEST defer=1 res=surface desc="run-tests.sh (prove -Ilib -It/lib -r t/)" \
     -- bash scripts/run-tests.sh
 
-sched_gate SIGNATURES desc="regenerate port_signatures.json" \
-    -- python3 scripts/enumerate_signatures.py
+# ---- Part 5 gate SUITES ------------------------------------------------------
+# The former per-gate SIGNATURES/DRIFT/SURFACE-*/SEMVER-DIFF/GEN-TYPE-DEGENERACY/
+# GEN-IDIOM/GEN-FRESH*/BEHAVIORAL-*/EMISSION/ERROR-ENVELOPE/PAGINATION-WIRED/
+# DOC-WIRE/REST-COVERAGE/SPEC-PARITY/SKILL-CONTRACT/SWAIG-*/WAIT-LIVENESS/DOC-*/
+# COUNT-CLAIM/ACCESSOR-TRUTH/STATUS-CLAIM/README-INCLUDE/*-LEDGER/PACKAGE-SMOKE/
+# META-CONSISTENT/ARTIFACT-DENY/RELEASE-FRESH gates now run under 6 SUITE engines.
+# Each suite emits every original gate NAME as a `[SUITE:RULE] ... PASS/FAIL` rule
+# ID (failure identity + allowlists + finding output unchanged). A suite exits
+# nonzero iff any of its rules fails. Byte-identity vs the old per-gate path is
+# proven by porting-sdk/tests/test_suite_parity*.py.
+#
+# The `--fn` helpers the old gates used (surface_fresh_gate, rest_coverage_gate,
+# spec_parity_gate, dayone_artifact_deny, pick_free_port) are reproduced INSIDE the
+# suites, so they are no longer defined here.
+#
+# Former single-gate scheduler features preserved by the suites internally:
+#   * SIGNATURES→DRIFT ordering, the SEMVER-DIFF-reads-SIGNATURES data dep, and the
+#     SURFACE-FRESH regenerate-then-restore all live inside the SURFACE suite.
+#   * mixed tiers are split with --rules: PACKAGE + BEHAVIORAL each schedule a
+#     per-PR line and a nightly line (nightly members broken out below).
+# PERL-SPECIFIC vs the TS reference: perl's behavioral RELAY rule keeps perl's exact
+# spelling BEHAVIORAL-WIRE-RELAY (hyphen, same as ts). perl's SURFACE suite does NOT
+# carry ROUTE-COLLISION (route_collision.py has no default perl registry cmd and,
+# fed route_registry.pl, flags 2 un-approved ROUTE-SPLIT findings — a real
+# disposition held for a follow-up, NOT silenced here), matching perl's prior
+# standalone run-ci which likewise omitted it. DOC-AUDIT + STATUS-CLAIM read perl's
+# on-disk port_surface.json (POD-aware), which the SURFACE suite regenerates+restores
+# — so SURFACE and DOC-TRUTH share res=surface.
 
-sched_gate DRIFT deps=SIGNATURES desc="diff_port_signatures vs python reference" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_signatures.py" \
-        --reference "$PORTING_SDK_DIR/python_signatures.json" \
-        --port-signatures "$PORT_ROOT/port_signatures.json" \
-        --surface-omissions "$PORT_ROOT/PORT_OMISSIONS.md" \
-        --surface-additions "$PORT_ROOT/PORT_ADDITIONS.md" \
-        --omissions "$PORT_ROOT/PORT_SIGNATURE_OMISSIONS.md"
+# SURFACE (parity spine): SIGNATURES→DRIFT ordered, SURFACE-FRESH regen/restore,
+# SURFACE-DIFF, SEMVER-DIFF, GEN-TYPE-DEGENERACY, GEN-IDIOM — all read the one
+# enumeration. res=surface: SURFACE-FRESH regenerates port_surface.json in place
+# (and restores it), so it must not overlap DOC-TRUTH's DOC-AUDIT/STATUS-CLAIM read.
+sched_gate SURFACE res=surface desc="surface parity suite (SIGNATURES/DRIFT/SURFACE-FRESH/SURFACE-DIFF/SEMVER-DIFF/GEN-TYPE-DEGENERACY/GEN-IDIOM)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/surface.py" --port perl --repo "$PORT_ROOT"
 
-sched_gate SURFACE-FRESH res=surface desc="check_surface_freshness (regen port_surface.json)" \
-    --fn surface_fresh_gate
+# GEN (regen-from-specs family): the 5 GEN-FRESH rules. The perltidy backstop each
+# generator runs needs _env.sh (sourced above, exported into every worker subshell).
+sched_gate GEN defer=1 desc="generated-code freshness suite (GEN-FRESH/-TESTS/-RELAY/-SWAIG/-SWML)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/gen.py" --port perl --repo "$PORT_ROOT"
 
+# BEHAVIORAL (one Layer-D pass per rule): the per-PR rules. WAIT-LIVENESS (nightly)
+# is the separate line below. NOTE perl's hyphen spelling BEHAVIORAL-WIRE-RELAY.
+sched_gate BEHAVIORAL defer=1 desc="behavioral suite (BEHAVIORAL-*/EMISSION/ERROR-ENVELOPE/PAGINATION-WIRED/DOC-WIRE/REST-COVERAGE/SPEC-PARITY/SKILL-CONTRACT/SWAIG-COVERAGE/SWAIG-CLI)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/behavioral.py" --port perl --repo "$PORT_ROOT" \
+        --rules BEHAVIORAL-WIRE,BEHAVIORAL-SWML,BEHAVIORAL-STATE,BEHAVIORAL-HTTP,BEHAVIORAL-WIRE-RELAY,EMISSION,ERROR-ENVELOPE,PAGINATION-WIRED,DOC-WIRE,REST-COVERAGE,SPEC-PARITY,SKILL-CONTRACT,SWAIG-COVERAGE,SWAIG-CLI
+
+sched_gate BEHAVIORAL-NIGHTLY tier=nightly defer=1 desc="behavioral suite, nightly rules (WAIT-LIVENESS)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/behavioral.py" --port perl --repo "$PORT_ROOT" \
+        --rules WAIT-LIVENESS
+
+# DOC-TRUTH (one markdown+POD walk): DOC-AUDIT/DOC-LINKS/DOC-LANG-PURITY/DOC-ENV/
+# COUNT-CLAIM/ACCESSOR-TRUTH/STATUS-CLAIM/README-INCLUDE. POD-aware (perl's docs are
+# POD-first). res=surface: DOC-AUDIT + STATUS-CLAIM read perl's on-disk
+# port_surface.json, which the SURFACE suite regenerates+restores.
+sched_gate DOC-TRUTH res=surface desc="doc-truth suite (DOC-AUDIT/DOC-LINKS/DOC-LANG-PURITY/DOC-ENV/COUNT-CLAIM/ACCESSOR-TRUTH/STATUS-CLAIM/README-INCLUDE)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/doc_truth.py" --port perl --repo "$PORT_ROOT"
+
+# LEDGER: SUPPRESSION-LEDGER + IGNORE-LEDGER-VERIFY.
+sched_gate LEDGER res=dayone desc="ledger governance suite (SUPPRESSION-LEDGER/IGNORE-LEDGER-VERIFY)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/ledger.py" --port perl --repo "$PORT_ROOT"
+
+# PACKAGE: per-PR rules (ARTIFACT-DENY/RELEASE-FRESH); nightly rules (PACKAGE-SMOKE/
+# META-CONSISTENT) on the separate line below. ARTIFACT-DENY reproduces perl's
+# Makefile.PL + make manifest → MANIFEST listing + restore/sweep inside the suite.
+sched_gate PACKAGE res=dayone desc="package suite, per-PR rules (ARTIFACT-DENY/RELEASE-FRESH)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/package.py" --port perl --repo "$PORT_ROOT" \
+        --rules ARTIFACT-DENY,RELEASE-FRESH
+
+sched_gate PACKAGE-NIGHTLY tier=nightly defer=1 res=dayone desc="package suite, nightly rules (PACKAGE-SMOKE/META-CONSISTENT)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/suites/package.py" --port perl --repo "$PORT_ROOT" \
+        --rules PACKAGE-SMOKE,META-CONSISTENT
+
+# ---- gates that stay standalone (native toolchains + singletons) -------------
 sched_gate NO-CHEAT desc="audit_no_cheat_tests" \
     -- python3 "$PORTING_SDK_DIR/scripts/audit_no_cheat_tests.py" --root "$PORT_ROOT"
 
-sched_gate REST-COVERAGE defer=1 desc="every implemented REST route covered success+error (parity + allowlist)" \
-    --fn rest_coverage_gate
-
-sched_gate SPEC-PARITY defer=1 desc="implemented routes == canonical spec (modulo SPEC_IMPLEMENTATION_GAPS.md)" \
-    --fn spec_parity_gate
-
-sched_gate EMISSION desc="diff_port_emission vs python to_dict()" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_emission.py" \
-        --dump-cmd "perl bin/emit-corpus.pl" \
-        --port-repo "$PORT_ROOT"
-
-# BEHAVIORAL-* (Layer D) — run the shared behavioral corpus through the port's
-# dump programs and structurally byte-compare against the signalwire-python oracle.
-# 2>/dev/null suppresses perl's experimental-feature warnings on stderr so ONLY JSON
-# reaches stdout; --python-sdk pins the oracle source (never the caller's CWD/env).
-sched_gate BEHAVIORAL-WIRE desc="diff_port_wire vs python oracle (Layer D)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_wire.py" \
-        --port perl --python-sdk "$PYTHON_SDK_DIR" \
-        --dump-cmd "perl -Ilib bin/wire-dump.pl 2>/dev/null"
-
-sched_gate BEHAVIORAL-SWML desc="diff_port_swml vs python oracle (Layer D)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_swml.py" \
-        --port perl --python-sdk "$PYTHON_SDK_DIR" \
-        --dump-cmd "perl -Ilib bin/swml-dump.pl 2>/dev/null"
-
-sched_gate BEHAVIORAL-STATE desc="diff_port_state vs python oracle (Layer D)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_state.py" \
-        --port perl --python-sdk "$PYTHON_SDK_DIR" \
-        --dump-cmd "perl -Ilib bin/state-dump.pl 2>/dev/null"
-
-sched_gate BEHAVIORAL-HTTP desc="diff_port_http vs python oracle (Layer D)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_http.py" \
-        --port perl --python-sdk "$PYTHON_SDK_DIR" \
-        --dump-cmd "perl -Ilib bin/http-dump.pl 2>/dev/null"
-
-sched_gate BEHAVIORAL-WIRE-RELAY desc="diff_port_wire_relay vs python oracle (Layer D)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_wire_relay.py" \
-        --port perl --python-sdk "$PYTHON_SDK_DIR" \
-        --dump-cmd "perl -Ilib bin/wire-relay-dump.pl 2>/dev/null"
-
 # FMT joins res=surface: run locally (no CI) it rewrites lib/**/*.pm in place via
-# `perltidy -b`, which a concurrent TEST (`perl -c` / module load) or surface-enumerator
-# (loads lib/) would otherwise read mid-write. Under CI (--check) it's read-only, but the
-# label is harmless there and keeps local and CI scheduling identical.
+# `perltidy -b`, which a concurrent TEST (`perl -c` / module load) or the surface
+# enumerator (loads lib/) would otherwise read mid-write. Under CI (--check) it's
+# read-only, but the label is harmless there and keeps local and CI scheduling
+# identical.
 sched_gate FMT defer=1 res=surface desc="run-format.sh (local: apply; CI: --check)" \
     -- bash scripts/run-format.sh ${CI:+--check}
 
 sched_gate LINT defer=1 desc="run-lint.sh (perlcritic severity 4, zero findings)" \
     -- bash scripts/run-lint.sh
 
-# ---- §C1 doc/example/CLI execution gates (mirrors python's run-ci.sh) ----
-# SNIPPET-COMPILE + DOC-CLI are cheap/blocking; EXAMPLES-RUN + SNIPPET-RUN are
-# defer=1 blocking. SNIPPET-RUN's residual was burned to zero (missing `use`
-# lines added, live-network/blocking-server/user-subclass snippets marked
-# `no-run`), so it now blocks like the other doc-execution gates.
+# ---- §C1 doc/example/CLI execution gates ------------------------------------
+# SNIPPET-COMPILE (documented code fences compile with lib/ on @INC) is HEAVY →
+# tier=nightly; DOC-CLI stays per-PR (cheap CLI-parse probe of documented swaig-test
+# invocations). EXAMPLES-RUN + SNIPPET-RUN execute/load the shipped examples + doc
+# snippets under STRICT-MOCKS on the nightly tier (MOCK_RELAY_STRICT=1: the mock_relay
+# REJECTS any inbound frame that violates the RELAY wire spec, so a wrong frame fails
+# LOUD instead of being silently journaled). `env VAR=val` (not a bare prefix) keeps
+# the command analyzable to the permission matcher.
 sched_gate SNIPPET-COMPILE tier=nightly desc="documented code snippets compile (perl -c with lib/ on @INC)" \
     -- python3 "$PORTING_SDK_DIR/scripts/snippet_compile.py" --port perl --repo .
 
 sched_gate DOC-CLI desc="documented swaig-test invocations parse against the real CLI" \
     -- python3 "$PORTING_SDK_DIR/scripts/doc_cli.py" --port perl --repo .
 
-# Wave-3 doc/API-truth gates — deterministic source/doc analysis (no build, no
-# mock, ~1.3s for all six). Per-PR tier: cheap enough to catch doc/API drift at
-# PR time rather than a day later in nightly.
-sched_gate ERROR-ENVELOPE desc="REST error carries the full (status,body,url,method) envelope + raised on >=400" \
-    -- python3 "$PORTING_SDK_DIR/scripts/error_envelope.py" --port perl --repo "$PORT_ROOT"
+# DEAD-PUBLIC-ERROR stays standalone (source analysis of exported error types — not
+# a doc-truth/behavioral rule). ERROR-ENVELOPE/PAGINATION-WIRED/DOC-WIRE run under
+# the BEHAVIORAL suite; DOC-ENV/COUNT-CLAIM/ACCESSOR-TRUTH/STATUS-CLAIM under
+# DOC-TRUTH.
 sched_gate DEAD-PUBLIC-ERROR desc="exported error types are raised/caught/user-signalled (no dead error surface)" \
     -- python3 "$PORTING_SDK_DIR/scripts/dead_public_error.py" --port perl --repo "$PORT_ROOT"
-sched_gate PAGINATION-WIRED desc="shipped iterator-protocol paginator is wired into list()" \
-    -- python3 "$PORTING_SDK_DIR/scripts/pagination_wired.py" --port perl --repo "$PORT_ROOT"
-sched_gate DOC-ENV desc="documented SIGNALWIRE_*/SWML_* env vars <=> code-read vars agree" \
-    -- python3 "$PORTING_SDK_DIR/scripts/doc_env.py" --port perl --repo "$PORT_ROOT"
-sched_gate COUNT-CLAIM desc="numeric doc claims (skills/namespaces) match reality" \
-    -- python3 "$PORTING_SDK_DIR/scripts/count_claim.py" --port perl --repo "$PORT_ROOT"
-sched_gate ACCESSOR-TRUTH desc="documented backtick method() refs exist in source" \
-    -- python3 "$PORTING_SDK_DIR/scripts/accessor_truth.py" --port perl --repo "$PORT_ROOT"
 
-# ---- gate-enforcement quartet (plan Parts A1/C2/2.4) ----
-# DOC-WIRE + STATUS-CLAIM are per-PR (POD-aware — perl's docs are POD-first).
-# WAIT-LIVENESS is nightly (spawns a dump program). GATE-INVENTORY is deliberately
-# NOT wired per-port: gen_gate_inventory.py resolves its reference as a sibling
-# signalwire-typescript checkout, absent in a port's CI layout (→ exit 2); it is
-# inherently porting-sdk-side and already runs in porting-sdk's own CI.
-#
-# DOC-WIRE (§A1) — the documented REST doc fixtures put the SPEC wire shape on the
-# wire (areacode not area_code, nested params:{text} not a flat item). doc_wire.py
-# spawns its OWN flag-mode mock (free port, self-cleaning) and replays the doc
-# fixtures via the runner, failing on any journaled wire_violations. Cheap/blocking.
-sched_gate DOC-WIRE desc="documented REST doc fixtures put the spec wire shape on the wire (areacode/params:{text})" \
-    -- python3 "$PORTING_SDK_DIR/scripts/doc_wire.py" --port perl --repo "$PORT_ROOT" \
-        --runner "perl $PORT_ROOT/scripts/doc_wire_runner.pl"
-
-# STATUS-CLAIM (§C2) — no false capability/status claims in docs OR POD (e.g. "not
-# yet implemented" next to a shipped method). POD-aware: scans lib/**/*.pm POD
-# blocks in addition to markdown. Deterministic source/doc analysis, cheap/blocking.
-sched_gate STATUS-CLAIM res=surface desc="doc/POD status/capability claims match the shipped surface" \
-    -- python3 "$PORTING_SDK_DIR/scripts/status_claim.py" --port perl --repo "$PORT_ROOT" \
-        --surface "$PORT_ROOT/port_surface.json"
-
-# WAIT-LIVENESS (§2.4) — the RELAY Action::wait() liveness contract: wait() BLOCKS
-# until the deferred completing event arrives, then returns (never a no-op early
-# return, never a hung wait). The corpus includes the NESTED wait case (wait inside
-# an on_completed callback → re-entrant _read_once). The port's dump classification
-# is diffed against the python-oracle golden. Nightly (spawns a dump program).
-sched_gate WAIT-LIVENESS tier=nightly defer=1 desc="wait() liveness corpus (incl. nested re-entrant wait) matches the python-oracle golden classification" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_wait_liveness.py" \
-        --port perl --python-sdk "$PYTHON_SDK_DIR" \
-        --dump-cmd "perl -Ilib $PORT_ROOT/bin/wait-liveness-dump.pl 2>/dev/null"
-
-# EXAMPLES-RUN + SNIPPET-RUN run under STRICT-MOCKS on the nightly tier
-# (MOCK_RELAY_STRICT=1): the mock_relay REJECTS any inbound frame that violates the
-# RELAY wire spec, so a shipped example / doc snippet that puts a wrong frame on the
-# wire fails LOUD instead of being silently ignored. `env VAR=val` (not a bare
-# prefix) keeps the command analyzable to the permission matcher.
 sched_gate EXAMPLES-RUN tier=nightly defer=1 desc="shipped examples load/start against the mock (modulo EXAMPLES_RUN_ALLOW.md; STRICT-MOCKS: MOCK_RELAY_STRICT=1)" \
     -- env MOCK_RELAY_STRICT=1 python3 "$PORTING_SDK_DIR/scripts/examples_run.py" --port perl --repo .
 
 sched_gate SNIPPET-RUN tier=nightly defer=1 desc="dynamic-port doc snippets run to a zero exit against the mock (STRICT-MOCKS: MOCK_RELAY_STRICT=1)" \
     -- env MOCK_RELAY_STRICT=1 python3 "$PORTING_SDK_DIR/scripts/snippet_run.py" --port perl --repo .
 
-# ---- §G anti-laundering ledger gate ----
-sched_gate SUPPRESSION-LEDGER res=dayone desc="no un-ledgered analyzer suppressions (perlcritic ## no critic etc.)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/suppression_ledger.py" --port perl --repo .
-
-# ---- §D1 packaging: build the real make-dist tarball, install clean, require it ----
-# Heavy (real per-port build) → defer=1, blocking (artifact builds/installs/imports).
-# package_smoke.py runs `perl Makefile.PL && make manifest && make dist` IN-TREE, so
-# (exactly like ARTIFACT-DENY) it rewrites the tracked MANIFEST and drops the dist
-# tarball. Wrap it so the tree is restored afterward — MANIFEST back to the committed
-# copy, MakeMaker byproducts + the tarball swept (tarball is .gitignore'd, but leave
-# no scratch behind per the repo cleanup rule).
-package_smoke_gate() {
-    python3 "$PORTING_SDK_DIR/scripts/package_smoke.py" --port perl --repo .
-    local rc=$?
-    git checkout -- MANIFEST 2>/dev/null || true
-    rm -f MANIFEST.bak MYMETA.json MYMETA.yml Makefile Makefile.old pm_to_blib \
-          SignalWire-*.tar SignalWire-*.tar.gz
-    return $rc
-}
-sched_gate PACKAGE-SMOKE tier=nightly defer=1 desc="real make-dist artifact builds, installs clean, and requires (MANIFEST completeness)" \
-    --fn package_smoke_gate
-
-sched_gate DOC-AUDIT res=surface desc="audit_docs vs port_surface.json" \
-    -- python3 "$PORTING_SDK_DIR/scripts/audit_docs.py" \
-        --root "$PORT_ROOT" \
-        --surface "$PORT_ROOT/port_surface.json" \
-        --ignore "$PORT_ROOT/DOC_AUDIT_IGNORE.md"
-
-sched_gate SURFACE-DIFF res=surface desc="diff_port_surface vs python reference" \
-    --fn surface_diff_gate
-
-sched_gate SKILL-CONTRACT desc="diff_skill_contracts vs python reference" \
-    -- python3 "$PORTING_SDK_DIR/scripts/diff_skill_contracts.py" \
-        --dump-cmd "perl bin/emit-skills.pl" \
-        --port-repo "$PORT_ROOT"
-
-sched_gate SWAIG-CLI desc="swaig-test shared mini-contract (verbs/serverless-reject/default-action)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/audit_swaig_cli_contract.py" \
-        --port perl \
-        --cmd "perl -I$PORT_ROOT/lib $PORT_ROOT/bin/swaig-test" \
-        --require-url-model \
-        --default-action-argv='--url|http://user:pass@127.0.0.1:1/' \
-        --no-serverless-argv='--url|http://user:pass@127.0.0.1:1/|--simulate-serverless|lambda|--list-tools'
-
-sched_gate SWAIG-COVERAGE desc="every engine SWAIG action emittable by FunctionResult (or allowlisted)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/swaig_coverage.py" --check \
-        --emission "$PORT_ROOT/lib/SignalWire/SWAIG/FunctionResult.pm"
-
-sched_gate DOC-LANG-PURITY res=dayone desc="no python-verbatim docs in a non-python port" \
-    -- python3 "$PORTING_SDK_DIR/scripts/doc_lang_purity.py" --port perl --repo .
-
-sched_gate DOC-LINKS res=dayone desc="every relative markdown link resolves to a tracked file" \
-    -- python3 "$PORTING_SDK_DIR/scripts/doc_links.py" --port perl --repo .
-
-sched_gate README-INCLUDE res=dayone desc="doc code blocks are byte-identical to their gate-compiled fixture regions" \
-    -- python3 "$PORTING_SDK_DIR/scripts/readme_include.py" --port perl --repo .
-
+# ROOT-HYGIENE + PUBLIC-JARGON stay standalone (source/root analysis, not a suite
+# family).
 sched_gate ROOT-HYGIENE res=dayone desc="no audit/scratch clutter tracked at repo root (allowlist ROOT_HYGIENE_ALLOW.md)" \
     -- python3 "$PORTING_SDK_DIR/scripts/root_hygiene.py" --port perl --repo .
-
-sched_gate IGNORE-LEDGER-VERIFY res=dayone desc="no laundered false-absence entries in DOC_AUDIT_IGNORE.md (strict: reason/approver/date required)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/ignore_ledger_verify.py" --port perl --repo . --require-fields
-
-sched_gate SEMVER-DIFF res=dayone desc="version bump matches API surface change vs release floor (port_signatures.baseline.json)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/semver_diff.py" --port perl --repo .
-
-sched_gate META-CONSISTENT tier=nightly res=dayone desc="package metadata consistency" \
-    -- python3 "$PORTING_SDK_DIR/scripts/meta_consistent.py" --port perl --repo .
-
-sched_gate ARTIFACT-DENY res=dayone desc="no porting artifacts in the PUBLISHED package (authoritative listing)" \
-    --fn dayone_artifact_deny
-
-# ---- expansion gates (Tier 5, now BLOCKING — backlog burned + allowlists approved) ---
-# Wired the same way as the Day-one gates above: single approvable
-# `python3 "$PORTING_SDK_DIR/scripts/<gate>.py" --port perl --repo .` prefix, NO
-# --report-only. Each was verified to exit 0 enforcing before wiring.
-#   * ROUTE-COLLISION is NOT wired for perl: route_collision.py has no default
-#     registry command for perl and, fed perl's route_registry.pl, currently flags
-#     2 ROUTE-SPLIT findings (call_flows/conference_rooms list_addresses, singular-
-#     vs-plural fabric path) with no human-approved ROUTE_COLLISION_ALLOW.md — a
-#     real disposition, held for a follow-up, not silenced here.
-sched_gate GEN-TYPE-DEGENERACY res=dayone desc="no degenerate generated typed aliases (allowlist GEN_TYPE_DEGENERACY_ALLOW.md)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/gen_type_degeneracy.py" --port perl --repo .
 
 sched_gate PUBLIC-JARGON res=dayone desc="no porting/internal jargon leaked into the public surface" \
     -- python3 "$PORTING_SDK_DIR/scripts/public_jargon.py" --port perl --repo .
 
-sched_gate GEN-IDIOM res=dayone desc="generated code is not lint-excluded (holds to the same idiom bar)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/gen_idiom.py" --port perl --repo .
-
-sched_gate RELEASE-FRESH res=dayone desc="publish workflow runs the gates before publishing (publish.yml gated)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/release_fresh.py" --port perl --repo .
+# ---- summary ----------------------------------------------------------------
 
 sched_run
 rc=$?

--- a/t/98_rest_transport_error.t
+++ b/t/98_rest_transport_error.t
@@ -1,0 +1,113 @@
+#!/usr/bin/env perl
+# Transport-error typing for the REST client (plan 1.3b).
+#
+# A TRANSPORT failure (connection refused / DNS failure / connection reset / TLS
+# error) must surface as the SDK's TYPED transport error --
+# SignalWireRestTransportError, a member of the SignalWireRestError family with
+# status_code => undef -- NOT a bare HTTP::Tiny synthetic-599 SignalWireRestError
+# as if the server had answered, and NOT a bare string die. This is the SDK half
+# of the cross-port ERROR-ENVELOPE transport case (envelope_transport_refused).
+use strict;
+use warnings;
+use Test::More;
+
+use SignalWire::REST::HttpClient;
+use SignalWire::REST::RestClient;
+use Scalar::Util qw(blessed);
+use IO::Socket::INET ();
+
+# --- The typed transport error class ---------------------------------------
+{
+    my $e = SignalWireRestTransportError->new(
+        body   => 'Could not connect to 127.0.0.1:1: Connection refused',
+        url    => '/api/fabric/addresses',
+        method => 'GET',
+    );
+    isa_ok( $e, 'SignalWireRestTransportError', 'transport error' );
+    isa_ok( $e, 'SignalWireRestError',
+        'transport error is a member of the SignalWireRestError family' );
+    ok( $e->isa('SignalWire::REST::HttpClient::Error'),
+        'transport error also isa the back-compat alias' );
+    is( $e->status_code, undef, 'transport error status_code is undef (no HTTP status)' );
+    is( $e->method, 'GET', 'transport error carries the method' );
+    is( $e->url, '/api/fabric/addresses', 'transport error carries the url/path' );
+    like(
+        "$e",
+        qr/GET .*failed to reach the server.*Connection refused/,
+        'transport error stringifies as "failed to reach the server" (no bogus status)'
+    );
+    unlike( "$e", qr/returned/, 'transport error does NOT say "returned <status>"' );
+}
+
+# --- _is_transport_failure: classifies the HTTP::Tiny synthetic 599 ---------
+# HTTP::Tiny returns status 599 / reason "Internal Exception" on a transport
+# failure (no real server sends a 599). A genuine >= 400 from the server must NOT
+# be classified as a transport failure.
+{
+    ok(
+        SignalWire::REST::HttpClient::_is_transport_failure(
+            { status => 599, reason => 'Internal Exception', content => 'refused' }
+        ),
+        'synthetic 599 / Internal Exception is a transport failure'
+    );
+    ok(
+        !SignalWire::REST::HttpClient::_is_transport_failure(
+            { status => 500, reason => 'Internal Server Error', content => '{}' }
+        ),
+        'a real 500 from the server is NOT a transport failure'
+    );
+    ok(
+        !SignalWire::REST::HttpClient::_is_transport_failure(
+            { status => 404, reason => 'Not Found', content => '{}' }
+        ),
+        'a real 404 is NOT a transport failure'
+    );
+    ok(
+        !SignalWire::REST::HttpClient::_is_transport_failure(
+            { status => 599, reason => 'Weird Real 599', content => '{}' }
+        ),
+        'a 599 that is NOT HTTP::Tiny\'s Internal Exception reason is NOT a transport failure'
+    );
+}
+
+# --- End to end: a real connection-refused raises the TYPED transport error --
+# Point the client at a DEAD port (bind an ephemeral port then release it, so
+# nothing is listening) and issue a GET. It must raise a typed transport error,
+# not a bare error and not a raw-599 SignalWireRestError with status 599.
+{
+    my $sock = IO::Socket::INET->new(
+        LocalAddr => '127.0.0.1',
+        LocalPort => 0,
+        Proto     => 'tcp',
+        Listen    => 1,
+    ) or die "cannot bind a probe port: $!";
+    my $dead = $sock->sockport;
+    $sock->close;    # release it -- now nothing is listening
+
+    my $client = SignalWire::REST::RestClient->new(
+        project => 'p',
+        token   => 't',
+        host    => "http://127.0.0.1:$dead",
+    );
+
+    my $err;
+    my $ok = eval {
+        $client->_http->get('/api/fabric/addresses');
+        1;
+    };
+    $err = $@ unless $ok;
+
+    ok( !$ok, 'a connection-refused GET raises (does not return)' );
+    ok( blessed($err), 'the raised error is an object, not a bare string die' )
+        or diag("raised: $err");
+    isa_ok( $err, 'SignalWireRestTransportError', 'the raised transport error' );
+    isa_ok( $err, 'SignalWireRestError',
+        'the raised error is caught by "catch SignalWireRestError"' );
+    is( $err->status_code, undef,
+        'the raised transport error has status_code undef (NOT a raw 599)' );
+    isnt( "$err", '599', 'the error is not a bare 599' );
+    like( "$err", qr/failed to reach the server/,
+        'the raised transport error stringifies as a transport failure' );
+}
+
+done_testing;

--- a/t/rest/04_calling_mock.t
+++ b/t/rest/04_calling_mock.t
@@ -357,23 +357,33 @@ subtest 'TestCallingAI' => sub {
 subtest 'TestCallingLive' => sub {
     subtest 'live_transcribe' => sub {
         my $client = MockTest::client();
-        my $body = $client->calling->live_transcribe('call-1', language => 'en-US');
+        my $body = $client->calling->live_transcribe(
+            'call-1',
+            action => { start => { lang => 'en-US', direction => ['local-caller'] } },
+        );
         is(ref $body, 'HASH', 'response is a hashref');
         ok(exists $body->{id}, 'response has id');
         my $params = _assert_command('calling.live_transcribe', 'call-1');
-        is($params->{language}, 'en-US', 'params.language');
+        is($params->{action}{start}{lang}, 'en-US', 'params.action.start.lang');
     };
 
     subtest 'live_translate' => sub {
         my $client = MockTest::client();
         my $body = $client->calling->live_translate(
-            'call-1', source_language => 'en', target_language => 'es',
+            'call-1',
+            action => {
+                start => {
+                    from_lang => 'en-US',
+                    to_lang   => 'es-ES',
+                    direction => ['local-caller'],
+                },
+            },
         );
         is(ref $body, 'HASH', 'response is a hashref');
         ok(exists $body->{id}, 'response has id');
         my $params = _assert_command('calling.live_translate', 'call-1');
-        is($params->{source_language}, 'en', 'params.source_language');
-        is($params->{target_language}, 'es', 'params.target_language');
+        is($params->{action}{start}{from_lang}, 'en-US', 'params.action.start.from_lang');
+        is($params->{action}{start}{to_lang},   'es-ES', 'params.action.start.to_lang');
     };
 };
 

--- a/t/rest/05_small_namespaces.t
+++ b/t/rest/05_small_namespaces.t
@@ -157,9 +157,8 @@ subtest 'TestImportedNumbers' => sub {
         my $client = MockTest::client();
         my $body = $client->imported_numbers->create(
             number       => '+15551234567',
-            sip_username => 'alice',
-            sip_password => 'secret',
-            sip_proxy    => 'sip.example.com',
+            number_type  => 'longcode',
+            capabilities => ['sms', 'voice'],
         );
         is(ref $body, 'HASH', 'response is a hashref');
         ok(exists $body->{id}, 'imported number has id');
@@ -167,9 +166,9 @@ subtest 'TestImportedNumbers' => sub {
         is($j->{method}, 'POST', 'POST recorded');
         is($j->{path},   '/api/relay/rest/imported_phone_numbers', 'path matches');
         my $sent = $j->{body} || {};
-        is($sent->{number},       '+15551234567',     'number forwarded');
-        is($sent->{sip_username}, 'alice',            'sip_username forwarded');
-        is($sent->{sip_proxy},    'sip.example.com', 'sip_proxy forwarded');
+        is($sent->{number},      '+15551234567',      'number forwarded');
+        is($sent->{number_type}, 'longcode',           'number_type forwarded');
+        is_deeply($sent->{capabilities}, ['sms', 'voice'], 'capabilities forwarded');
     };
 };
 
@@ -204,17 +203,17 @@ subtest 'TestSipProfile' => sub {
     subtest 'update' => sub {
         my $client = MockTest::client();
         my $body = $client->sip_profile->update(
-            domain         => 'myco.sip.signalwire.com',
-            default_codecs => ['PCMU', 'PCMA'],
+            domain_identifier => 'myco.sip.signalwire.com',
+            default_codecs    => ['PCMU', 'PCMA'],
         );
         is(ref $body, 'HASH', 'response is a hashref');
-        ok(exists $body->{domain} || exists $body->{default_codecs},
-            'sip_profile resource has domain or default_codecs');
+        ok(exists $body->{domain_identifier} || exists $body->{default_codecs},
+            'sip_profile resource has domain_identifier or default_codecs');
         my $j = MockTest::journal_last();
         is($j->{method}, 'PUT', 'sip_profile update uses PUT');
         is($j->{path},   '/api/relay/rest/sip_profile', 'path matches');
         my $sent = $j->{body} || {};
-        is($sent->{domain},          'myco.sip.signalwire.com', 'domain forwarded');
+        is($sent->{domain_identifier}, 'myco.sip.signalwire.com', 'domain_identifier forwarded');
         is_deeply($sent->{default_codecs}, ['PCMU', 'PCMA'], 'default_codecs forwarded');
     };
 };

--- a/t/rest/13_fabric_mock.t
+++ b/t/rest/13_fabric_mock.t
@@ -157,7 +157,7 @@ subtest 'TestFabricTokens' => sub {
     subtest 'test_create_invite_token' => sub {
         my $client = MockTest::client();
         my $body = $client->fabric->tokens->create_invite_token(
-            email => 'invitee@example.com',
+            address_id => 'addr-1',
         );
         is(ref $body, 'HASH', 'expected hashref');
 
@@ -166,13 +166,13 @@ subtest 'TestFabricTokens' => sub {
         # subscriber/invites uses the singular 'subscriber' path segment.
         is($last->{path}, '/api/fabric/subscriber/invites', 'path matches');
         is(ref $last->{body}, 'HASH', 'body is hashref');
-        is($last->{body}{email}, 'invitee@example.com', 'email forwarded');
+        is($last->{body}{address_id}, 'addr-1', 'address_id forwarded');
     };
 
     subtest 'test_create_embed_token' => sub {
         my $client = MockTest::client();
         my $body = $client->fabric->tokens->create_embed_token(
-            allowed_addresses => ['addr-1', 'addr-2'],
+            token => 'embed-tok-1',
         );
         is(ref $body, 'HASH', 'expected hashref');
 
@@ -180,8 +180,7 @@ subtest 'TestFabricTokens' => sub {
         is($last->{method}, 'POST', 'POST recorded');
         is($last->{path}, '/api/fabric/embeds/tokens', 'path matches');
         is(ref $last->{body}, 'HASH', 'body is hashref');
-        is_deeply($last->{body}{allowed_addresses}, ['addr-1', 'addr-2'],
-            'allowed_addresses forwarded');
+        is($last->{body}{token}, 'embed-tok-1', 'token forwarded');
     };
 
     subtest 'test_refresh_subscriber_token' => sub {

--- a/t/rest/15_registry_mock.t
+++ b/t/rest/15_registry_mock.t
@@ -58,8 +58,8 @@ subtest 'TestRegistryBrands' => sub {
         my $body = $client->registry->brands->create_campaign(
             'brand-2',
             {
-                usecase     => 'LOW_VOLUME',
-                description => 'MFA',
+                sms_use_case => 'LOW_VOLUME',
+                description  => 'MFA',
             },
         );
         is(ref $body, 'HASH', 'expected hashref');
@@ -69,7 +69,7 @@ subtest 'TestRegistryBrands' => sub {
         is($last->{path}, "$REG_BASE/brands/brand-2/campaigns",
             'path matches');
         is(ref $last->{body}, 'HASH', 'body is hashref');
-        is($last->{body}{usecase}, 'LOW_VOLUME', 'usecase forwarded');
+        is($last->{body}{sms_use_case}, 'LOW_VOLUME', 'sms_use_case forwarded');
         is($last->{body}{description}, 'MFA', 'description forwarded');
     };
 };
@@ -92,7 +92,7 @@ subtest 'TestRegistryCampaigns' => sub {
         # RegistryCampaigns.update calls _http->put(...) — distinct from
         # the generic CrudResource which uses PATCH.
         my $body = $client->registry->campaigns->update(
-            'camp-2', description => 'Updated',
+            'camp-2', name => 'Updated',
         );
         is(ref $body, 'HASH', 'expected hashref');
 
@@ -100,7 +100,7 @@ subtest 'TestRegistryCampaigns' => sub {
         is($last->{method}, 'PUT', 'PUT recorded (not PATCH)');
         is($last->{path}, "$REG_BASE/campaigns/camp-2", 'path matches');
         is(ref $last->{body}, 'HASH', 'body is hashref');
-        is($last->{body}{description}, 'Updated', 'description forwarded');
+        is($last->{body}{name}, 'Updated', 'name forwarded');
     };
 
     subtest 'test_list_numbers_uses_numbers_subpath' => sub {
@@ -118,7 +118,7 @@ subtest 'TestRegistryCampaigns' => sub {
     subtest 'test_create_order_posts_to_orders_subpath' => sub {
         my $client = MockTest::client();
         my $body = $client->registry->campaigns->create_order(
-            'camp-4', numbers => ['pn-1', 'pn-2'],
+            'camp-4', phone_numbers => ['pn-1', 'pn-2'],
         );
         is(ref $body, 'HASH', 'expected hashref');
 
@@ -127,7 +127,7 @@ subtest 'TestRegistryCampaigns' => sub {
         is($last->{path}, "$REG_BASE/campaigns/camp-4/orders",
             'path matches');
         is(ref $last->{body}, 'HASH', 'body is hashref');
-        is_deeply($last->{body}{numbers}, ['pn-1', 'pn-2'], 'numbers forwarded');
+        is_deeply($last->{body}{phone_numbers}, ['pn-1', 'pn-2'], 'phone_numbers forwarded');
     };
 };
 

--- a/t/rest/16_pagination_mock.t
+++ b/t/rest/16_pagination_mock.t
@@ -77,7 +77,7 @@ subtest 'TestPaginatedIterator' => sub {
                     { id => 'addr-2', name => 'second' },
                 ],
                 links => {
-                    next => 'http://example.com/api/fabric/addresses?cursor=page2',
+                    next => 'http://example.com/api/fabric/addresses?page_token=page2',
                 },
             },
         );
@@ -106,10 +106,10 @@ subtest 'TestPaginatedIterator' => sub {
         my @gets = @{ $addr_gets->() };
         my @mine = @gets[ $before .. $#gets ];
         is(scalar(@mine), 2, 'two paginated GETs recorded');
-        # The second fetch carries cursor=page2 from the first response's
+        # The second fetch carries page_token=page2 from the first response's
         # links.next.
-        is_deeply($mine[1]{query_params}{cursor}, ['page2'],
-            'second fetch carries cursor=page2');
+        is_deeply($mine[1]{query_params}{page_token}, ['page2'],
+            'second fetch carries page_token=page2');
     };
 
     subtest 'test_resource_paginate_walks_all_pages' => sub {
@@ -126,7 +126,7 @@ subtest 'TestPaginatedIterator' => sub {
                     { id => 'pg-2', name => 'second' },
                 ],
                 links => {
-                    next => 'http://example.com/api/fabric/addresses?cursor=next2',
+                    next => 'http://example.com/api/fabric/addresses?page_token=next2',
                 },
             },
         );
@@ -163,8 +163,8 @@ subtest 'TestPaginatedIterator' => sub {
         my @gets = @{ $addr_gets->() };
         my @mine = @gets[ $before .. $#gets ];    # only this subtest's GETs
         is(scalar(@mine), 2, 'paginate() issued exactly two page GETs');
-        is_deeply($mine[1]{query_params}{cursor}, ['next2'],
-            'second page fetch carried cursor=next2 from links.next');
+        is_deeply($mine[1]{query_params}{page_token}, ['next2'],
+            'second page fetch carried page_token=next2 from links.next');
     };
 
     subtest 'test_next_raises_stop_iteration_when_done' => sub {


### PR DESCRIPTION
Consolidated gate-enforcement work for signalwire-perl (one PR per repo). Folds the previously-separate strict-mocks, part5 gate-suites, and RELAY action-wrap branches into a single `plan/gate-enforcement` branch.

Contents:
- §2.2 STRICT-MOCKS: 400-mode default (MOCK_SIGNALWIRE_STRICT / MOCK_RELAY_STRICT), wire-violation consumer wired, burn-to-zero.
- Part-5 gate-suite form of run-ci.sh (every gate NAME preserved as a rule ID).
- RELAY live_transcribe / live_translate action-wrap parity where applicable.
- Transport-error surface reconciliation (SignalWireRestTransportError).

Depends on porting-sdk landing first (port CI clones porting-sdk main for the oracle / relay corpus / gate-inventory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
