### PR TITLE
ci: unpin porting-sdk checkout back to main (post-merge)

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -54,7 +54,7 @@ jobs:
           # blocking on this branch) needs the SPEC-AWARE route_collision.py that lives
           # on porting-sdk plan/a-bar-2026-07-18, not yet on main. REVERT this ref to
           # main when that porting-sdk branch merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           path: porting-sdk
           fetch-depth: 1
           token: ${{ secrets.PORTING_SDK_TOKEN }}

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -62,7 +62,7 @@ jobs:
           # blocking on this branch) needs the SPEC-AWARE route_collision.py that lives
           # on porting-sdk plan/a-bar-2026-07-18, not yet on main. REVERT this ref to
           # main when that porting-sdk branch merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/multi-os.yml
+++ b/.github/workflows/multi-os.yml
@@ -90,7 +90,7 @@ jobs:
           # blocking on this branch) needs the SPEC-AWARE route_collision.py that lives
           # on porting-sdk plan/a-bar-2026-07-18, not yet on main. REVERT this ref to
           # main when that porting-sdk branch merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,7 +99,7 @@ jobs:
           # blocking on this branch) needs the SPEC-AWARE route_collision.py that lives
           # on porting-sdk plan/a-bar-2026-07-18, not yet on main. REVERT this ref to
           # main when that porting-sdk branch merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
           # blocking on this branch) needs the SPEC-AWARE route_collision.py that lives
           # on porting-sdk plan/a-bar-2026-07-18, not yet on main. REVERT this ref to
           # main when that porting-sdk branch merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           path: porting-sdk
           fetch-depth: 1
           token: ${{ secrets.PORTING_SDK_TOKEN }}

--- a/.github/workflows/surface-audit.yml
+++ b/.github/workflows/surface-audit.yml
@@ -45,7 +45,7 @@ jobs:
           # blocking on this branch) needs the SPEC-AWARE route_collision.py that lives
           # on porting-sdk plan/a-bar-2026-07-18, not yet on main. REVERT this ref to
           # main when that porting-sdk branch merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           path: porting-sdk
           fetch-depth: 1
           token: ${{ secrets.PORTING_SDK_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           # blocking on this branch) needs the SPEC-AWARE route_collision.py that lives
           # on porting-sdk plan/a-bar-2026-07-18, not yet on main. REVERT this ref to
           # main when that porting-sdk branch merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 


### PR DESCRIPTION
The `plan/a-bar-2026-07-18` branch is merged and deleted, so the 7 workflows pinned to `ref: plan/a-bar-2026-07-18` fail at the porting-sdk checkout step — reddening perl's Surface/Test/Doc CI on main. Reverts all to `ref: main` per the REVERT-on-merge comments.

Also carries the surface fix already on main (payload field-surface rule + POD-phantom removal) — this PR's CI is the first run of those against porting-sdk **main**'s merged oracle, so a green here confirms perl's surface is clean end-to-end.

Companion: porting-sdk #106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqhUoqrbptHNS3cypq9s6t