### PR TITLE
ci: unpin porting-sdk checkout to main (post-merge)

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -53,7 +53,7 @@ jobs:
           # PINNED to wave/1-aplus: the doc-audit tooling (DOC-WIRE + the audit scripts)
           # must match the wave/1-aplus oracle + differs this PR targets, not main.
           # REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           fetch-depth: 1
           token: ${{ secrets.PORTING_SDK_TOKEN }}

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -62,7 +62,7 @@ jobs:
           # oracle + register the new PSDK BEHAVIORAL rules (PAGINATION-CORPUS etc.) that
           # main's porting-sdk rejects. REVERT this ref to main when porting-sdk
           # wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/multi-os.yml
+++ b/.github/workflows/multi-os.yml
@@ -90,7 +90,7 @@ jobs:
           # oracle + register the new PSDK BEHAVIORAL rules (PAGINATION-CORPUS etc.) that
           # main's porting-sdk rejects. REVERT this ref to main when porting-sdk
           # wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 
@@ -100,7 +100,7 @@ jobs:
           repository: signalwire/signalwire-python
           path: signalwire-python
           # PINNED to wave/1-aplus (the PY-7 reference). REVERT to main on merge.
-          ref: wave/1-aplus
+          ref: main
 
       - name: Setup Perl
         uses: shogo82148/actions-setup-perl@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,7 +99,7 @@ jobs:
           # oracle + register the new PSDK BEHAVIORAL rules (PAGINATION-CORPUS etc.) that
           # main's porting-sdk rejects. REVERT this ref to main when porting-sdk
           # wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 
@@ -113,7 +113,7 @@ jobs:
           repository: signalwire/signalwire-python
           path: signalwire-python
           # PINNED to wave/1-aplus (the PY-7 reference). REVERT to main on merge.
-          ref: wave/1-aplus
+          ref: main
 
       - name: Setup Perl
         uses: shogo82148/actions-setup-perl@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
           # oracle + register the new PSDK BEHAVIORAL rules (PAGINATION-CORPUS etc.) that
           # main's porting-sdk rejects. REVERT this ref to main when porting-sdk
           # wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           fetch-depth: 1
           token: ${{ secrets.PORTING_SDK_TOKEN }}

--- a/.github/workflows/surface-audit.yml
+++ b/.github/workflows/surface-audit.yml
@@ -45,7 +45,7 @@ jobs:
           # NEW oracle (python_surface.json / python_signatures.json) carrying PY-7
           # request_options, which lives on porting-sdk wave/1-aplus, not main. REVERT
           # this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           fetch-depth: 1
           token: ${{ secrets.PORTING_SDK_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           # oracle + the PAGINATION-CORPUS/RELAY-LIVENESS differs that live on porting-sdk
           # wave/1-aplus, not yet on main (PY-7 request_options is a wave/1-aplus oracle
           # addition). REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 
@@ -62,7 +62,7 @@ jobs:
           # PINNED to wave/1-aplus: the reference SDK carrying PY-7 request_options +
           # the new paginator/relay behavior this PR mirrors. REVERT to main when the
           # python wave/1-aplus work merges.
-          ref: wave/1-aplus
+          ref: main
 
       - name: Setup Perl
         uses: shogo82148/actions-setup-perl@v1


### PR DESCRIPTION
Wave 1 merged; wave/1-aplus deleted. Revert workflow pins to `ref: main`. 0 residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)