### PR TITLE
feat(rest): RequestOptions envelope — timeout/retries/abort (plan 4.2)

### DIFF
--- a/bin/emit-envelope.pl
+++ b/bin/emit-envelope.pl
@@ -73,6 +73,7 @@ use lib File::Spec->catdir( $RealBin, File::Spec->updir, 't', 'lib' );
 
 use SignalWire::REST::HttpClient;
 use SignalWire::REST::RestClient;
+use SignalWire::REST::RequestOptions;
 use MockTest ();
 
 # The mock child pid we spawn (if any), torn down on exit.
@@ -218,8 +219,27 @@ sub run_case ($case) {
     reset_journal();
     reset_scenarios();
 
+    # Arm the scenario. scenario_repeat arms the SAME override N times (FIFO) so a
+    # retry-armed case sees the failure on every attempt (the mock consumes one
+    # per request). Default 1 (a single arming) when the field is absent.
     my $scen = $case->{scenario};
-    arm_scenario( $case->{endpoint}, $scen ) if defined $scen;
+    if ( defined $scen ) {
+        my $repeat = $case->{scenario_repeat} // 1;
+        arm_scenario( $case->{endpoint}, $scen ) for 1 .. $repeat;
+    }
+
+    # Per-request options (plan 4.2): the corpus supplies {retries?, retry_backoff?,
+    # timeout?}; pass them as a RequestOptions so the retry-armed cases exercise the
+    # real retry loop. retry_backoff is pinned to 0 in the corpus so no wall-clock
+    # wait occurs. Absent => the port's default (retries 0, no retry).
+    my $req_opts;
+    if ( my $ro = $case->{request_options} ) {
+        $req_opts = SignalWire::REST::RequestOptions->new(
+            ( exists $ro->{retries}       ? ( retries       => $ro->{retries} )       : () ),
+            ( exists $ro->{retry_backoff} ? ( retry_backoff => $ro->{retry_backoff} ) : () ),
+            ( exists $ro->{timeout}       ? ( timeout       => $ro->{timeout} )       : () ),
+        );
+    }
 
     # Build the client. For a transport case, point it at a DEAD port so the
     # connection is refused; otherwise at the live mock.
@@ -235,10 +255,17 @@ sub run_case ($case) {
     my $http = $client->_http;
 
     eval {
-        if ( $call->{method} eq 'GET' ) {
-            $http->get($path);
+        my $method = $call->{method};
+        if ( $method eq 'GET' ) {
+            $http->get( $path, request_options => $req_opts );
+        } elsif ( $method eq 'POST' ) {
+            # POST cases carry a body (relay-rest.create_address); drive a real
+            # POST so the idempotency-asymmetry retry logic is exercised.
+            $http->post( $path, body => $call->{body}, request_options => $req_opts );
         } else {
-            $http->_request( $call->{method}, $path );
+            $http->_request( $method, $path,
+                body            => $call->{body},
+                request_options => $req_opts );
         }
         1;
     } or do {

--- a/lib/SignalWire/REST/HttpClient.pm
+++ b/lib/SignalWire/REST/HttpClient.pm
@@ -6,6 +6,10 @@ use Moo;
 use HTTP::Tiny;
 use JSON         qw(encode_json decode_json);
 use MIME::Base64 qw(encode_base64);
+use Scalar::Util qw(blessed);
+use Time::HiRes  qw(sleep);
+
+use SignalWire::REST::RequestOptions;
 
 # Derive the outbound User-Agent from the distribution $VERSION -- the single
 # source of truth in lib/SignalWire.pm (also what Makefile.PL's VERSION_FROM
@@ -30,9 +34,17 @@ sub _sdk_version {
 
 my $USER_AGENT = 'signalwire-perl/' . _sdk_version();
 
-has 'project'      => ( is => 'ro', required => 1 );
-has 'token'        => ( is => 'ro', required => 1 );
-has 'host'         => ( is => 'ro', required => 1 );
+has 'project' => ( is => 'ro', required => 1 );
+has 'token'   => ( is => 'ro', required => 1 );
+has 'host'    => ( is => 'ro', required => 1 );
+
+# The CLIENT-DEFAULT request options (plan 4.2) -- a
+# SignalWire::REST::RequestOptions applied to every request, shallow-overridden
+# per call by a request_options passed to a verb. undef => the built-in defaults
+# (30s timeout, no retries) for every request. Stored here so the whole resource
+# tree (which shares this one HttpClient) inherits it.
+has 'request_options' => ( is => 'ro', default => sub { undef } );
+
 has 'base_url'     => ( is => 'lazy' );
 has '_ua'          => ( is => 'lazy' );
 has '_auth_header' => ( is => 'lazy' );
@@ -101,27 +113,90 @@ sub _request {
         $request_opts{content} = encode_json( $opts{body} );
     }
 
-    my $response = $self->_ua->request( $method, $url, \%request_opts );
+    # Resolve the effective options: per-request over client-default over the
+    # built-in defaults (plan 4.2). Every field is concrete after resolve().
+    my $ro = SignalWire::REST::RequestOptions::Resolver::resolve( $self->request_options,
+        $opts{request_options} );
 
-    unless ( $response->{success} ) {
+    # total attempts = retries + 1; retry a retryable status (idempotency-aware)
+    # or a transport failure, honoring Retry-After then exponential backoff.
+    # abort_signal is checked cooperatively BEFORE every attempt.
+    my $attempt = 0;
+    while (1) {
+        $attempt++;
+
+        # Cooperative cancellation: a set abort_signal raises the typed transport
+        # error (no response was produced) before the send. Checked between
+        # attempts -- the honest portable minimum for a synchronous client.
+        if ( _abort_is_set( $ro->{abort_signal} ) ) {
+            die SignalWireRestTransportError->new(
+                body   => 'request cancelled by abort_signal',
+                url    => $path,
+                method => $method,
+            );
+        }
+
+        # Per-attempt wall-clock timeout: HTTP::Tiny carries the timeout on the
+        # object, so scope the resolved timeout onto the shared UA for this send
+        # and restore it afterwards (the resource tree shares one UA).
+        my $ua       = $self->_ua;
+        my $saved_to = $ua->{timeout};
+        $ua->{timeout} = $ro->{timeout} if defined $ro->{timeout};
+        my $response = $ua->request( $method, $url, \%request_opts );
+        $ua->{timeout} = $saved_to;
+
+        if ( $response->{success} ) {
+
+            # 204 No Content or empty body
+            if ( $response->{status} == 204 || !$response->{content} ) {
+                return {};
+            }
+            my $result;
+            eval { $result = decode_json( $response->{content} ) };
+            return { raw => $response->{content} } if $@;
+            return $result;
+        }
+
+        # --- failure paths (transport vs HTTP >= 400), retry-aware ---
 
         # Distinguish a TRANSPORT failure (the request never reached the server --
-        # connection refused, DNS failure, connection reset, TLS error) from a real
-        # HTTP >= 400 response. HTTP::Tiny does NOT throw on a transport failure; it
-        # SYNTHESISES a response with status 599 / reason "Internal Exception" (599 is
-        # reserved by HTTP::Tiny for its own internal exceptions -- no real server
-        # sends it). Map that synthetic 599 to the TYPED transport error
-        # (SignalWireRestTransportError, status_code => undef), a member of the
-        # SignalWireRestError family, so a caller catching SignalWireRestError handles
-        # every REST failure (HTTP + transport) with one eval -- instead of a raw 599
-        # leaking through as if the server had answered. Python parity:
-        # signalwire.rest._base.SignalWireRestTransportError (plan 1.3b).
+        # connection refused, DNS failure, connection reset, TLS error, read
+        # timeout) from a real HTTP >= 400 response. HTTP::Tiny does NOT throw on a
+        # transport failure; it SYNTHESISES a response with status 599 / reason
+        # "Internal Exception" (599 is reserved by HTTP::Tiny for its own internal
+        # exceptions -- no real server sends it). Map that synthetic 599 to the
+        # TYPED transport error (SignalWireRestTransportError, status_code => undef),
+        # a member of the SignalWireRestError family, so a caller catching
+        # SignalWireRestError handles every REST failure (HTTP + transport) with one
+        # eval. Python parity: signalwire.rest._base.SignalWireRestTransportError
+        # (plan 1.3b).
         if ( _is_transport_failure($response) ) {
+            if ( $attempt <= $ro->{retries} ) {
+                _backoff_sleep( $ro->{retry_backoff} * ( 2**( $attempt - 1 ) ) );
+                next;
+            }
             die SignalWireRestTransportError->new(
                 body   => $response->{content} // '',
                 url    => $path,
                 method => $method,
             );
+        }
+
+        # A real HTTP-error response. Retry if attempts remain AND the status is
+        # retryable for this method (idempotency-aware), honoring Retry-After when
+        # present then exponential backoff.
+        if (
+            $attempt <= $ro->{retries}
+            && SignalWire::REST::RequestOptions::Resolver::status_is_retryable(
+                $method, $response->{status}, $ro
+            )
+            )
+        {
+            my $delay = _retry_after_seconds($response);
+            $delay = $ro->{retry_backoff} * ( 2**( $attempt - 1 ) )
+                unless defined $delay;
+            _backoff_sleep($delay);
+            next;
         }
 
         my $body = $response->{content} // '';
@@ -136,42 +211,87 @@ sub _request {
         );
     }
 
-    # 204 No Content or empty body
-    if ( $response->{status} == 204 || !$response->{content} ) {
-        return {};
-    }
+    # Unreachable: the while(1) loop only exits via a return (success) or a die
+    # (transport/HTTP error). Present to satisfy Subroutines::RequireFinalReturn.
+    return;
+}
 
-    my $result;
-    eval { $result = decode_json( $response->{content} ) };
-    if ($@) {
-        return { raw => $response->{content} };
+# Cooperative-cancellation probe: an abort_signal is any object/coderef answering
+# ->is_set (an object's is_set method) or a plain coderef (called). Truthy =>
+# cancel. undef => never cancelled.
+sub _abort_is_set {
+    my ($signal) = @_;
+    return 0 unless defined $signal;
+    if ( blessed($signal) && $signal->can('is_set') ) {
+        return $signal->is_set ? 1 : 0;
     }
-    return $result;
+    if ( ref $signal eq 'CODE' ) {
+        return $signal->() ? 1 : 0;
+    }
+    return 0;
+}
+
+# Backoff sleep between retries. A seam so a retry_backoff of 0 (the corpus /
+# tests use it) never waits on wall-clock -- the mock proves attempt ORDERING,
+# not real time. Time::HiRes::sleep handles the fractional exponential delays.
+sub _backoff_sleep {
+    my ($seconds) = @_;
+    sleep($seconds) if defined $seconds && $seconds > 0;
+    return;
+}
+
+# Parse a Retry-After header (delta-seconds form) off a response, or undef when
+# absent / an HTTP-date form (fall back to computed backoff). HTTP::Tiny
+# lower-cases header keys and gives an arrayref when a header repeats.
+sub _retry_after_seconds {
+    my ($response) = @_;
+    my $headers    = $response->{headers} || {};
+    my $value      = $headers->{'retry-after'};
+    $value = $value->[0] if ref $value eq 'ARRAY';
+    return unless defined $value;
+    return ( $value =~ /^\s*\d+(?:\.\d+)?\s*$/ ) ? ( $value + 0 ) : undef;
 }
 
 sub get {
     my ( $self, $path, %opts ) = @_;
-    return $self->_request( 'GET', $path, params => $opts{params} );
+    return $self->_request(
+        'GET', $path,
+        params          => $opts{params},
+        request_options => $opts{request_options}
+    );
 }
 
 sub post {
     my ( $self, $path, %opts ) = @_;
-    return $self->_request( 'POST', $path, body => $opts{body}, params => $opts{params} );
+    return $self->_request(
+        'POST', $path,
+        body            => $opts{body},
+        params          => $opts{params},
+        request_options => $opts{request_options}
+    );
 }
 
 sub put {
     my ( $self, $path, %opts ) = @_;
-    return $self->_request( 'PUT', $path, body => $opts{body} );
+    return $self->_request(
+        'PUT', $path,
+        body            => $opts{body},
+        request_options => $opts{request_options}
+    );
 }
 
 sub patch {
     my ( $self, $path, %opts ) = @_;
-    return $self->_request( 'PATCH', $path, body => $opts{body} );
+    return $self->_request(
+        'PATCH', $path,
+        body            => $opts{body},
+        request_options => $opts{request_options}
+    );
 }
 
 sub delete_request {
-    my ( $self, $path ) = @_;
-    return $self->_request( 'DELETE', $path );
+    my ( $self, $path, %opts ) = @_;
+    return $self->_request( 'DELETE', $path, request_options => $opts{request_options} );
 }
 
 # Detect an HTTP::Tiny TRANSPORT failure vs a real HTTP error response.

--- a/lib/SignalWire/REST/RequestOptions.pm
+++ b/lib/SignalWire/REST/RequestOptions.pm
@@ -1,0 +1,119 @@
+package SignalWire::REST::RequestOptions;
+use strict;
+use warnings;
+use Moo;
+
+# RequestOptions -- the REST request-options envelope (plan 4.2), the Perl mirror
+# of signalwire.rest._request_options. A single value object controlling
+# per-request transport behavior: timeout, retries (with an idempotency-aware
+# retry policy + exponential backoff), and cooperative cancellation. Supplied at
+# two levels:
+#
+#   * Client default: RestClient->new(..., request_options => ...) stored on the
+#     HttpClient and applied to every request.
+#   * Per-request override: each verb accepts an optional request_options that
+#     SHALLOW-overrides the client default for that one call -- an unset (undef)
+#     field falls back to the client default, then the built-in default.
+#
+# The timeout + retry semantics are the reference-pinned, wire-observable
+# contract (the mock sees N attempts and honors the backoff ordering).
+# abort_signal fidelity is per-port idiom: every port exposes the field; how
+# deeply the cancellation cuts is the language's business. Perl's REST client is
+# SYNCHRONOUS (HTTP::Tiny), so -- like the Python sync client -- it cannot
+# interrupt an in-flight blocking socket read; cancellation is checked
+# cooperatively BETWEEN attempts (the honest, portable minimum). The abort_signal
+# is any object/coderef answering ->is_set (a coderef is called; an object's
+# is_set method is invoked); truthy => the request raises before the send.
+#
+# All fields are optional; undef means "inherit" -- resolved per-request over
+# client-default over the built-in default (see resolve()).
+
+has 'timeout'         => ( is => 'ro', default => sub { undef } );
+has 'retries'         => ( is => 'ro', default => sub { undef } );
+has 'retry_on_status' => ( is => 'ro', default => sub { undef } );
+has 'retry_backoff'   => ( is => 'ro', default => sub { undef } );
+has 'abort_signal'    => ( is => 'ro', default => sub { undef } );
+
+# The field set (used by merge()/resolve() so a new field is added in one place).
+my @FIELDS = qw(timeout retries retry_on_status retry_backoff abort_signal);
+
+# merge -- return a NEW RequestOptions with any set (defined) field of $override
+# applied over $self. This is the per-request-over-client-default shallow merge:
+# an unset (undef) field on $override leaves $self's value intact. Returns $self
+# unchanged when $override is undef. (Mirrors Python RequestOptions.merge, which
+# dataclasses.replace()s the set fields.)
+sub merge {
+    my ( $self, $override ) = @_;
+    return $self unless defined $override;
+    my %changes;
+    for my $name (@FIELDS) {
+        my $value = $override->$name;
+        $changes{$name} = $value if defined $value;
+    }
+    return ref($self)->new( ( map { $_ => $self->$_ } @FIELDS ), %changes );
+}
+
+# --- Module free functions (Python parity: the module-level resolve() +
+# status_is_retryable() in signalwire.rest._request_options). They live in a
+# distinct package with no class so they project onto the reference module's
+# free-function surface, not onto the RequestOptions class. ---
+package SignalWire::REST::RequestOptions::Resolver;    ## no critic (ProhibitMultiplePackages)
+use strict;
+use warnings;
+
+# The built-in defaults (the contract floor). undef on a RequestOptions field
+# means "inherit"; these are what an unset field resolves to at apply-time.
+our $DEFAULT_TIMEOUT         = 30.0;
+our $DEFAULT_RETRIES         = 0;
+our @DEFAULT_RETRY_ON_STATUS = ( 429, 500, 502, 503, 504 );
+our $DEFAULT_RETRY_BACKOFF   = 0.5;
+
+# Methods with no server-side side effect -- safe to retry on any retryable
+# status. POST/PATCH are excluded: they may create/mutate, so they retry ONLY on
+# a transport error or 429/503 (throttles), never blindly on 500/502/504, to
+# avoid duplicate side effects. This asymmetry is part of the pinned contract.
+my %IDEMPOTENT_METHODS = map { $_ => 1 } qw(GET PUT DELETE HEAD OPTIONS);
+
+# resolve -- the effective options: per-request over client-default over
+# built-in. undef on any field inherits the next level down; the built-in
+# defaults are the floor. Returns a plain hashref with every field concrete:
+#   { timeout, retries, retry_on_status (hashref set), retry_backoff, abort_signal }.
+# (The Python analogue returns an _EffectiveOptions dataclass; Perl's honest
+# idiom for that private, no-undef value is a hashref -- an internal detail the
+# retry loop reads, not part of the public surface.)
+sub resolve {
+    my ( $client_default, $per_request ) = @_;
+    my $base   = $client_default // SignalWire::REST::RequestOptions->new;
+    my $merged = $base->merge($per_request);
+
+    my $ros = $merged->retry_on_status;
+    my %status_set =
+        defined $ros
+        ? ( map { $_ => 1 } @$ros )
+        : ( map { $_ => 1 } @DEFAULT_RETRY_ON_STATUS );
+
+    return {
+        timeout         => defined $merged->timeout ? $merged->timeout : $DEFAULT_TIMEOUT,
+        retries         => defined $merged->retries ? $merged->retries : $DEFAULT_RETRIES,
+        retry_on_status => \%status_set,
+        retry_backoff   => defined $merged->retry_backoff
+        ? $merged->retry_backoff
+        : $DEFAULT_RETRY_BACKOFF,
+        abort_signal => $merged->abort_signal,
+    };
+}
+
+# status_is_retryable -- whether an HTTP $status for $method should trigger a
+# retry given the resolved $opts (the resolve() hashref). Idempotent methods
+# (GET/PUT/DELETE) retry on the full retry_on_status set. Non-idempotent methods
+# (POST/PATCH) retry only on 429/503 (the Retry-After-bearing throttles, which
+# mean "the request was NOT processed"), never on 500/502/504, to avoid
+# replaying a side effect that may have partially applied.
+sub status_is_retryable {
+    my ( $method, $status, $opts ) = @_;
+    return 0 unless $opts->{retry_on_status}{$status};
+    return 1 if $IDEMPOTENT_METHODS{ uc $method };
+    return ( $status == 429 || $status == 503 ) ? 1 : 0;
+}
+
+1;

--- a/lib/SignalWire/REST/RestClient.pm
+++ b/lib/SignalWire/REST/RestClient.pm
@@ -30,6 +30,16 @@ has 'host' => (
     default => sub { $ENV{SIGNALWIRE_SPACE} },
 );
 
+# Client-default request options (plan 4.2): a SignalWire::REST::RequestOptions
+# applied to every request the shared HttpClient issues, shallow-overridden
+# per-call by a request_options passed to a verb. undef => the built-in defaults
+# (30s timeout, no retries). Mirrors the Python reference's
+# RestClient(..., request_options=...).
+has 'request_options' => (
+    is      => 'ro',
+    default => sub { undef },
+);
+
 # Fail loud when a credential is neither passed nor present in the environment —
 # same contract as the Python reference (rest/client.py raises ValueError with a
 # message naming the three SIGNALWIRE_* env vars).
@@ -64,9 +74,10 @@ with 'SignalWire::REST::Namespaces::Generated::ResourceTree';
 sub _build__http {
     my ($self) = @_;
     return SignalWire::REST::HttpClient->new(
-        project => $self->_project_id,
-        token   => $self->token,
-        host    => $self->host,
+        project         => $self->_project_id,
+        token           => $self->token,
+        host            => $self->host,
+        request_options => $self->request_options,
     );
 }
 

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -27524,6 +27524,11 @@
                   "required": false
                 },
                 {
+                  "name": "request_options",
+                  "type": "optional<class:signalwire.rest._request_options.RequestOptions>",
+                  "required": false
+                },
+                {
                   "name": "base_url",
                   "type": "any",
                   "required": false
@@ -27560,6 +27565,12 @@
                   "name": "path",
                   "type": "string",
                   "required": true
+                },
+                {
+                  "name": "opts",
+                  "type": "dict<string,any>",
+                  "required": false,
+                  "kind": "var_keyword"
                 }
               ],
               "returns": "any"
@@ -27574,6 +27585,12 @@
                   "name": "path",
                   "type": "string",
                   "required": true
+                },
+                {
+                  "name": "opts",
+                  "type": "dict<string,any>",
+                  "required": false,
+                  "kind": "var_keyword"
                 }
               ],
               "returns": "any"
@@ -27592,6 +27609,11 @@
                 {
                   "name": "params",
                   "type": "optional<dict<string,any>>",
+                  "required": false
+                },
+                {
+                  "name": "request_options",
+                  "type": "optional<class:signalwire.rest._request_options.RequestOptions>",
                   "required": false
                 }
               ],
@@ -27621,6 +27643,11 @@
                   "name": "body",
                   "type": "any",
                   "required": false
+                },
+                {
+                  "name": "request_options",
+                  "type": "optional<class:signalwire.rest._request_options.RequestOptions>",
+                  "required": false
                 }
               ],
               "returns": "any"
@@ -27644,6 +27671,11 @@
                 {
                   "name": "params",
                   "type": "optional<dict<string,any>>",
+                  "required": false
+                },
+                {
+                  "name": "request_options",
+                  "type": "optional<class:signalwire.rest._request_options.RequestOptions>",
                   "required": false
                 }
               ],
@@ -27673,6 +27705,20 @@
                   "name": "body",
                   "type": "any",
                   "required": false
+                },
+                {
+                  "name": "request_options",
+                  "type": "optional<class:signalwire.rest._request_options.RequestOptions>",
+                  "required": false
+                }
+              ],
+              "returns": "any"
+            },
+            "request_options": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
                 }
               ],
               "returns": "any"
@@ -27931,6 +27977,144 @@
         }
       }
     },
+    "signalwire.rest._request_options": {
+      "classes": {
+        "RequestOptions": {
+          "methods": {
+            "__init__": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "timeout",
+                  "type": "optional<float>",
+                  "required": false
+                },
+                {
+                  "name": "retries",
+                  "type": "optional<int>",
+                  "required": false
+                },
+                {
+                  "name": "retry_on_status",
+                  "type": "optional<list<int>>",
+                  "required": false
+                },
+                {
+                  "name": "retry_backoff",
+                  "type": "optional<float>",
+                  "required": false
+                },
+                {
+                  "name": "abort_signal",
+                  "type": "optional<class:signalwire.rest._request_options._AbortSignal>",
+                  "required": false
+                }
+              ],
+              "returns": "void"
+            },
+            "abort_signal": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                }
+              ],
+              "returns": "any"
+            },
+            "merge": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "override",
+                  "type": "optional<class:signalwire.rest._request_options.RequestOptions>",
+                  "required": true
+                }
+              ],
+              "returns": "any"
+            },
+            "retries": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                }
+              ],
+              "returns": "any"
+            },
+            "retry_backoff": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                }
+              ],
+              "returns": "any"
+            },
+            "retry_on_status": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                }
+              ],
+              "returns": "any"
+            },
+            "timeout": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                }
+              ],
+              "returns": "any"
+            }
+          }
+        }
+      },
+      "functions": {
+        "resolve": {
+          "params": [
+            {
+              "name": "client_default",
+              "type": "optional<class:signalwire.rest._request_options.RequestOptions>",
+              "required": true
+            },
+            {
+              "name": "per_request",
+              "type": "optional<class:signalwire.rest._request_options.RequestOptions>",
+              "required": true
+            }
+          ],
+          "returns": "any"
+        },
+        "status_is_retryable": {
+          "params": [
+            {
+              "name": "method",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "status",
+              "type": "int",
+              "required": true
+            },
+            {
+              "name": "opts",
+              "type": "class:signalwire.rest._request_options._EffectiveOptions",
+              "required": true
+            }
+          ],
+          "returns": "any"
+        }
+      }
+    },
     "signalwire.rest.client": {
       "classes": {
         "RestClient": {
@@ -27952,6 +28136,11 @@
                   "required": false
                 },
                 {
+                  "name": "request_options",
+                  "type": "optional<class:signalwire.rest._request_options.RequestOptions>",
+                  "required": false
+                },
+                {
                   "name": "project_id",
                   "type": "any",
                   "required": false
@@ -27965,6 +28154,15 @@
               "returns": "void"
             },
             "host": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                }
+              ],
+              "returns": "any"
+            },
+            "request_options": {
               "params": [
                 {
                   "name": "self",

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,5 +1,5 @@
 {
-   "generated_from" : "signalwire-perl @ 82d9361cdae1e64b46bda560816d05d4576b5e50",
+   "generated_from" : "signalwire-perl @ d0307140488a20d2589ccaf1ccae69a1c4c18899",
    "modules" : {
       "signalwire" : {
          "classes" : {},
@@ -1378,6 +1378,17 @@
             ]
          },
          "functions" : []
+      },
+      "signalwire.rest._request_options" : {
+         "classes" : {
+            "RequestOptions" : [
+               "merge"
+            ]
+         },
+         "functions" : [
+            "resolve",
+            "status_is_retryable"
+         ]
       },
       "signalwire.rest.client" : {
          "classes" : {

--- a/scripts/enumerate_signatures.py
+++ b/scripts/enumerate_signatures.py
@@ -445,6 +445,9 @@ FREE_FN_PACKAGES = {
     "SignalWire::Security::WebhookValidator",  # validate_webhook_signature, validate_request
     "SignalWire::Security::WebhookMiddleware",  # make_webhook_validation_dependency
     "SignalWire::Security::SecurityUtils",  # filter_sensitive_headers, redact_url, is_valid_hostname
+    # RequestOptions envelope (plan 4.2): the module-level resolve() +
+    # status_is_retryable() free functions (signalwire.rest._request_options).
+    "SignalWire::REST::RequestOptions::Resolver",
 }
 
 # Free-function name overrides — for cases where the Python canonical

--- a/scripts/enumerate_surface.pl
+++ b/scripts/enumerate_surface.pl
@@ -293,6 +293,17 @@ my %PACKAGE_TO_PY = (
     'SignalWire::REST::RestClient' => { module => 'signalwire.rest.client', class => 'RestClient' },
     'SignalWire::REST::HttpClient' => { module => 'signalwire.rest._base',  class => 'HttpClient' },
 
+    # RequestOptions envelope (plan 4.2). The value object maps to the oracle's
+    # signalwire.rest._request_options.RequestOptions (surface = merge only; the
+    # data-field accessors and the auto __init__ are not surface, matching the
+    # python dataclass). The module-level resolve() / status_is_retryable() live
+    # in a distinct class => undef package so they project onto the reference
+    # module's free-function surface.
+    'SignalWire::REST::RequestOptions' =>
+        { module => 'signalwire.rest._request_options', class => 'RequestOptions' },
+    'SignalWire::REST::RequestOptions::Resolver' =>
+        { module => 'signalwire.rest._request_options', class => undef },
+
     # Canonical REST error (Python parity: signalwire.rest._base.SignalWireRestError).
     # The class is `package SignalWireRestError`; the legacy fully-qualified name
     # SignalWire::REST::HttpClient::Error is a glob-alias of the same stash for
@@ -1309,6 +1320,12 @@ my %FORCE_IMPLICIT_INIT = map { $_ => 1 } (
 # as a public method. Matching that keeps the diff meaningful.
 my %SKIP_IMPLICIT_INIT = map { $_ => 1 } (
     'SignalWire::Relay::Constants',
+
+    # RequestOptions (plan 4.2): the oracle surface for
+    # signalwire.rest._request_options.RequestOptions is ONLY `merge` -- the
+    # python @dataclass's auto-generated __init__ is not recorded as surface, so
+    # the Perl Moo root's implicit __init__ is suppressed to match.
+    'SignalWire::REST::RequestOptions',
 
     # SWML helper classes whose Python reference class does NOT expose an
     # __init__ in the surface oracle: SwmlRenderer (staticmethod-only) and the

--- a/t/rest/20_request_options.t
+++ b/t/rest/20_request_options.t
@@ -1,0 +1,239 @@
+#!/usr/bin/env perl
+# RequestOptions envelope -- behavioral contract over the real mock (plan 4.2).
+#
+# Translated from signalwire-python/tests/unit/rest/test_request_options.py.
+# These drive a real RestClient through the real HTTP::Tiny transport into the
+# shared mock_signalwire and assert on the recorded journal -- the same journal
+# the REST-COVERAGE gate reads. Retry / timeout are wire-observable: the mock
+# sees N attempts and honors the backoff ordering, so the contract is proven
+# over the real mock, NOT a transport mock.
+#
+# Contract pinned here (the oracle):
+#   - retries: a retryable failure is retried up to `retries` extra times; the
+#     mock sees retries + 1 attempts; the final success is returned.
+#   - idempotency asymmetry: GET/PUT/DELETE retry on the full retry_on_status
+#     set; POST/PATCH retry only on 429/503 (throttles), never 500/502/504.
+#   - timeout: a server-side delay exceeding the timeout raises the transport
+#     error family.
+#   - abort_signal: set before a request raises the transport error family.
+#   - per-request options shallow-override the client default.
+
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use Test::More;
+use Scalar::Util qw(blessed);
+
+use MockTest;
+use SignalWire::REST::RequestOptions;
+
+my $ADDRESSES_ENDPOINT = 'fabric.list_fabric_addresses';
+my $ADDRESSES_PATH     = '/api/fabric/addresses';
+my $CREATE_ENDPOINT    = 'relay-rest.create_address';
+my $CREATE_PATH        = '/api/relay/rest/addresses';
+
+# Arm the FULL scenario JSON (status / response / headers? / delay_ms?) --
+# MockTest::scenario_set only forwards {status,response}; the timeout case needs
+# delay_ms passed through, so post the control-plane frame directly (auth-scoped
+# like scenario_set).
+sub arm_full {
+    my ( $endpoint, $scenario ) = @_;
+    my $q = MockTest::_scope_query();
+    my $payload = JSON::encode_json($scenario);
+    my $resp = MockTest::_ua()->post(
+        "$MockTest::BASE_URL/__mock__/scenarios/$endpoint$q",
+        { content => $payload, headers => { 'Content-Type' => 'application/json' } },
+    );
+    die "arm_full failed: $resp->{status} - $resp->{content}" unless $resp->{success};
+    return;
+}
+
+# Count this client's journal entries matching (method, path). The mock journal
+# is scoped per-process (per auth), NOT per-subtest, and MockTest::journal_reset
+# is a no-op while a project is active -- so a raw count accumulates across
+# subtests. Every assertion therefore measures a DELTA: snapshot the count before
+# the call under test, then assert how many NEW entries it produced.
+sub count_hits {
+    my ( $method, $path ) = @_;
+    my $entries = MockTest::journal_all();
+    return scalar grep {
+        ( $_->{method} // '' ) eq $method && ( $_->{path} // '' ) eq $path
+    } @$entries;
+}
+
+# ---- Retry contract: a retryable failure is retried ----------------------
+subtest 'TestRetryContract' => sub {
+    subtest 'test_get_retries_503_then_succeeds' => sub {
+        my $client = MockTest::client();
+        # Arm a single 503; the default synthesized 200 follows it. retries=1
+        # retries the 503 into the 200 => 2 attempts.
+        my $before = count_hits( 'GET', $ADDRESSES_PATH );
+        MockTest::scenario_set( $ADDRESSES_ENDPOINT, 503, { errors => [ { code => 'X' } ] } );
+        my $result = $client->_http->get( $ADDRESSES_PATH,
+            request_options =>
+                SignalWire::REST::RequestOptions->new( retries => 1, retry_backoff => 0 ) );
+        ok( defined $result, 'retry-into-200 returned a body' );
+        is( count_hits( 'GET', $ADDRESSES_PATH ) - $before, 2,
+            'expected 2 attempts (503 then 200)' );
+    };
+
+    subtest 'test_no_retries_by_default_raises_on_first_failure' => sub {
+        my $client = MockTest::client();
+        my $before = count_hits( 'GET', $ADDRESSES_PATH );
+        MockTest::scenario_set( $ADDRESSES_ENDPOINT, 503, { errors => [ { code => 'X' } ] } );
+        my $err;
+        my $ok = eval { $client->_http->get($ADDRESSES_PATH); 1 };
+        $err = $@ unless $ok;
+        ok( !$ok, 'default (retries 0) raises on the first failure' );
+        isa_ok( $err, 'SignalWireRestError', 'raised typed error' );
+        is( $err->status_code, 503, 'status is 503' );
+        is( count_hits( 'GET', $ADDRESSES_PATH ) - $before, 1, 'default must not retry' );
+    };
+
+    subtest 'test_retries_exhausted_raises_last_error' => sub {
+        my $client = MockTest::client();
+        # Two 503s + retries=1 => 2 attempts, both 503 => raise the 503.
+        my $before = count_hits( 'GET', $ADDRESSES_PATH );
+        MockTest::scenario_set( $ADDRESSES_ENDPOINT, 503, { errors => [ { code => 'X' } ] } );
+        MockTest::scenario_set( $ADDRESSES_ENDPOINT, 503, { errors => [ { code => 'X' } ] } );
+        my $err;
+        my $ok = eval {
+            $client->_http->get( $ADDRESSES_PATH,
+                request_options =>
+                    SignalWire::REST::RequestOptions->new( retries => 1, retry_backoff => 0 ) );
+            1;
+        };
+        $err = $@ unless $ok;
+        ok( !$ok, 'exhausted retries raises' );
+        isa_ok( $err, 'SignalWireRestError', 'raised typed error' );
+        is( $err->status_code, 503, 'status is 503' );
+        is( count_hits( 'GET', $ADDRESSES_PATH ) - $before, 2,
+            'retries=1 => exactly 2 attempts' );
+    };
+};
+
+# ---- Idempotency asymmetry: POST/PATCH don't blindly retry 500 -----------
+subtest 'TestIdempotencyAsymmetry' => sub {
+    subtest 'test_post_does_not_retry_500' => sub {
+        my $client = MockTest::client();
+        # 500 is NOT retryable for a non-idempotent method even with retries armed.
+        my $before = count_hits( 'POST', $CREATE_PATH );
+        MockTest::scenario_set( $CREATE_ENDPOINT, 500, { error => 'x' } );
+        my $err;
+        my $ok = eval {
+            $client->_http->post( $CREATE_PATH,
+                body => { label => 'x' },
+                request_options =>
+                    SignalWire::REST::RequestOptions->new( retries => 2, retry_backoff => 0 ) );
+            1;
+        };
+        $err = $@ unless $ok;
+        ok( !$ok, 'POST 500 raises' );
+        isa_ok( $err, 'SignalWireRestError', 'raised typed error' );
+        is( $err->status_code, 500, 'status is 500' );
+        is( count_hits( 'POST', $CREATE_PATH ) - $before, 1,
+            'POST must not retry a 500 (side-effect safety)' );
+    };
+
+    subtest 'test_post_does_retry_503' => sub {
+        my $client = MockTest::client();
+        # 503 (throttle) IS retryable even for a non-idempotent method.
+        my $before = count_hits( 'POST', $CREATE_PATH );
+        MockTest::scenario_set( $CREATE_ENDPOINT, 503, { error => 'x' } );
+        $client->_http->post( $CREATE_PATH,
+            body => { label => 'x' },
+            request_options =>
+                SignalWire::REST::RequestOptions->new( retries => 1, retry_backoff => 0 ) );
+        is( count_hits( 'POST', $CREATE_PATH ) - $before, 2,
+            'POST retries a 503 throttle (safe): 503 then 200' );
+    };
+};
+
+# ---- Timeout: a slow response exceeding the timeout raises transport error --
+subtest 'TestTimeout' => sub {
+    subtest 'test_slow_response_times_out' => sub {
+        my $client = MockTest::client();
+        # Arm a 200 delayed 400ms; a 100ms timeout must fire => transport error.
+        arm_full( $ADDRESSES_ENDPOINT,
+            { status => 200, response => { data => [], links => {} }, delay_ms => 400 } );
+        my $err;
+        my $ok = eval {
+            $client->_http->get( $ADDRESSES_PATH,
+                request_options => SignalWire::REST::RequestOptions->new( timeout => 0.1 ) );
+            1;
+        };
+        $err = $@ unless $ok;
+        ok( !$ok, 'a timeout raises' );
+        isa_ok( $err, 'SignalWireRestTransportError', 'raised transport error' );
+    };
+};
+
+# ---- AbortSignal: a set signal raises before the request goes out --------
+subtest 'TestAbortSignal' => sub {
+    subtest 'test_preset_abort_raises_transport_error' => sub {
+        my $client = MockTest::client();
+        # A coderef returning true is a set signal (Perl's cooperative-cancel idiom).
+        my $signal = sub { 1 };
+        my $before = count_hits( 'GET', $ADDRESSES_PATH );
+        my $err;
+        my $ok = eval {
+            $client->_http->get( $ADDRESSES_PATH,
+                request_options =>
+                    SignalWire::REST::RequestOptions->new( abort_signal => $signal ) );
+            1;
+        };
+        $err = $@ unless $ok;
+        ok( !$ok, 'a set abort_signal raises' );
+        isa_ok( $err, 'SignalWireRestTransportError', 'raised transport error' );
+        is( count_hits( 'GET', $ADDRESSES_PATH ) - $before, 0,
+            'aborted request must not reach the server' );
+    };
+};
+
+# ---- Per-request override shallow-overrides the client default -----------
+subtest 'TestPerRequestOverride' => sub {
+    subtest 'test_per_request_retries_override_client_default' => sub {
+        # Client default = no retries (the built-in default when request_options is
+        # unset); per-request opts in to 1 retry. Uses MockTest::client() so the
+        # shared mock is ensured up the same way the other subtests do.
+        my $client = MockTest::client();
+        MockTest::scenario_set( $ADDRESSES_ENDPOINT, 503, { errors => [ { code => 'X' } ] } );
+        my $result = $client->_http->get( $ADDRESSES_PATH,
+            request_options =>
+                SignalWire::REST::RequestOptions->new( retries => 1, retry_backoff => 0 ) );
+        ok( defined $result, 'per-request retries override the client default (retried into 200)' );
+    };
+
+    subtest 'test_client_default_retries_applied' => sub {
+        # A client-default request_options (retries=1) is applied to a plain call
+        # with no per-request override. Ensure the shared mock first via client(),
+        # then build a client carrying the default and point it at the same host.
+        MockTest::client();    # ensure the singleton mock is up
+        my $client = SignalWire::REST::RestClient->new(
+            project         => $MockTest::PROJECT,
+            token           => $MockTest::TOKEN,
+            host            => $MockTest::BASE_URL,
+            request_options =>
+                SignalWire::REST::RequestOptions->new( retries => 1, retry_backoff => 0 ),
+        );
+        MockTest::scenario_set( $ADDRESSES_ENDPOINT, 503, { errors => [ { code => 'X' } ] } );
+        my $result = $client->_http->get($ADDRESSES_PATH);
+        ok( defined $result,
+            'client-default retries retried the 503 into the 200 (no per-request opts)' );
+    };
+
+    subtest 'test_merge_is_shallow' => sub {
+        # Unit-level: merge applies only the set fields of the override.
+        my $base = SignalWire::REST::RequestOptions->new( retries => 5, timeout => 12 );
+        my $merged = $base->merge(
+            SignalWire::REST::RequestOptions->new( retries => 1 ) );
+        is( $merged->retries, 1, 'override retries wins' );
+        is( $merged->timeout, 12, 'unset override field keeps the base value' );
+        is( $base->retries, 5, 'merge does not mutate the base' );
+        my $noop = $base->merge(undef);
+        is( $noop->retries, 5, 'merge(undef) returns self unchanged' );
+    };
+};
+
+done_testing;


### PR DESCRIPTION
Plan item 4.2 — the RequestOptions transport envelope in this port's idiom, implementing the python reference contract.

Adds RequestOptions (timeout + retries + abort) with client-default + per-request override, the idempotency-aware retry policy (GET/PUT/DELETE full set; POST/PATCH only 429/503), exponential backoff honoring Retry-After, and cooperative cancellation in the port's native primitive. Refreshes the envelope-dump program for the new retry corpus and schedules the ENVELOPE behavioral gate (diff_port_envelope vs the python oracle — verified ✓ PASS). Request-options unit tests over the shared mock (no transport stub).

Depends on porting-sdk landing first (port CI clones porting-sdk main for the oracle + ENVELOPE gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
