### PR TITLE
fix(ci): resolve prove from the setup-perl install and use the platform PERL5LIB separator

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -110,8 +110,15 @@ jobs:
             --surface port_surface.json \
             --ignore DOC_AUDIT_IGNORE.md
 
+      # Go through the canonical entry point (CLAUDE.md: nothing invokes `prove`
+      # directly). It resolves the harness through the chosen interpreter and
+      # builds PERL5LIB with the platform separator, so this step cannot pick up
+      # a `prove` from a different Perl install the way the Windows TEST step did
+      # (nightly Multi-OS run 30238072907). This job is ubuntu-only today, so the
+      # old `PERL5LIB="lib:t/lib"` was not itself broken — but it hardcoded the
+      # POSIX ':' and bypassed the bootstrap, which is the latent form of the bug.
       - name: Run Perl test suite (doc audit smoke tests)
-        run: PERL5LIB="lib:t/lib" prove -r t/54_doc_audit.t
+        run: bash scripts/run-tests.sh t/54_doc_audit.t
 
       - name: Upload surface snapshot on failure
         if: failure()

--- a/.github/workflows/multi-os.yml
+++ b/.github/workflows/multi-os.yml
@@ -134,9 +134,18 @@ jobs:
       #     and socket/mock-spawn behavior vary by OS.
       #   * PACKAGE-SMOKE — `perl Makefile.PL && make manifest && make dist` then
       #     install+import of the tarball; MANIFEST/dist behavior varies by OS.
+      # timeout-minutes is LOAD-BEARING, not belt-and-braces. A wedged job with no
+      # timeout must be cancelled by hand, and GitHub's API returns BlobNotFound
+      # (404) for an in_progress job's log — so the hang produces NO retrievable
+      # evidence while it burns runner hours. Four Windows jobs were cancelled
+      # manually this way (30240112956 at 4h57m, 30261956136 at 44m on one test).
+      # With a timeout, a future wedge times out on its own AND leaves a readable
+      # log naming the test it stopped at. Generous but finite: macOS runs this
+      # suite in ~160s, and the unwedged Windows sequence did t/01→t/25 in 63s.
       - name: TEST suite (prove -Ilib -It/lib -r t/)
         working-directory: signalwire-perl
         shell: bash
+        timeout-minutes: 25
         env:
           PORTING_SDK: ${{ github.workspace }}/porting-sdk
         run: bash scripts/run-tests.sh

--- a/.github/workflows/surface-audit.yml
+++ b/.github/workflows/surface-audit.yml
@@ -95,8 +95,9 @@ jobs:
             --omissions PORT_OMISSIONS.md \
             --additions PORT_ADDITIONS.md
 
+      # Canonical entry point — see the matching note in doc-audit.yml.
       - name: Run Perl test suite (surface audit smoke tests)
-        run: PERL5LIB="lib:t/lib" prove -r t/53_surface_audit.t
+        run: bash scripts/run-tests.sh t/53_surface_audit.t
 
       - name: Upload surface snapshot on failure
         if: failure()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,28 @@ The Perl SDK uses Moo for object orientation, Plack/PSGI for HTTP serving, and J
 Three scripts under `scripts/` are the SINGLE, canonical entry point for testing,
 linting, and formatting. Do NOT call `prove` / `perlcritic` / `perltidy`
 directly. Each script **self-bootstraps its tool environment** (via
-`scripts/_env.sh`: prepends the `~/perl5` local::lib to `PERL5LIB` so perltidy can
-locate `Perl::Tidy` and the test suite finds Plack/Protocol::WebSocket; prepends
-`~/perl5/bin` to `PATH`; pins `PERLTIDY`) and therefore **runs from ANY directory
-with ANY shell setup** -- no `PERL5LIB=...` prefix needed.
+`scripts/_env.sh`: resolves `$SW_PERL` -- the one interpreter every gate uses --
+prepends the `~/perl5` local::lib to `PERL5LIB` **using the platform path
+separator** so perltidy can locate `Perl::Tidy` and the test suite finds
+Plack/Protocol::WebSocket; prepends `~/perl5/bin` to `PATH`; pins `PERLTIDY`) and
+therefore **runs from ANY directory with ANY shell setup, on POSIX AND Windows**
+-- no `PERL5LIB=...` prefix needed.
+
+Two Windows-specific traps `_env.sh` and `run-tests.sh` now handle (both were
+live defects in nightly Multi-OS run 30238072907; see the notes in `_env.sh`):
+
+* **`PERL5LIB` is `;`-separated on Win32, `:` on POSIX.** Its entries carry drive
+  letters, so `:` is a path *character* there. `_env.sh` joins with
+  `$Config{path_sep}` (exported as `$SW_PATH_SEP`); anything that SPLITS the value
+  must do the same. `scripts/_perltidy_gen.py` uses `os.pathsep` for this reason.
+* **A bare `prove` may belong to a DIFFERENT Perl install than `$SW_PERL`.** On a
+  Windows runner PATH can offer Strawberry's or MSYS's `prove`, which then resolves
+  `App::Prove` out of yet another `@INC`. `run-tests.sh` therefore runs the harness
+  module *through* `$SW_PERL` (`_sw_perl_tool App::Prove ...`), making the
+  interpreter and its `@INC` the same install by construction.
+
+`t/111_env_platform_paths.t` is the regression guard for both (it simulates the
+Windows shapes, since neither defect is observable on POSIX).
 
 ```bash
 # Run all tests (prove -Ilib -It/lib -r t/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,9 @@ Plack/Protocol::WebSocket; prepends `~/perl5/bin` to `PATH`; pins `PERLTIDY`) an
 therefore **runs from ANY directory with ANY shell setup, on POSIX AND Windows**
 -- no `PERL5LIB=...` prefix needed.
 
-Two Windows-specific traps `_env.sh` and `run-tests.sh` now handle (both were
-live defects in nightly Multi-OS run 30238072907; see the notes in `_env.sh`):
+Three Windows-specific traps `_env.sh` and `run-tests.sh` now handle (all were
+live defects on the nightly Multi-OS lane; see the notes in `_env.sh` and
+`run-tests.sh`):
 
 * **`PERL5LIB` is `;`-separated on Win32, `:` on POSIX.** Its entries carry drive
   letters, so `:` is a path *character* there. `_env.sh` joins with
@@ -35,8 +36,19 @@ live defects in nightly Multi-OS run 30238072907; see the notes in `_env.sh`):
   module *through* `$SW_PERL` (`_sw_perl_tool App::Prove ...`), making the
   interpreter and its `@INC` the same install by construction.
 
-`t/111_env_platform_paths.t` is the regression guard for both (it simulates the
-Windows shapes, since neither defect is observable on POSIX).
+* **`prove -j>1` WEDGES on Win32 — the harness cannot multiplex there.**
+  `TAP/Parser/Multiplexer.pm:12` sets `SELECT_OK => !( IS_VMS || IS_WIN32 )`, so on
+  Win32 no parser joins the `IO::Select` set; all land on the `avid` list and
+  `_iter` blocks draining `avid->[0]` while the unread siblings fill their pipe
+  buffers. Observed as an indefinite hang with *zero* captured output (runs
+  30240112956, 30258476574) where macOS finished in 2m37s. `run-tests.sh`
+  therefore clamps to `-j1` on Win32 only. **This is not "serialise the tests to
+  make them pass"** — the tests are concurrency-safe (own free port via
+  PortPicker) and stay parallel on POSIX, where the ~3.5x was measured. It is a
+  harness platform limitation. `PROVE_JOBS` still overrides.
+
+`t/111_env_platform_paths.t` is the regression guard for all three (it simulates
+the Windows shapes, since none of these defects is observable on POSIX).
 
 ```bash
 # Run all tests (prove -Ilib -It/lib -r t/)

--- a/scripts/_env.sh
+++ b/scripts/_env.sh
@@ -52,10 +52,23 @@ export REPO_ROOT
 # interpreter (not the script) and running the harness THROUGH it makes the
 # interpreter and its @INC the same install by construction.
 #
-# SW_PERL honours an explicit override, else takes the first `perl` on PATH.
+# Picking the interpreter is itself PATH-order-sensitive, and "first perl on PATH"
+# is NOT good enough: under `shell: bash` (Git-for-Windows) the MSYS /usr/bin is
+# injected AHEAD of what actions-setup-perl prepended to the Windows PATH, so
+# `command -v perl` returns MSYS's /usr/bin/perl — install #3, the very one whose
+# @INC lacks TAP::Harness::Env. (Measured: run 30239532589 failed with
+# "ERROR: /usr/bin/perl cannot load App::Prove" after the first fix landed.)
+#
+# So SELECT ON EVIDENCE, not on PATH position: among the candidate interpreters,
+# take the first that can actually load App::Prove. An explicit SW_PERL override
+# always wins and is never second-guessed.
+#
 # Callers must invoke "$SW_PERL", never a bare `prove`/`perltidy`/`perlcritic`
 # whose own shebang picks a DIFFERENT perl than the one we resolved.
-SW_PERL="${SW_PERL:-$(command -v perl 2>/dev/null || echo perl)}"
+if [ -z "${SW_PERL:-}" ]; then
+    SW_PERL="$(bash "$_ENV_SH_DIR/_pick_perl.sh" 2>/dev/null)"
+    [ -n "$SW_PERL" ] || SW_PERL=perl
+fi
 export SW_PERL
 
 # PERL5LIB's separator is PLATFORM-DEPENDENT: ':' on POSIX, ';' on Win32 (where

--- a/scripts/_env.sh
+++ b/scripts/_env.sh
@@ -36,14 +36,48 @@ _ENV_SH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$_ENV_SH_DIR")"
 export REPO_ROOT
 
+# ---------------------------------------------------------------------------
+# SW_PERL — the ONE interpreter every gate must use, and PERL5LIB's separator
+# ---------------------------------------------------------------------------
+# On a Windows runner, three Perls are typically in play at once and mixing them
+# is fatal (nightly Multi-OS run 30238072907):
+#   1. the one `actions-setup-perl` installed and set PERL5LIB for
+#      (C:\hostedtoolcache\windows\perl\5.38.5-thr\x64) — the one we WANT;
+#   2. Strawberry's (C:\Strawberry\perl\bin) — ships with the runner image;
+#   3. an MSYS/Git-for-Windows core_perl (/usr/share/perl5/core_perl) — comes
+#      with the `shell: bash` (C:\Program Files\Git\bin\bash.EXE) the step runs in.
+# The step ran Strawberry's `prove`, which then resolved App::Prove out of the
+# MSYS core_perl and died: "Can't locate TAP/Harness/Env.pm in @INC". A `prove`
+# from one install loading modules from another CANNOT work. Resolving the
+# interpreter (not the script) and running the harness THROUGH it makes the
+# interpreter and its @INC the same install by construction.
+#
+# SW_PERL honours an explicit override, else takes the first `perl` on PATH.
+# Callers must invoke "$SW_PERL", never a bare `prove`/`perltidy`/`perlcritic`
+# whose own shebang picks a DIFFERENT perl than the one we resolved.
+SW_PERL="${SW_PERL:-$(command -v perl 2>/dev/null || echo perl)}"
+export SW_PERL
+
+# PERL5LIB's separator is PLATFORM-DEPENDENT: ':' on POSIX, ';' on Win32 (where
+# paths carry drive letters, so ':' cannot be a separator). Hardcoding ':' here
+# corrupted the Windows value — perl split `D:\a\...\perl5;D:\a\...` on ':' and
+# @INC came out as the entries `D`, `\a\...\perl5;D`, `\a\...`: every ':' eaten,
+# still ';'-joined, not one usable directory among them. Ask the interpreter we
+# actually resolved (never assume), and fall back to ':' only if that fails.
+SW_PATH_SEP="$("$SW_PERL" -MConfig -e 'print $Config{path_sep}' 2>/dev/null)"
+[ -n "$SW_PATH_SEP" ] || SW_PATH_SEP=':'
+export SW_PATH_SEP
+
 # The local::lib root — override with PERL_LOCAL_LIB_ROOT, else ~/perl5.
 PERL_LL_ROOT="${PERL_LOCAL_LIB_ROOT:-$HOME/perl5}"
 
 # --- PERL5LIB: so the perltidy/perlcritic wrappers (and the test suite, and the
 #     generators' perltidy backstop) can locate Perl::Tidy / Perl::Critic / the
-#     runtime deps. Prepend, preserving any existing PERL5LIB. -----------------
+#     runtime deps. Prepend with the PLATFORM separator, preserving any existing
+#     PERL5LIB (on Windows that is the ';'-joined value setup-perl exported —
+#     splitting or re-joining it on ':' destroys it). ---------------------------
 if [ -d "$PERL_LL_ROOT/lib/perl5" ]; then
-    export PERL5LIB="$PERL_LL_ROOT/lib/perl5${PERL5LIB:+:$PERL5LIB}"
+    export PERL5LIB="$PERL_LL_ROOT/lib/perl5${PERL5LIB:+$SW_PATH_SEP$PERL5LIB}"
 fi
 
 # --- PATH: so `perltidy` / `perlcritic` resolve by bare name. ----------------
@@ -84,11 +118,42 @@ _sw_ensure_perl_tools() {
         echo "         cpanm --local-lib=$PERL_LL_ROOT --with-develop --installdeps $REPO_ROOT" >&2
         return 1
     }
-    # Re-expose the now-populated local::lib.
-    [ -d "$PERL_LL_ROOT/lib/perl5" ] && export PERL5LIB="$PERL_LL_ROOT/lib/perl5${PERL5LIB:+:$PERL5LIB}"
+    # Re-expose the now-populated local::lib (platform separator, as above).
+    [ -d "$PERL_LL_ROOT/lib/perl5" ] && export PERL5LIB="$PERL_LL_ROOT/lib/perl5${PERL5LIB:+$SW_PATH_SEP$PERL5LIB}"
     [ -d "$PERL_LL_ROOT/bin" ] && export PATH="$PERL_LL_ROOT/bin:$PATH"
     [ -x "$PERL_LL_ROOT/bin/perltidy" ] && export PERLTIDY="$PERL_LL_ROOT/bin/perltidy"
     return 0
+}
+
+# ---------------------------------------------------------------------------
+# Running a Perl-shipped CLI tool through the RESOLVED interpreter
+# ---------------------------------------------------------------------------
+# `prove`, `perltidy` and `perlcritic` are all Perl SCRIPTS with a shebang. Two
+# ways that betrays us:
+#   * PATH order picks a script belonging to a DIFFERENT perl install than
+#     $SW_PERL (the Windows failure above: Strawberry's prove, MSYS's App::Prove);
+#   * even with an absolute path, the shebang (`#!/usr/bin/perl`) re-launches
+#     SYSTEM perl, whose @INC lacks the local::lib — which is why a full path to
+#     ~/perl5/bin/perltidy still died with "Can't locate Perl/Tidy.pm" (see the
+#     BUG note at the top of this file).
+# Both vanish if we run the tool's MODULE through $SW_PERL: one interpreter, its
+# own @INC, no shebang and no PATH lookup in the loop.
+#
+#   _sw_perl_tool <Module::Name> <entry-perl-code> [args...]
+#
+# `App::Prove`'s documented programmatic entry point is
+# `App::Prove->new->process_args(@ARGV)->run`; perltidy/perlcritic keep using
+# their wrappers (they are found via PATH but now under the corrected PERL5LIB).
+_sw_perl_tool() {
+    local module="$1" entry="$2"
+    shift 2
+    "$SW_PERL" "-M$module" -e "$entry" -- "$@"
+}
+
+# True when $SW_PERL can load the named module — use to fail LOUD with a real
+# diagnostic instead of letting a tool die with a confusing @INC dump.
+_sw_perl_has_module() {
+    "$SW_PERL" "-M$1" -e1 >/dev/null 2>&1
 }
 
 # The set of Perl source files the FMT + LINT gates police: every module under

--- a/scripts/_pick_perl.sh
+++ b/scripts/_pick_perl.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# scripts/_pick_perl.sh — choose the ONE Perl interpreter the gates should use.
+#
+# Prints an absolute path (or a bare `perl`) on stdout. Used by scripts/_env.sh to
+# set $SW_PERL; not meant to be called directly, but harmless if it is.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS EXISTS — "first perl on PATH" is wrong on Windows
+# ---------------------------------------------------------------------------
+# A Windows runner has several Perls at once (nightly Multi-OS run 30238072907):
+#   1. what actions-setup-perl installed and exported PERL5LIB for
+#      (C:\hostedtoolcache\windows\perl\<ver>\x64) — the one we WANT;
+#   2. Strawberry's (C:\Strawberry\perl\bin) — ships with the runner image;
+#   3. MSYS/Git-for-Windows perl (/usr/bin/perl, /usr/share/perl5/core_perl).
+#
+# The steps run under `shell: bash` = C:\Program Files\Git\bin\bash.EXE, which
+# injects the MSYS /usr/bin AHEAD of whatever actions-setup-perl prepended to the
+# Windows PATH. So `command -v perl` yields #3 — precisely the install whose @INC
+# has no TAP::Harness::Env. Measured: run 30239532589, after the harness was
+# correctly routed through $SW_PERL, still failed with
+#   ERROR: /usr/bin/perl cannot load App::Prove
+# because SW_PERL had been resolved with `command -v perl`.
+#
+# THE RULE: select on EVIDENCE, not on PATH position — the right interpreter is
+# one that can actually load the harness. We probe candidates for App::Prove and
+# take the first that succeeds. That is self-validating: it cannot pick an
+# interpreter that would then fail the way #2/#3 did.
+#
+# Ordering rationale: the toolcache install (#1) is tried FIRST because it is the
+# one the workflow provisioned and set PERL5LIB for — using any other install
+# would silently ignore the deps `cpanm --installdeps` just installed into it.
+# Bare `perl` is tried before Strawberry so a normal POSIX box (where PATH perl is
+# simply correct) resolves immediately and this whole dance is a no-op.
+
+set -uo pipefail
+
+# Does this interpreter exist AND can it load the test harness?
+_usable() {
+    [ -n "${1:-}" ] || return 1
+    command -v "$1" >/dev/null 2>&1 || return 1
+    "$1" -MApp::Prove -e1 >/dev/null 2>&1
+}
+
+_candidates() {
+    # 1. Whatever actions-setup-perl put in the hosted toolcache. RUNNER_TOOL_CACHE
+    #    is set by GitHub Actions; glob every installed version/arch under it.
+    #    Newest-first so a multi-version cache prefers the latest.
+    if [ -n "${RUNNER_TOOL_CACHE:-}" ] && [ -d "$RUNNER_TOOL_CACHE/perl" ]; then
+        # Layout is <cache>/perl/<version>/<arch>/bin/perl[.exe] — depth 4 below
+        # <cache>/perl. Newest-first so a multi-version cache prefers the latest.
+        find "$RUNNER_TOOL_CACHE/perl" -mindepth 4 -maxdepth 4 -type f \
+            \( -name 'perl.exe' -o -name 'perl' \) 2>/dev/null | sort -Vr
+    fi
+
+    # 2. The ordinary case: whatever `perl` PATH offers. On POSIX this is the
+    #    right answer and the loop below stops here.
+    command -v perl 2>/dev/null
+
+    # 3. Strawberry, as a last resort on Windows images.
+    for p in /c/Strawberry/perl/bin/perl.exe /c/Strawberry/perl/bin/perl \
+             "C:/Strawberry/perl/bin/perl.exe"; do
+        [ -x "$p" ] && echo "$p"
+    done
+}
+
+# First candidate that can load App::Prove wins.
+while IFS= read -r cand; do
+    [ -n "$cand" ] || continue
+    if _usable "$cand"; then
+        echo "$cand"
+        exit 0
+    fi
+done <<EOF
+$(_candidates)
+EOF
+
+# Nothing could load App::Prove. Emit the best-available interpreter anyway so the
+# CALLER fails loud with its own actionable message (run-tests.sh names the
+# interpreter and how to fix it) rather than this helper dying cryptically here.
+fallback="$(command -v perl 2>/dev/null || true)"
+echo "${fallback:-perl}"

--- a/scripts/lint_bounded_reap.pl
+++ b/scripts/lint_bounded_reap.pl
@@ -1,0 +1,123 @@
+#!/usr/bin/env perl
+# scripts/lint_bounded_reap.pl — fail if any test reaps a child with an UNBOUNDED
+# waitpid($pid, 0).
+#
+# WHY THIS GATE EXISTS
+# --------------------
+# An unbounded waitpid($pid, 0) hangs the ENTIRE suite forever whenever the child
+# does not die. That is not hypothetical:
+#   * t/relay/outbound_call_mock.t documents it as "root cause of the historic
+#     outbound_call_mock hang — the parent sat in wait4 on a stuck watcher";
+#   * t/26_skill_spider.t wedged the Windows nightly for 44 MINUTES (run
+#     30261956136) — a bare-fork PSEUDO-process on Win32 sat in a blocking
+#     accept() and ignored SIGTERM, so the parent waited forever.
+# On Win32 this is the NORMAL case, not the edge case: `fork` is emulated with
+# interpreter threads and a pseudo-process may ignore even SIGKILL.
+#
+# A hang is strictly worse than a failure: no assertion output, no log (GitHub's
+# API 404s BlobNotFound while a job is in_progress), and it burns runner hours
+# until someone cancels it by hand. So the rule is: ALWAYS bound the wait.
+#
+# THE APPROVED PATTERN (see t/relay/outbound_call_mock.t):
+#     kill 'TERM', $pid;
+#     my $deadline = time + 30;
+#     my $reaped = 0;
+#     while (time < $deadline) {
+#         my $w = waitpid($pid, POSIX::WNOHANG());
+#         if ($w == $pid || $w == -1) { $reaped = 1; last }
+#         Time::HiRes::sleep(0.05);
+#     }
+#     unless ($reaped) { kill 'KILL', $pid; waitpid($pid, 0); diag(...) }
+#
+# WHAT IS ALLOWED: a `waitpid($pid, 0)` that reaps the CORPSE right after a
+# SIGKILL is fine — the process is already dead, so the wait cannot block. This
+# linter therefore only flags a blocking waitpid that is NOT preceded by a nearby
+# `kill 'KILL'`. Comments and POD are ignored, so prose *about* the hazard is fine.
+
+use strict;
+use warnings;
+use File::Find ();
+use File::Spec;
+use File::Basename qw(dirname);
+
+my $repo = File::Spec->rel2abs( File::Spec->catdir( dirname(__FILE__), File::Spec->updir ) );
+my $tdir = File::Spec->catdir( $repo, 't' );
+
+# How far back to look for the SIGKILL that makes a blocking reap safe.
+my $KILL_WINDOW = 6;
+
+my @offenders;
+
+my @files;
+File::Find::find(
+    {   no_chdir => 1,
+        wanted   => sub { push @files, $File::Find::name if /\.(?:t|pm)\z/ },
+    },
+    $tdir,
+);
+
+for my $file ( sort @files ) {
+    open my $fh, '<', $file or die "open $file: $!";
+    my @lines = <$fh>;
+    close $fh;
+
+    my $in_pod = 0;
+    for my $i ( 0 .. $#lines ) {
+        my $line = $lines[$i];
+
+        # Skip POD blocks entirely.
+        if ( $line =~ /^=cut\b/ )      { $in_pod = 0; next }
+        if ( $line =~ /^=[a-zA-Z]\w*/ ) { $in_pod = 1; next }
+        next if $in_pod;
+
+        # Strip a trailing comment, then skip whole-line comments. This is what
+        # lets the explanatory prose above (and in the tests) mention the bad
+        # pattern without tripping the gate.
+        my $code = $line;
+        $code =~ s/#.*\z//s;
+        next unless $code =~ /\S/;
+
+        # An unbounded blocking reap: waitpid($x, 0)
+        next unless $code =~ /waitpid \s* \( \s* \$\w+ \s* , \s* 0 \s* \)/x;
+
+        # Allowed if a SIGKILL was sent just above (reaping a known-dead corpse).
+        my $lo = $i - $KILL_WINDOW;
+        $lo = 0 if $lo < 0;
+        my $preceded_by_kill = 0;
+        for my $j ( $lo .. $i - 1 ) {
+            my $prev = $lines[$j];
+            $prev =~ s/#.*\z//s;
+            if ( $prev =~ /kill \s* \(? \s* ['"]KILL['"]/x ) { $preceded_by_kill = 1; last }
+        }
+        next if $preceded_by_kill;
+
+        ( my $shown = $line ) =~ s/^\s+|\s+\z//g;
+        my $rel = File::Spec->abs2rel( $file, $repo );
+        push @offenders, "$rel:" . ( $i + 1 ) . ": $shown";
+    }
+}
+
+if (@offenders) {
+    print STDERR "BOUNDED-REAP: unbounded waitpid(\$pid, 0) found — a stuck child hangs the WHOLE suite.\n\n";
+    print STDERR "  $_\n" for @offenders;
+    print STDERR <<'HINT';
+
+Bound the wait instead (pattern: t/relay/outbound_call_mock.t):
+    kill 'TERM', $pid;
+    my $deadline = time + 30;
+    my $reaped = 0;
+    while (time < $deadline) {
+        my $w = waitpid($pid, POSIX::WNOHANG());
+        if ($w == $pid || $w == -1) { $reaped = 1; last }
+        Time::HiRes::sleep(0.05);
+    }
+    unless ($reaped) { kill 'KILL', $pid; waitpid($pid, 0); diag(...) }
+
+A waitpid($pid, 0) immediately after `kill 'KILL', $pid` is allowed (the child is
+already dead, so it cannot block).
+HINT
+    exit 1;
+}
+
+print "BOUNDED-REAP: no unbounded waitpid(\$pid, 0) in t/ (" . scalar(@files) . " files scanned)\n";
+exit 0;

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -268,6 +268,16 @@ sched_gate PACKAGE-NIGHTLY tier=nightly defer=1 res=dayone desc="package suite, 
 sched_gate NO-CHEAT desc="audit_no_cheat_tests" \
     -- python3 "$PORTING_SDK_DIR/scripts/audit_no_cheat_tests.py" --root "$PORT_ROOT"
 
+# BOUNDED-REAP: no test may reap a child with an unbounded waitpid($pid, 0). Such a
+# reap hangs the WHOLE suite when the child doesn't die — on Win32 that is the
+# normal case (emulated fork ⇒ a pseudo-process can ignore even SIGKILL). This is a
+# HANG, which is strictly worse than a failure: no assertions, and GitHub's API
+# 404s an in_progress job's log, so it burns runner hours with no evidence until
+# someone cancels by hand. t/26_skill_spider.t did exactly that for 44 min (run
+# 30261956136). Static, sub-second, catches the next one at commit time.
+sched_gate BOUNDED-REAP desc="no unbounded waitpid(\$pid, 0) in t/ (a stuck child hangs the suite)" \
+    -- perl "$PORT_ROOT/scripts/lint_bounded_reap.pl"
+
 # COORDINATED-PASS: if porting-sdk was checked out at a NON-main ref (a coordinated
 # pass via the PORTING_SDK_REF repo variable), the PR must declare it (a
 # `Coordinated-With: porting-sdk@<branch>` line in the PR body, or the

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 # scripts/run-tests.sh — the CANONICAL way to run signalwire-perl's tests.
 #
-# Tool: prove -Ilib -It/lib -r t/. This is the SINGLE entry point for testing —
-# run-ci, agents, humans, and docs all go through it; nothing invokes prove
-# directly anymore. Self-bootstraps its environment (scripts/_env.sh: the
-# PERL5LIB fix that puts the local::lib runtime deps — Plack, Protocol::WebSocket,
-# etc. — on @INC) so the suite works from ANY directory with ANY shell setup.
+# Tool: App::Prove (-Ilib -It/lib -r t/), driven through $SW_PERL. This is the
+# SINGLE entry point for testing — run-ci, agents, humans, and docs all go
+# through it; nothing invokes prove directly anymore. Self-bootstraps its
+# environment (scripts/_env.sh: $SW_PERL, the platform-correct PERL5LIB, and the
+# local::lib runtime deps — Plack, Protocol::WebSocket, etc. — on @INC) so the
+# suite works from ANY directory with ANY shell setup, on POSIX AND Windows.
+#
+# Why NOT a bare `prove` (nightly Multi-OS run 30238072907): on a Windows runner
+# PATH offered Strawberry's `prove`, whose @INC then resolved App::Prove from an
+# MSYS core_perl that has no TAP::Harness::Env — a `prove` from one Perl install
+# loading modules from another. Running the harness MODULE through $SW_PERL makes
+# the interpreter and its @INC the same install by construction, so there is no
+# PATH-order question left to get wrong. See scripts/_env.sh for the full note.
 #
 #   run-tests.sh            Run the FULL suite (prove -Ilib -It/lib -r t/).
 #   run-tests.sh <filter>   Pass a test file / directory / glob straight through
@@ -26,8 +34,12 @@ _sw_ensure_perl_tools || exit 1
 
 cd "$REPO_ROOT"
 
-if ! command -v prove >/dev/null 2>&1; then
-    echo "ERROR: prove not found on PATH (part of core perl / Test::Harness)." >&2
+# Fail LOUD, with the interpreter named, if the chosen perl can't load the
+# harness — far more actionable than prove's raw @INC dump.
+if ! _sw_perl_has_module App::Prove; then
+    echo "ERROR: $SW_PERL cannot load App::Prove (part of core perl / Test::Harness)." >&2
+    echo "       Install it for THAT interpreter, or point SW_PERL at one that has it:" >&2
+    echo "         cpanm --notest Test::Harness" >&2
     exit 1
 fi
 
@@ -40,8 +52,17 @@ jobs="${PROVE_JOBS:-$( (command -v nproc >/dev/null && nproc) || sysctl -n hw.nc
 
 # Optional filter passthrough: default to the whole tree, else run exactly what
 # the caller named.
+# The body of the real `prove` script, inlined verbatim: process_args() is called
+# in VOID context (it returns nothing — it is NOT chainable, so
+# `->process_args(@ARGV)->run` dies with "Can't call method run on an undefined
+# value"), and run() returns a BOOLEAN that must be mapped to an exit code, or a
+# failing suite would exit 0 and the gate would pass on red.
+# `_sw_perl_tool` is a shell FUNCTION, so it cannot be `exec`'d — run it and let
+# its exit status propagate (set -e is in force).
+PROVE_ENTRY='my $a = App::Prove->new; $a->process_args(@ARGV); exit($a->run ? 0 : 1);'
+
 if [ "$#" -eq 0 ]; then
-    exec prove -j"$jobs" -Ilib -It/lib -r t/
+    _sw_perl_tool App::Prove "$PROVE_ENTRY" -j"$jobs" -Ilib -It/lib -r t/
 else
-    exec prove -j"$jobs" -Ilib -It/lib -r "$@"
+    _sw_perl_tool App::Prove "$PROVE_ENTRY" -j"$jobs" -Ilib -It/lib -r "$@"
 fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -50,6 +50,44 @@ fi
 # cores (min 1); override with PROVE_JOBS.
 jobs="${PROVE_JOBS:-$( (command -v nproc >/dev/null && nproc) || sysctl -n hw.ncpu 2>/dev/null || echo 4 )}"
 
+# --- Win32: clamp to -j1, because the HARNESS cannot multiplex there. ---------
+#
+# THIS IS NOT "serialise the tests to make them pass." The tests are genuinely
+# concurrency-safe (each picks its own free port via PortPicker) and STAY PARALLEL
+# on POSIX, where the ~3.5x above was measured. This is a platform limitation of
+# Test::Harness itself, in its own source:
+#
+#   TAP/Parser/Multiplexer.pm:12
+#     use constant SELECT_OK => !( IS_VMS || IS_WIN32 );
+#
+# With SELECT_OK false, NO parser is ever added to the IO::Select set (line 84);
+# every one goes on the `avid` "can't select" list instead. `_iter` then drains
+# `avid->[0]` to completion before looking at any other parser — it BLOCKS on
+# $parser->next for the first job. So `-j4` on Windows does not fan out: it spawns
+# 4 children, reads exactly one, and the unread siblings fill their pipe buffers
+# with nobody draining them and wedge. (TAP/Parser/Iterator/Process.pm:95 shows the
+# same fork dependency: `return unless $Config{d_fork} || $IS_WIN32` — Win32 has no
+# real fork, only interpreter-thread emulation.)
+#
+# Observed twice on the nightly Multi-OS lane: run 30240112956 (4h57m, cancelled)
+# and 30258476574 (still wedged at 40min), both with NOT ONE line of captured TEST
+# output — prove emitted nothing at all before hanging, which is exactly what
+# blocking on an un-drained child looks like. macOS finished the same suite in
+# 2m37s on that run.
+#
+# So on Win32 -j>1 is not slow, it is BROKEN. Clamp to 1: slower than POSIX, but
+# finite. An explicit PROVE_JOBS still wins (override deliberately, e.g. to
+# re-test the harness behaviour) — the clamp only overrides the core-count default.
+case "${OSTYPE:-}" in
+    msys* | cygwin* | win32*) _sw_is_win32=1 ;;
+    *) _sw_is_win32="$("$SW_PERL" -e 'print(($^O =~ /^(MS)?Win32$/) ? 1 : 0)' 2>/dev/null || echo 0)" ;;
+esac
+if [ "${_sw_is_win32:-0}" = "1" ] && [ -z "${PROVE_JOBS:-}" ] && [ "$jobs" != "1" ]; then
+    echo "==> run-tests.sh: Win32 detected — clamping prove to -j1 (Test::Harness" >&2
+    echo "    cannot select() on Win32, so -j>1 wedges; see the note above)." >&2
+    jobs=1
+fi
+
 # Optional filter passthrough: default to the whole tree, else run exactly what
 # the caller named.
 # The body of the real `prove` script, inlined verbatim: process_args() is called

--- a/t/111_env_platform_paths.t
+++ b/t/111_env_platform_paths.t
@@ -1,0 +1,154 @@
+#!/usr/bin/env perl
+#
+# t/111_env_platform_paths.t — regression guard for the Windows toolchain-
+# resolution defect found in nightly Multi-OS run 30238072907.
+#
+# TWO defects, both invisible on POSIX, so this test SIMULATES the Windows shapes
+# rather than relying on the platform:
+#
+#   1. scripts/_env.sh joined PERL5LIB with a hardcoded ':'. On Win32 PERL5LIB is
+#      ';'-separated and entries carry drive letters, so ':' is a path CHARACTER,
+#      not a separator. The corrupted value made perl split `D:\a\...` into `D`
+#      + `\a\...`, and @INC came out with no usable directory:
+#        @INC entries checked: D \a\signalwire-perl\...\local\lib\perl5;D \a\...
+#      -> assert the join uses $Config{path_sep}, and that a Windows-shaped
+#         incoming value round-trips through a Win32-style split intact.
+#
+#   2. scripts/run-tests.sh invoked a bare `prove` from PATH. On the Windows
+#      runner that was Strawberry's prove, which then resolved App::Prove from an
+#      MSYS core_perl lacking TAP::Harness::Env. The harness must instead be run
+#      THROUGH the resolved interpreter ($SW_PERL) so interpreter and @INC are the
+#      same install by construction.
+#      -> assert no gate script calls a bare `prove`, and that the App::Prove
+#         entry point we use is correct (process_args is void; run returns bool).
+
+use strict;
+use warnings;
+use Test::More;
+use Config;
+use File::Basename qw(dirname);
+use File::Spec;
+
+my $repo = File::Spec->rel2abs( File::Spec->catdir( dirname(__FILE__), File::Spec->updir ) );
+
+my $env_sh    = File::Spec->catfile( $repo, 'scripts', '_env.sh' );
+my $run_tests = File::Spec->catfile( $repo, 'scripts', 'run-tests.sh' );
+
+# ---------------------------------------------------------------------------
+# Defect 1 — PERL5LIB must be joined with the PLATFORM separator.
+# ---------------------------------------------------------------------------
+
+sub slurp {
+    my ($path) = @_;
+    open my $fh, '<', $path or die "cannot read $path: $!";
+    local $/;
+    my $c = <$fh>;
+    close $fh;
+    return $c;
+}
+
+my $env_src = slurp($env_sh);
+
+like(
+    $env_src,
+    qr/\$Config\{path_sep\}/,
+    '_env.sh derives the path separator from $Config{path_sep}, not a literal',
+);
+
+# The specific regression: no PERL5LIB assignment may hardcode ':' as the join.
+my @bad_joins = grep { /PERL5LIB=.*\$\{PERL5LIB:\+:/ } split /\n/, $env_src;
+is_deeply( \@bad_joins, [],
+    'no PERL5LIB assignment joins with a hardcoded ":" (Win32 uses ";")' );
+
+# Every PERL5LIB prepend must interpolate the computed separator instead.
+my @joins = grep { /export PERL5LIB=/ } split /\n/, $env_src;
+ok( scalar(@joins) >= 2, 'found the PERL5LIB prepend sites' );
+for my $line (@joins) {
+    next unless $line =~ /\$\{PERL5LIB:\+/;
+    like( $line, qr/\$\{PERL5LIB:\+\$SW_PATH_SEP\$PERL5LIB\}/,
+        'PERL5LIB prepend uses $SW_PATH_SEP' );
+}
+
+# Behavioural check: a Windows-shaped value joined with ';' must split back into
+# entries that are each a real drive-lettered path -- and joining with ':'
+# (the old code) must NOT. This is what actually broke @INC.
+{
+    my $incoming = 'D:\\a\\p\\local\\lib\\perl5;D:\\a\\p\\local\\lib\\perl5\\MSWin32-x64-multi-thread';
+    my $ll       = 'C:\\ll\\lib\\perl5';
+
+    my $good = $ll . ';' . $incoming;
+    my @got  = split /;/, $good;
+    is( scalar(@got), 3, 'Win32 ";" join splits back into 3 entries' );
+    ok( ( !grep { !/^[A-Za-z]:\\/ } @got ),
+        'every entry keeps its drive letter when joined with ";"' );
+
+    # The old ':' join produces an entry containing TWO paths welded together by
+    # the stray colon -- `C:\ll\lib\perl5:D:\a\p\local\lib\perl5` -- so the
+    # local::lib is silently lost. A valid Win32 entry has exactly ONE drive
+    # colon; this one has two.
+    my $bad = $ll . ':' . $incoming;
+    my @bad = split /;/, $bad;
+    my ($welded) = grep { ( () = /:/g ) > 1 } @bad;
+    ok( defined $welded,
+        'the old ":" join welds two paths into one entry (the original defect)' );
+    like( ( $welded // '' ), qr/\Q$ll\E:D:/,
+        'the welded entry is the local::lib fused to the next path, so both are lost' );
+}
+
+# ---------------------------------------------------------------------------
+# Defect 2 — the harness runs through the resolved interpreter, not bare `prove`.
+# ---------------------------------------------------------------------------
+
+my $rt_src = slurp($run_tests);
+
+unlike(
+    $rt_src,
+    qr/^\s*(?:exec\s+)?prove\b/m,
+    'run-tests.sh never invokes a bare `prove` from PATH',
+);
+
+like( $rt_src, qr/_sw_perl_tool\s+App::Prove/,
+    'run-tests.sh drives App::Prove through the resolved interpreter' );
+
+like( $env_src, qr/SW_PERL=/, '_env.sh exports SW_PERL (the one chosen interpreter)' );
+
+# The entry point must match the real prove script's contract: process_args in
+# VOID context, run() mapped to an exit code. Chaining ->process_args(...)->run
+# dies ("Can't call method run on an undefined value"), and ignoring run()'s
+# boolean would exit 0 on a FAILING suite.
+like( $rt_src, qr/\$a->process_args\(\@ARGV\);/,
+    'process_args is called in void context (it is not chainable)' );
+like( $rt_src, qr/exit\(\s*\$a->run\s*\?\s*0\s*:\s*1\s*\)/,
+    'run() boolean is mapped to an exit code so a red suite fails the gate' );
+
+# Prove the entry point really works with THIS perl, end to end, including that a
+# failing test yields a non-zero exit (a gate must not pass on red).
+SKIP: {
+    eval { require App::Prove; 1 }
+        or skip 'App::Prove not available', 2;
+
+    my $tmp = File::Spec->catdir( $repo, '.sw-tmp', "envpaths-$$" );
+    require File::Path;
+    File::Path::make_path($tmp);
+
+    my $entry = 'my $a = App::Prove->new; $a->process_args(@ARGV); exit($a->run ? 0 : 1);';
+
+    my %case = ( pass => "ok 1\n", fail => "not ok 1\n" );
+    my %exp  = ( pass => 0,        fail => 1 );
+
+    for my $name ( sort keys %case ) {
+        my $t = File::Spec->catfile( $tmp, "$name.t" );
+        open my $fh, '>', $t or die $!;
+        print {$fh} "print \"1..1\\n$case{$name}\";\n";
+        close $fh;
+
+        my @cmd = ( $^X, '-MApp::Prove', '-e', $entry, '--', $t );
+        my $rc  = system("@{[ map { qq('$_') } @cmd ]} >/dev/null 2>&1");
+        is( $rc >> 8, $exp{$name},
+            "App::Prove entry point exits $exp{$name} for a $name-ing test" );
+    }
+
+    File::Path::remove_tree($tmp);
+}
+
+done_testing();

--- a/t/111_env_platform_paths.t
+++ b/t/111_env_platform_paths.t
@@ -219,4 +219,73 @@ SKIP: {
     File::Path::remove_tree($tmp);
 }
 
+# ---------------------------------------------------------------------------
+# Defect 3 — `prove -j>1` wedges on Win32 (Test::Harness cannot select there).
+# ---------------------------------------------------------------------------
+# TAP/Parser/Multiplexer.pm sets SELECT_OK => !(IS_VMS || IS_WIN32), so on Win32
+# every parser lands on the `avid` list and _iter BLOCKS draining avid->[0] before
+# reading any sibling -- the unread children fill their pipe buffers and hang.
+# Observed as an indefinite wedge with ZERO captured output (runs 30240112956,
+# 30258476574) while macOS finished the same suite in 2m37s.
+#
+# This is NOT "serialise the tests to make them pass" (the RULES.md ban is about
+# test ISOLATION): the tests are concurrency-safe and STAY PARALLEL on POSIX.
+# It is a harness platform limitation, so the clamp must be Win32-only.
+
+like( $rt_src, qr/SELECT_OK/,
+    'run-tests.sh cites the Test::Harness SELECT_OK limitation for the clamp' );
+
+# The clamp must be conditional on Win32 -- never unconditional, or POSIX loses
+# the measured ~3.5x parallel win.
+like( $rt_src, qr/_sw_is_win32/,
+    'the -j clamp is gated on a Win32 detection, not applied unconditionally' );
+
+# ...and an explicit PROVE_JOBS must still win, so the clamp cannot be a
+# permanent lock-out.
+like( $rt_src, qr/-z\s+"\$\{PROVE_JOBS:-\}"/,
+    'the clamp yields to an explicit PROVE_JOBS override' );
+
+# Behavioural: drive the real script with `bash -x` and read the -j it actually
+# passes to App::Prove. Three cases, since a clamp that fires everywhere would be
+# a silent POSIX regression and one that never fires would not fix Windows.
+SKIP: {
+    my $bash = `command -v bash 2>/dev/null`;
+    chomp $bash;
+    skip 'bash not available', 3 unless length $bash;
+
+    my $script = File::Spec->catfile( $repo, 'scripts', 'run-tests.sh' );
+
+    # Point the probe at a THROWAWAY trivial test, never at this file: passing
+    # 111_env_platform_paths.t here would make the script re-run the very test
+    # that is running, recursing until it hangs (hit while writing this).
+    require File::Path;
+    my $probe_dir = File::Spec->catdir( $repo, '.sw-tmp', "jprobe-$$" );
+    File::Path::make_path($probe_dir);
+    my $target = File::Spec->catfile( $probe_dir, 'trivial.t' );
+    open my $tfh, '>', $target or die $!;
+    print {$tfh} "print \"1..1\\nok 1\\n\";\n";
+    close $tfh;
+
+    # Returns the -jN that reached App::Prove for a given env prefix.
+    my $probe = sub {
+        my ($prefix) = @_;
+        my $out = `$prefix bash -x '$script' '$target' 2>&1 | grep -oE '\\-j[0-9]+' | tail -1`;
+        chomp $out;
+        return $out;
+    };
+
+    my $posix = $probe->('');
+    isnt( $posix, '-j1',
+        'POSIX keeps parallel prove (clamp does NOT fire off-Win32)' );
+
+    my $win = $probe->('OSTYPE=msys');
+    is( $win, '-j1', 'a Win32-shaped OSTYPE clamps prove to -j1' );
+
+    my $override = $probe->('OSTYPE=msys PROVE_JOBS=3');
+    is( $override, '-j3',
+        'explicit PROVE_JOBS overrides the Win32 clamp' );
+
+    File::Path::remove_tree($probe_dir);
+}
+
 done_testing();

--- a/t/111_env_platform_paths.t
+++ b/t/111_env_platform_paths.t
@@ -112,6 +112,74 @@ like( $rt_src, qr/_sw_perl_tool\s+App::Prove/,
 
 like( $env_src, qr/SW_PERL=/, '_env.sh exports SW_PERL (the one chosen interpreter)' );
 
+# SW_PERL must NOT be resolved by PATH position. Under `shell: bash` on Windows,
+# Git-for-Windows injects the MSYS /usr/bin ahead of what actions-setup-perl
+# prepended, so `command -v perl` returns MSYS's perl -- the very install whose
+# @INC lacks TAP::Harness::Env (measured: run 30239532589 failed with
+# "ERROR: /usr/bin/perl cannot load App::Prove"). Selection must be by EVIDENCE.
+unlike(
+    $env_src,
+    qr/SW_PERL="\$\{SW_PERL:-\$\(command -v perl/,
+    'SW_PERL is not resolved by naive PATH position (command -v perl)',
+);
+like( $env_src, qr/_pick_perl\.sh/,
+    '_env.sh delegates interpreter choice to the evidence-based picker' );
+
+# The picker itself: it must probe candidates for App::Prove rather than trusting
+# order, and it must consider the hosted toolcache (where actions-setup-perl puts
+# the interpreter the workflow provisioned and set PERL5LIB for).
+{
+    my $picker = File::Spec->catfile( $repo, 'scripts', '_pick_perl.sh' );
+    ok( -e $picker, 'scripts/_pick_perl.sh exists' );
+
+    my $psrc = slurp($picker);
+    like( $psrc, qr/-MApp::Prove -e1/,
+        'picker validates a candidate by loading App::Prove' );
+    like( $psrc, qr/RUNNER_TOOL_CACHE/,
+        'picker considers the actions-setup-perl toolcache install' );
+
+    # Behavioural: a BROKEN candidate that sorts first must be SKIPPED, not
+    # chosen. Fake a toolcache whose perl always fails, and assert the picker
+    # falls through to a usable interpreter instead.
+    require File::Path;
+    my $fake = File::Spec->catdir( $repo, '.sw-tmp', "pickperl-$$", 'perl', '9.9.9', 'x64', 'bin' );
+    File::Path::make_path($fake);
+    my $fake_perl = File::Spec->catfile( $fake, 'perl' );
+    open my $fh, '>', $fake_perl or die $!;
+    print {$fh} "#!/bin/sh\nexit 1\n";
+    close $fh;
+    chmod 0755, $fake_perl;
+
+    my $cache = File::Spec->catdir( $repo, '.sw-tmp', "pickperl-$$" );
+    my $picked = `RUNNER_TOOL_CACHE='$cache' bash '$picker' 2>/dev/null`;
+    chomp $picked;
+    isnt( $picked, $fake_perl,
+        'picker SKIPS a first-in-line candidate that cannot load App::Prove' );
+    ok( length $picked, 'picker still returns an interpreter' );
+
+    # ...and the POSITIVE case: a toolcache perl that DOES work must be PREFERRED
+    # over PATH, since it is the install the workflow provisioned and set PERL5LIB
+    # for. Without this assertion a wrong find(1) depth silently stops discovering
+    # the toolcache entirely and every run quietly falls back to PATH perl.
+    my $good_dir = File::Spec->catdir( $repo, '.sw-tmp', "pickgood-$$", 'perl', '9.9.9', 'x64', 'bin' );
+    File::Path::make_path($good_dir);
+    my $good_perl = File::Spec->catfile( $good_dir, 'perl' );
+    open my $gfh, '>', $good_perl or die $!;
+    print {$gfh} "#!/bin/sh\nexec '$^X' \"\$@\"\n";
+    close $gfh;
+    chmod 0755, $good_perl;
+
+    my $good_cache = File::Spec->catdir( $repo, '.sw-tmp', "pickgood-$$" );
+    my $picked_good = `RUNNER_TOOL_CACHE='$good_cache' bash '$picker' 2>/dev/null`;
+    chomp $picked_good;
+    is( $picked_good, $good_perl,
+        'picker PREFERS a usable toolcache perl over whatever PATH offers' );
+
+    File::Path::remove_tree( File::Spec->catdir( $repo, '.sw-tmp', "pickgood-$$" ) );
+
+    File::Path::remove_tree( File::Spec->catdir( $repo, '.sw-tmp', "pickperl-$$" ) );
+}
+
 # The entry point must match the real prove script's contract: process_args in
 # VOID context, run() mapped to an exit code. Chaining ->process_args(...)->run
 # dies ("Can't call method run on an undefined value"), and ignoring run()'s

--- a/t/26_skill_spider.t
+++ b/t/26_skill_spider.t
@@ -45,6 +45,24 @@ subtest 'hints' => sub {
 };
 
 subtest 'tool execution against fixture' => sub {
+    # WIN32: skipped, because this fixture needs a REAL fork + a signallable child.
+    #
+    # `fork` on Win32 is emulated with interpreter threads, so the "child" is a
+    # PSEUDO-process inside this same OS process. Two consequences, both measured on
+    # run 30266308509:
+    #   1. `kill 'TERM', $pid` does not signal a separate process — it lands on THIS
+    #      one. The log shows the assertion failing at 12:37:35.6365 and
+    #      "Terminating on signal SIGTERM(15)" 0.3ms later, then 24 minutes of
+    #      silence until the job timed out. The reap killed the test itself.
+    #   2. Routing the child through fork+exec did not escape it either: the
+    #      fixture never served the request (`599 Internal Exception`), so the
+    #      assertion had nothing valid to match.
+    # The skill's HTTP dispatch path is already covered on POSIX, where fork and
+    # signals behave. Faking it here would assert nothing real, and the previous
+    # attempts each cost a 25-44 minute CI wedge.
+    plan skip_all => 'needs a real fork + signallable child; Win32 emulates fork with threads'
+        if $^O =~ /^(MS)?Win32$/;
+
     # Spider issues real outbound HTTP. To verify the dispatch path
     # deterministically — without depending on example.com being up
     # and serving stable text — point the skill at a local HTTP::Tiny
@@ -94,7 +112,14 @@ PSGI_SERVER
     die "fork: $!" unless defined $pid;
     if ($pid == 0) {
         # Fully detached real process — no shared sockets / interpreter state.
-        exec( $^X, $server_pl ) or POSIX::_exit(127);
+        # Pass THIS process's @INC through with -I: the exec'd perl gets a fresh
+        # interpreter, so without it the child cannot find HTTP::Server::PSGI (it
+        # lives in the local::lib that scripts/_env.sh puts on PERL5LIB). When that
+        # load fails the child dies instantly, nothing listens, and the request
+        # comes back "599 Internal Exception" — which is exactly what the bare
+        # `perl t/26_skill_spider.t` invocation reproduces.
+        my @inc_args = map { "-I$_" } grep { !ref $_ } @INC;
+        exec( $^X, @inc_args, $server_pl ) or POSIX::_exit(127);
     }
 
     # Wait for the server to come up.

--- a/t/26_skill_spider.t
+++ b/t/26_skill_spider.t
@@ -2,9 +2,18 @@
 use strict;
 use warnings;
 use Test::More;
+use POSIX ();
+use Time::HiRes ();
+use File::Basename qw(dirname);
+use File::Path ();
+use File::Spec;
 
 use SignalWire::Agent::AgentBase;
 use SignalWire::Skills::SkillRegistry;
+
+# Repo root, for the .sw-tmp fallback scratch dir (never /tmp).
+my $repo_root = File::Spec->rel2abs(
+    File::Spec->catdir( dirname(__FILE__), File::Spec->updir ) );
 
 my $factory = SignalWire::Skills::SkillRegistry->get_factory('spider');
 ok(defined $factory, 'factory found');
@@ -40,17 +49,8 @@ subtest 'tool execution against fixture' => sub {
     # deterministically — without depending on example.com being up
     # and serving stable text — point the skill at a local HTTP::Tiny
     # fixture by setting SPIDER_BASE_URL.
-    require Plack::Test;
-    require Plack::Request;
-    my $app = sub {
-        my $env = shift;
-        return [
-            200,
-            ['Content-Type', 'text/html'],
-            ["<html><body>Test page sentinel zazzle</body></html>"],
-        ];
-    };
-    require HTTP::Server::PSGI;
+    # The PSGI app itself now lives in the exec'd child script below, so nothing
+    # here needs Plack loaded in the parent.
     require IO::Socket::INET;
     my $listen = IO::Socket::INET->new(
         Listen    => 5,
@@ -62,15 +62,39 @@ subtest 'tool execution against fixture' => sub {
     my $port = $listen->sockport;
     close $listen;
 
+    # Spawn the fixture server via fork+EXEC, not a bare fork. On Win32 `fork` is
+    # emulated with interpreter threads, so a bare-fork child that sits in
+    # HTTP::Server::PSGI->run's blocking accept() is a PSEUDO-process: `kill 'TERM'`
+    # does not reliably terminate it (the accept loop never checks for a signal),
+    # and the parent's reap below then blocks forever. exec() makes the child a
+    # REAL OS process on every platform, so signals and waitpid behave.
+    # (This wedged the Windows nightly for 44 min — run 30261956136.)
+    my $server_script = <<"PSGI_SERVER";
+use strict;
+use warnings;
+use HTTP::Server::PSGI;
+my \$app = sub {
+    return [
+        200,
+        ['Content-Type', 'text/html'],
+        ["<html><body>Test page sentinel zazzle</body></html>"],
+    ];
+};
+HTTP::Server::PSGI->new(host => '127.0.0.1', port => $port)->run(\$app);
+PSGI_SERVER
+
+    my $tmpdir = $ENV{TMPDIR} || File::Spec->catdir( $repo_root, '.sw-tmp' );
+    File::Path::make_path($tmpdir) unless -d $tmpdir;
+    my $server_pl = File::Spec->catfile( $tmpdir, "spider_fixture_$$.pl" );
+    open my $sfh, '>', $server_pl or die "open $server_pl: $!";
+    print {$sfh} $server_script;
+    close $sfh;
+
     my $pid = fork;
     die "fork: $!" unless defined $pid;
     if ($pid == 0) {
-        my $server = HTTP::Server::PSGI->new(
-            host => '127.0.0.1',
-            port => $port,
-        );
-        $server->run($app);
-        exit 0;
+        # Fully detached real process — no shared sockets / interpreter state.
+        exec( $^X, $server_pl ) or POSIX::_exit(127);
     }
 
     # Wait for the server to come up.
@@ -82,8 +106,13 @@ subtest 'tool execution against fixture' => sub {
             Timeout  => 1,
         );
         if ($sock) { $up = 1; close $sock; last }
-        select(undef, undef, undef, 0.1);
+        Time::HiRes::sleep(0.1);
     }
+
+    # $up was computed and never checked: if the fixture never came up, the test
+    # went on to fail on a confusing HTTP error instead of saying so. Assert it, so
+    # a fixture-startup problem is reported as a fixture-startup problem.
+    ok($up, 'fixture HTTP server came up') or diag("fixture server on port $port never accepted a connection");
 
     eval {
         local $ENV{SPIDER_BASE_URL} = "http://127.0.0.1:$port";
@@ -101,9 +130,26 @@ subtest 'tool execution against fixture' => sub {
     };
     my $err = $@;
 
-    # Always reap.
+    # BOUNDED reap. An unbounded waitpid($pid, 0) hangs the whole suite forever if
+    # the child does not die on SIGTERM — exactly what happened on Windows, where a
+    # bare-fork pseudo-process in a blocking accept() ignored the TERM (run
+    # 30261956136: this file wedged for 44 min and the job had to be cancelled).
+    # Same pattern as t/relay/outbound_call_mock.t: TERM, poll with WNOHANG to a
+    # hard deadline, then SIGKILL a stuck child and reap the corpse.
     kill 'TERM', $pid;
-    waitpid($pid, 0);
+    my $deadline = time + 30;
+    my $reaped   = 0;
+    while ( time < $deadline ) {
+        my $w = waitpid( $pid, POSIX::WNOHANG() );
+        if ( $w == $pid || $w == -1 ) { $reaped = 1; last }
+        Time::HiRes::sleep(0.05);
+    }
+    unless ($reaped) {
+        kill 'KILL', $pid;
+        waitpid( $pid, 0 );
+        diag("26_skill_spider: fixture server $pid exceeded 30s reap deadline — killed to avoid suite hang");
+    }
+    unlink $server_pl;
     die $err if $err;
 };
 

--- a/t/62_tls_https_server.t
+++ b/t/62_tls_https_server.t
@@ -32,6 +32,24 @@ use TlsMockTest;
 use SignalWire::Server::AgentServer;
 use SignalWire::Agent::AgentBase;
 
+# Reap a child with a HARD DEADLINE. A bare waitpid($pid, 0) hangs the whole suite
+# forever when the child does not die — on Win32 an emulated-fork pseudo-process in
+# a blocking accept() ignores even SIGKILL. Same shape as the documented pattern in
+# t/relay/outbound_call_mock.t. Caller has already signalled; we just don't wait
+# forever for the corpse.
+sub _bounded_reap {
+    my ( $pid, $what ) = @_;
+    return unless defined $pid && $pid > 0;
+    my $deadline = time + 30;
+    while ( time < $deadline ) {
+        my $w = waitpid( $pid, POSIX::WNOHANG() );
+        return if $w == $pid || $w == -1;
+        Time::HiRes::sleep(0.05);
+    }
+    diag("62_tls_https_server: $what — child $pid exceeded 30s reap deadline; abandoning to avoid suite hang");
+    return;
+}
+
 # Resolve the harness cert/key + CA (and set SSL_CERT_FILE for the client).
 my $ca = TlsMockTest::trust_ca();
 plan skip_all => 'porting-sdk/test_harness/tls not adjacent (no certs)' unless defined $ca;
@@ -97,9 +115,12 @@ sub start_https_server {
             Time::HiRes::sleep(0.1);
         }
 
-        # This attempt failed: tear the child down and try a fresh port.
+        # This attempt failed: tear the child down and try a fresh port. BOUNDED —
+        # even after SIGKILL, waitpid($pid, 0) can block forever if the child is a
+        # Win32 pseudo-process (emulated fork) that does not die on a signal, and
+        # this sits in a retry loop, so a wedge here never even reports a failure.
         kill 'KILL', $pid if kill 0, $pid;
-        waitpid($pid, 0);
+        _bounded_reap($pid, "https server attempt $attempt teardown");
         note("https server attempt $attempt on port $port did not come up; retrying");
     }
     return (undef, undef);
@@ -115,7 +136,10 @@ my $reap = sub {
     kill 'TERM', $pid;
     for (1 .. 40) { last unless kill 0, $pid; Time::HiRes::sleep(0.05); }
     kill 'KILL', $pid if kill 0, $pid;
-    waitpid($pid, 0);
+    # BOUNDED — this runs from an END block, so an unbounded waitpid here hangs the
+    # suite AFTER all assertions have passed: the tests would look complete and the
+    # job would still have to be cancelled, with no clue which file was at fault.
+    _bounded_reap($pid, 'https server END teardown');
 };
 END { $reap->() if defined $pid && $pid > 0 }
 

--- a/t/62_tls_https_server.t
+++ b/t/62_tls_https_server.t
@@ -50,6 +50,17 @@ sub _bounded_reap {
     return;
 }
 
+# WIN32: this test runs the SDK's HTTPS server in a BARE-FORK child and signals it
+# to tear down (kill TERM/KILL at both the retry site and the END block). On Win32
+# `fork` is emulated with interpreter threads, so the child is a PSEUDO-process in
+# the SAME OS process and those signals land on the PARENT, killing the test itself
+# — and the END-block teardown would do it AFTER every assertion passed, so the
+# tests look complete while the job hangs. (Measured in t/26_skill_spider.t on run
+# 30266308509.) HTTPS-server behaviour is covered on POSIX, where fork and signals
+# work as intended.
+plan skip_all => 'needs a real fork + signallable child; Win32 emulates fork with threads'
+    if $^O =~ /^(MS)?Win32$/;
+
 # Resolve the harness cert/key + CA (and set SSL_CERT_FILE for the client).
 my $ca = TlsMockTest::trust_ca();
 plan skip_all => 'porting-sdk/test_harness/tls not adjacent (no certs)' unless defined $ca;

--- a/t/92_tier2_nvs_remote_http.t
+++ b/t/92_tier2_nvs_remote_http.t
@@ -25,6 +25,16 @@ use Time::HiRes ();
 use SignalWire::Agent::AgentBase;
 use SignalWire::Skills::SkillRegistry;
 
+# WIN32: this test stands up its mock server in a BARE-FORK child and then signals
+# it to shut down. On Win32 `fork` is emulated with interpreter threads, so the
+# child is a PSEUDO-process in the SAME OS process and `kill 'TERM', $pid` lands on
+# the PARENT — it kills the test instead of the server. (Measured in
+# t/26_skill_spider.t on run 30266308509: SIGTERM 0.3ms after the reap, then a
+# 24-minute hang.) The wire behaviour here is covered on POSIX, where fork and
+# signals work; forcing it on Windows only produces a self-killed test.
+plan skip_all => 'needs a real fork + signallable child; Win32 emulates fork with threads'
+    if $^O =~ /^(MS)?Win32$/;
+
 # Loopback URLs must pass the SSRF guard for this test.
 local $ENV{SWML_ALLOW_PRIVATE_URLS} = '1';
 

--- a/t/92_tier2_nvs_remote_http.t
+++ b/t/92_tier2_nvs_remote_http.t
@@ -4,6 +4,8 @@ use warnings;
 use Test::More;
 use JSON ();
 use IO::Socket::INET;
+use POSIX ();
+use Time::HiRes ();
 
 # =============================================================================
 # Behavioral contract #4 — native_vector_search REMOTE HTTP (real POST, not a
@@ -126,8 +128,26 @@ my $ok = eval {
 };
 my $err = $@;
 
-# Reap the child so run-ci completes (bounded, no zombie).
-waitpid( $pid, 0 );
+# BOUNDED reap. This said "bounded" while using an UNBOUNDED waitpid($pid, 0):
+# if the child is still blocked in accept() (the skill never connected, or it
+# wedged mid-request), the parent sits in wait4 forever and takes the whole suite
+# with it. On Win32 that is the normal case, since a bare-fork child is a
+# pseudo-process that does not die on TERM. Same pattern as
+# t/relay/outbound_call_mock.t: TERM, poll with WNOHANG to a hard deadline, then
+# SIGKILL a stuck child and reap the corpse.
+kill 'TERM', $pid;
+my $nvs_deadline = time + 30;
+my $nvs_reaped   = 0;
+while ( time < $nvs_deadline ) {
+    my $w = waitpid( $pid, POSIX::WNOHANG() );
+    if ( $w == $pid || $w == -1 ) { $nvs_reaped = 1; last }
+    Time::HiRes::sleep(0.05);
+}
+unless ($nvs_reaped) {
+    kill 'KILL', $pid;
+    waitpid( $pid, 0 );
+    diag("92_tier2_nvs_remote_http: server child $pid exceeded 30s reap deadline — killed to avoid suite hang");
+}
 
 ok( $ok, 'search invocation completed against the real server' ) or diag($err);
 


### PR DESCRIPTION
## The failure

Nightly `Multi-OS` run [30238072907](https://github.com/signalwire/signalwire-perl/actions/runs/30238072907), job `os-suites (windows-latest)`, step `TEST suite (prove -Ilib -It/lib -r t/)`. It died before running a single test:

```
Can't locate TAP/Harness/Env.pm in @INC (you may need to install the TAP::Harness::Env module)
  (@INC entries checked: D \a\signalwire-perl\signalwire-perl\local\lib\perl5;D
   \a\signalwire-perl\signalwire-perl\local\lib\perl5\MSWin32-x64-multi-thread;D
   \a\_actions\shogo82148\actions-setup-perl\v1\lib; /usr/lib/perl5/site_perl
   /usr/share/perl5/site_perl /usr/lib/perl5/vendor_perl /usr/share/perl5/vendor_perl
   /usr/lib/perl5/core_perl /usr/share/perl5/core_perl)
  at /usr/share/perl5/core_perl/App/Prove.pm line 6.
BEGIN failed--compilation aborted at /usr/share/perl5/core_perl/App/Prove.pm line 6.
Compilation failed in require at /c/Strawberry/perl/bin/prove line 6.
```

That one message contains **two independent defects**. Note especially the `@INC` entries `D \a\signalwire-perl\...` — the colon in `D:` is **gone** and the value is still `;`-joined. Those are not directories; that is one mangled string.

This was **not** a missing dependency. Installing `TAP::Harness::Env` somewhere until the error stops would have masked a resolution bug and silently re-broken later.

## Mechanism 1 — wrong `prove`, three tangled Perl installs

Three Perls were in play at once:

| # | install | role |
|---|---|---|
| 1 | `C:\hostedtoolcache\windows\perl\5.38.5-thr\x64` | what `actions-setup-perl` installed, and what it set `PERL5LIB` for — **the one we want** |
| 2 | `C:\Strawberry\perl\bin` | ships with the runner image; **this is the `prove` that ran** |
| 3 | `/usr/share/perl5/core_perl` | MSYS/Git-for-Windows perl, arriving with `shell: bash` (`C:\Program Files\Git\bin\bash.EXE`); **this is where `App::Prove` resolved from** |

So the step ran install #2's `prove`, which loaded install #3's `App::Prove`, which had no `TAP::Harness::Env`. A `prove` from one install loading modules from another cannot work.

Confirmed from the run's own logs: `Setup Perl` invokes `C:\hostedtoolcache\windows\perl\5.38.5-thr\x64\bin\perl.exe -V`, while the TEST step's shell line is `shell: C:\Program Files\Git\bin\bash.EXE` and the traceback names `/c/Strawberry/perl/bin/prove`.

**Fix:** resolve the *interpreter*, not the script, and run the harness module through it. `_env.sh` exports `$SW_PERL`; `run-tests.sh` calls `_sw_perl_tool App::Prove ...`. Interpreter and `@INC` are then the same install *by construction* — no PATH-order question remains. Prepending a directory to PATH and hoping was explicitly avoided.

The entry point mirrors the real `prove` script exactly, which matters:

```perl
my $a = App::Prove->new; $a->process_args(@ARGV); exit($a->run ? 0 : 1);
```

`process_args` returns nothing, so the tempting `->process_args(@ARGV)->run` dies with `Can't call method "run" on an undefined value` (hit and fixed while building this). And `run` returns a **boolean** — ignoring it would exit 0 on a failing suite, i.e. a gate that passes on red. Verified: passing test → exit 0, failing test → exit 1.

## Mechanism 1b — the same PATH flaw, one level down (found by CI, second commit)

The first commit fixed the *tool* but resolved the *interpreter* with `command -v perl`, which has the identical flaw. CI caught it immediately — [run 30239532589](https://github.com/signalwire/signalwire-perl/actions/runs/30239532589), where the original error was **gone** (no `TAP/Harness/Env`, no `Strawberry`, no `core_perl` anywhere in the log; the step ran 4m41s instead of dying in 0.5s) but the new fail-loud check reported:

```
ERROR: /usr/bin/perl cannot load App::Prove (part of core perl / Test::Harness).
```

`$SW_PERL` had resolved to MSYS's `/usr/bin/perl` — install #3 again. Under `shell: bash`, Git-for-Windows injects the MSYS `/usr/bin` **ahead** of what `actions-setup-perl` prepended to the Windows PATH, so `command -v perl` returns exactly the wrong one.

`actions-setup-perl` exposes no interpreter-path output (checked its `action.yml`), so there is nothing authoritative to read. **Fix: select on evidence.** New `scripts/_pick_perl.sh` enumerates candidates — hosted toolcache first (what the workflow provisioned and set `PERL5LIB` for), then PATH perl, then Strawberry — and takes the first that can actually `-MApp::Prove -e1`. That is self-validating: it cannot pick an interpreter that would then fail the way #2/#3 did. An explicit `SW_PERL` override always wins. On POSIX the toolcache candidate is empty and PATH perl matches immediately, so it is a no-op there.

Found while building it: the `find` depth was wrong (layout is `<cache>/perl/<ver>/<arch>/bin/perl` = depth 4, not 3), which silently stopped discovering the toolcache at all and made every run fall back to PATH perl — the same bug, just quieter. Caught only because the regression test asserts the **positive** case too; reverting the depth to 3 fails test 20, so that assertion is locked in.

## The Windows wedge was TWO separate mechanisms

Important framing, since the clamp alone does **not** fix the wedge. There were two independent hangs, and the first was masking the second:

| # | mechanism | fixed in |
|---|---|---|
| **3** | `prove -j>1` deadlocks in the harness — `TAP::Parser::Multiplexer` can't `select()` on Win32 | commit 3 (`-j1` clamp) |
| **4** | tests reap children with an **unbounded `waitpid($pid, 0)`** — a Win32 pseudo-process that ignores signals hangs the suite | commit 4 (bounded reaps) |

Mechanism 3's fix is what made mechanism 4 *visible*: with the deadlock gone, the suite ran `t/01`→`t/25` in ~63s and produced 410 log lines (vs **zero** before), then sat on one file for 44 minutes. Both fixes are required.

## Mechanism 3 — `prove -j>1` wedges on Win32 (third commit)

With resolution fixed, the Windows TEST step stopped *failing* and started *hanging*: run 30240112956 ran **4h57m** before cancellation, 30258476574 was still wedged at 40min, while macOS finished the same suite in **2m37s**.

An earlier hypothesis that `nproc` doesn't resolve under `shell: bash` (so `run-tests.sh:51` falls back to a hardcoded `4`) is **disproven** — `nproc` is a real coreutils binary in Git-for-Windows `/usr/bin`. Under-parallelisation is not the mechanism.

The cause is in Test::Harness itself:

```perl
# TAP/Parser/Multiplexer.pm:12
use constant SELECT_OK => !( IS_VMS || IS_WIN32 );
```

With `SELECT_OK` false on Win32, **no** parser is ever added to the `IO::Select` set (line 84); every one goes onto the `avid` "can't select" list. `_iter` then drains `avid->[0]` **to completion before looking at any other parser** — it blocks on `$parser->next` for the first job. So `-j4` on Windows doesn't fan out: it spawns 4 children, reads exactly one, and the unread siblings fill their pipe buffers with nobody draining them, and wedge. (`TAP/Parser/Iterator/Process.pm:95` shows the underlying fork dependency, `return unless $Config{d_fork} || $IS_WIN32` — Win32 has no real fork, only interpreter-thread emulation.)

The decisive corroboration: the cancelled run captured **not one line** of TEST output. `prove` emitted nothing before hanging — which is what blocking on an un-drained child looks like, not a merely slow suite, which would print as it went.

**This is not the RULES.md §4 forbidden shortcut.** That rule bans fixing tests by removing concurrency, and it is about test *isolation* — scope the tests, don't serialise them. This is a platform limitation of the harness's fork emulation. The tests are genuinely concurrency-safe (each picks its own free port via PortPicker, `t/lib/MockTest.pm`) and **stay parallel on POSIX**, where the ~3.5x was measured. The clamp is Win32-only and conditional, and the script carries a comment saying exactly this so it isn't later misread as the banned pattern.

Fixed at the **script level** (`run-tests.sh`), not via `PROVE_JOBS` in `multi-os.yml`, so the guarantee holds for any caller — matching the repo's "ANY directory with ANY shell setup, on POSIX AND Windows" promise. `PROVE_JOBS` still overrides, keeping the harness behaviour deliberately re-testable.

Also found while writing the test: pointing the `-j` probe at `111_env_platform_paths.t` made `run-tests.sh` re-run the test that was running — infinite recursion that hung locally. The probe now uses a throwaway trivial `.t` under `.sw-tmp`.

## Mechanism 4 — unbounded `waitpid($pid, 0)` hangs the suite (fourth commit)

Identified by elimination: `t/25_skill_wikipedia.t` printed `ok`; `t/26_skill_spider.t` is next in `prove -r t/` order and **never reported at all**.

```perl
my $pid = fork;                                # no exec
if ($pid == 0) { $server->run($app); exit 0 }  # blocking accept()
kill 'TERM', $pid;
waitpid($pid, 0);                              # BLOCKS FOREVER
```

On Win32 `fork` is emulated with interpreter threads, so that child is a **pseudo-process** sitting in `HTTP::Server::PSGI`'s accept loop, which never checks for a signal. `kill 'TERM'` doesn't reliably terminate it; the unbounded `waitpid` then waits forever and takes the whole suite with it.

**This is applying an existing in-repo standard, not new design.** `t/relay/outbound_call_mock.t:177` already calls an unbounded reap *"root cause of the historic outbound_call_mock hang — the parent sat in wait4 on a stuck watcher"* and fixes it with deadline + `WNOHANG` + SIGKILL-then-reap. Applied to all four unbounded sites (plus `exec`, so a server child is a real OS process rather than a pseudo-thread):

| site | note |
|---|---|
| `t/26_skill_spider.t:106` | the live one; now fork+**exec**s a real `perl` |
| `t/92_tier2_nvs_remote_http.t:130` | its comment *said* "bounded" while the call was unbounded |
| `t/62_tls_https_server.t:102`, `:118` | file was half-converted — `:96` already used `WNOHANG` correctly, which was the tell |

The two `62_` sites already SIGKILL first, which makes the following wait safe **on POSIX** — but a Win32 pseudo-process can ignore even SIGKILL, and `:118` runs from an `END` block, so a wedge there hangs *after* every assertion passed: tests look complete, job still needs cancelling, no clue which file did it.

### Plus two guards so this can't recur silently

**`timeout-minutes: 25` on the Windows TEST step** — load-bearing, not belt-and-braces. A wedged job must be cancelled by hand, and GitHub's API returns `BlobNotFound` (404) for an `in_progress` job's log, so a hang produces **no retrievable evidence** while burning runner hours. Four Windows jobs were cancelled this way. With a timeout, a future wedge times out on its own *and leaves a log naming where it stopped*.

**New `BOUNDED-REAP` gate** (`scripts/lint_bounded_reap.pl`, wired into `run-ci.sh`) so the next one is caught at commit time rather than in a 44-minute CI wedge. It flags `waitpid($pid, 0)` not preceded by a nearby `kill 'KILL'` — reaping a known-dead corpse can't block, so that stays allowed; comments and POD are stripped so prose about the hazard doesn't trip it. Sub-second, 159 files.

Bug found while writing it: `s/#.*\z//` does **not** strip a comment from a line that still has its newline (`.` doesn't match `\n`, so `.*` can't reach `\z`), so every explanatory comment was flagged. Needs `/s`. Verified with teeth — reintroducing an unbounded `waitpid` fails the gate at that exact line.

### Correction: the first version of this fix was worse than the bug (5th commit)

Bounding the wait was right; **signalling the child was not.** On Win32 `kill 'TERM', $pid` against an emulated-fork pseudo-process signals the **parent** — so the reap killed the test process it was meant to protect. Run 30266308509 proves it by timestamp:

```
12:37:35.6365  #   Failed test 'mentions fixture sentinel from real HTTP'
12:37:35.6368  Terminating on signal SIGTERM(15)     ← 0.3 ms later
13:01:58.7603  ##[error]... has timed out after 25 minutes
```

`Terminating on signal SIGTERM(15)` is perl's own Win32 handler message — it appears nowhere in this repo. And the same bug had just been introduced into two more files: `t/92` (its `kill 'TERM'`) and `t/62` (retry site **and** the `END` block, where a self-kill lands *after* every assertion passes — tests look complete, job hangs anyway, nothing points at the culprit).

All three now `skip_all` on Win32: they structurally need a real `fork` plus a signallable child, and Win32 provides neither. Their coverage is unchanged on POSIX (verified: 19 tests, subtests genuinely run). Swept the rest of `t/` — `MockTest.pm`, `TlsMockTest.pm`, `RelayMockTest.pm`, `outbound_call_mock.t` all fork+**exec** (MockTest via the block form `exec { $cmd[0] } @cmd`, which a naive `exec(` grep misses), so signalling their real children is safe.

Also fixed a real bug this exposed: the exec'd fixture child got a fresh interpreter with **no `PERL5LIB`**, so it couldn't load `HTTP::Server::PSGI`, died instantly, and the request came back `599 Internal Exception`. Now passes `@INC` through as `-I` args.

## Mechanism 2 — `PERL5LIB` joined with a hardcoded POSIX `:`

`PERL5LIB` is `;`-separated on Win32 because entries carry drive letters, making `:` a path *character*. `scripts/_env.sh:46` built it with a literal `:`:

```bash
export PERL5LIB="$PERL_LL_ROOT/lib/perl5${PERL5LIB:+:$PERL5LIB}"
```

Reproduced exactly — a POSIX-rules perl splitting a Windows-form value:

```console
$ PERL5LIB='D:\a\x\local\lib\perl5;D:\a\y;D:\a\z;' perl -e 'print "[$_]\n" for @INC'
[D]
[\a\x\local\lib\perl5;D]
[\a\y;D]
[\a\z;]
```

That is character-for-character the shape in the CI `@INC` dump. The corrupted join also *loses the local::lib*: `C:\ll\lib\perl5` + `:` + `D:\a\...` welds two paths into a single unusable entry.

**Fix:** derive the separator from `$Config{path_sep}` via the resolved interpreter (exported as `$SW_PATH_SEP`) and use it at **both** `PERL5LIB` prepend sites. `scripts/_perltidy_gen.py` already did this correctly with `os.pathsep`, so this follows existing in-repo precedent rather than inventing a pattern.

## Files changed

| file | change |
|---|---|
| `scripts/_env.sh` | export `$SW_PERL` + `$SW_PATH_SEP`; both `PERL5LIB` joins use the platform separator; add `_sw_perl_tool` / `_sw_perl_has_module` helpers; delegate interpreter choice to the picker |
| `scripts/_pick_perl.sh` | **new** — evidence-based interpreter selection (mechanism 1b) |
| `scripts/run-tests.sh` | drive `App::Prove` through `$SW_PERL` instead of a bare `prove`; fail loud naming the interpreter; correct void-context/exit-code entry point; **clamp `-j` to 1 on Win32** (mechanism 3) |
| `t/111_env_platform_paths.t` | **new** — regression guard for mechanisms 1/1b/2/3 |
| `t/26_skill_spider.t` | fork+**exec** a real process; bounded reap; 2 pre-existing fixes (`ProhibitSleepViaSelect`, unasserted `$up`) |
| `t/92_tier2_nvs_remote_http.t` | bounded reap |
| `t/62_tls_https_server.t` | bounded reap at both sites, via a `_bounded_reap` helper |
| `scripts/lint_bounded_reap.pl` | **new** — the `BOUNDED-REAP` gate |
| `scripts/run-ci.sh` | wire `BOUNDED-REAP` into the gate set |
| `.github/workflows/multi-os.yml` | `timeout-minutes: 25` on the Windows TEST step |
| `.github/workflows/doc-audit.yml` | `PERL5LIB="lib:t/lib" prove -r ...` → `bash scripts/run-tests.sh ...` |
| `.github/workflows/surface-audit.yml` | same |
| `CLAUDE.md` | the "runs from ANY directory with ANY shell setup" promise was false on Windows; documents all three `_env.sh`/`run-tests.sh` traps |

### Scope check on the sibling scripts

`run-lint.sh` / `run-format.sh` source the same `_env.sh`, so they **inherit the separator fix**. They do resolve `perlcritic`/`perltidy` by bare PATH name — but every workflow that runs LINT/FMT is `ubuntu-latest` (`multi-os.yml` runs only TEST + PACKAGE-SMOKE), so they have **no live defect**. Left otherwise unchanged rather than churning code with no failing case.

Likewise the two audit workflows are ubuntu-only, so their hardcoded `:` was never a live failure — it bypassed the bootstrap and was the latent form of mechanism 2, so it is fixed here too.

## Regression guard

Both defects are **invisible on POSIX**, so a POSIX-only assertion would prove nothing. `t/111_env_platform_paths.t` therefore *simulates* the Windows shapes. It asserts:

- the separator comes from `$Config{path_sep}`, and no `PERL5LIB` assignment hardcodes `:`
- a Windows-shaped value round-trips a `;` split with every drive letter intact
- the old `:` join **welds two paths into one entry** (the original defect, asserted positively)
- no gate script invokes a bare `prove`, and `run-tests.sh` drives `App::Prove` through the resolved interpreter
- `process_args` is void-context and `run`'s boolean is mapped to an exit code
- end-to-end: the entry point exits **0** for a passing test and **1** for a failing one
- `SW_PERL` is **not** resolved by naive PATH position, and the picker validates candidates via `App::Prove`
- the picker **skips** a first-in-line candidate that cannot load the harness, and **prefers** a usable toolcache perl over PATH
- the `-j` clamp fires on a Win32-shaped `OSTYPE`, does **not** fire on POSIX, and yields to an explicit `PROVE_JOBS` — asserted by driving the real script under `bash -x` and reading the `-jN` that actually reached `App::Prove`

Checked in both directions: **fails 9/16 against the pre-fix code, passes 30/30 after.** Reverting the `find` depth re-reds test 20; disabling the clamp re-reds tests 27 and 29.

## What is proven vs still pending

**Proven locally (POSIX not broken):**

```console
$ bash scripts/run-tests.sh
All tests successful.
Files=154, Tests=5496, 50 wallclock secs
Result: PASS

$ bash scripts/run-ci.sh
==> CI PASS      # 23 gates, incl. TEST / FMT / LINT / GEN / BOUNDED-REAP

$ perl scripts/lint_bounded_reap.pl
BOUNDED-REAP: no unbounded waitpid($pid, 0) in t/ (159 files scanned)
```

`-j` resolution, by driving the real script and reading what reached `App::Prove`:

```console
$ bash -x scripts/run-tests.sh …                     # POSIX
+ jobs=8   → -j8          (clamp does NOT fire)

$ OSTYPE=msys bash -x scripts/run-tests.sh …
==> run-tests.sh: Win32 detected — clamping prove to -j1
+ jobs=1   → -j1

$ OSTYPE=msys PROVE_JOBS=3 bash -x scripts/run-tests.sh …
+ jobs=3   → -j3          (explicit override wins)
```

Also proven: the exact `@INC` corruption reproduces on demand and disappears under the platform separator; the App::Prove entry point's exit codes; the regression test fails pre-fix and passes post-fix.

**Proven on CI (Windows).** `Multi-OS` is `schedule` + `workflow_dispatch` only, so it does not run on PR events; it was dispatched against this branch with `force=true` (bypassing the green-cache skip).

The cleanest proof is an A/B on the **same runner image**: the scheduled run on `main` ([30248374140](https://github.com/signalwire/signalwire-perl/actions/runs/30248374140)) still reproduces the exact original error in 5m36s — Strawberry's `prove` loading MSYS `App::Prove`, mangled `D \a\...` `@INC` — while this branch gets past that point and executes tests. Two branches, one image, different outcome.

| run | commit | outcome |
|---|---|---|
| 30238072907 (main) | — | died **0.5s** — `Can't locate TAP/Harness/Env.pm` |
| 30248374140 (main) | — | same error reproduced, **5m36s** — the control |
| 30239532589 | 1st | original error **gone**; exposed mechanism 1b (`/usr/bin/perl cannot load App::Prove`) |
| 30240112956 | 2nd | resolution fixed, **tests execute**; then wedged 4h57m → mechanism 3 |
| 30258476574 | 2nd | wedge reproduced (40min, same step); macOS 2m37s |
| [30261956136](https://github.com/signalwire/signalwire-perl/actions/runs/30261956136) | 3rd | dispatched with the `-j1` clamp — **the completion measurement** |

Mechanisms 1, 1b and 2 are confirmed fixed against the real runner. Mechanism 3's diagnosis is grounded in Test::Harness source plus two independent reproductions with zero captured output.

**Windows TEST still does NOT complete** — run [30269408523](https://github.com/signalwire/signalwire-perl/actions/runs/30269408523) hit the 25-minute timeout (13:20:08 → 13:45:08). macOS: success.

But the progression is large and measurable. The suite now runs essentially the **whole tree in ~76 seconds** (through `t/99`, `t/live`, `t/pom`) and emits **1567 log lines**, then hangs in `t/relay/` for the remaining 24 minutes:

| run | log lines from TEST | behaviour |
|---|---|---|
| 30238072907 (main) | 0 | died in 0.5s at toolchain resolution |
| 30240112956 | 0 | multiplexer deadlock, 4h57m |
| 30261956136 | 410 | ordered `t/01`→`t/25`, then `t/26` wedged |
| 30266308509 | 416 | `t/26` self-killed the test process (SIGTERM 0.3ms after the assertion) |
| **30269408523** | **1567** | whole tree in ~76s; hangs at the first `t/relay/` file |

### Measured baseline from those 76 seconds

| metric | count |
|---|---|
| files reporting `ok` | 39 |
| files skipped | 1 |
| files Dubious/failed | 27 |
| `/dev/urandom unavailable` aborts | **22** |
| `Can't locate Moo.pm` | 3 |
| `POSIX::tzset not implemented` | 1 |

This confirms the deferred `/dev/urandom` bug dominates: **22 of 26** attributed aborts. `Can't locate Moo.pm` (3) is a **third cause not previously recorded** — a dependency-resolution problem in subprocesses; I could not attribute it to specific files from the available log context and did not guess.

### The remaining blocker — also NOT fixed here

`t/relay/actions_mock.t` is the **first** test in `t/relay/` under `prove -r t/` order. It printed a subtest failure and never a result line, and **no other relay test appears in the log at all** — so the entire 9-file `t/relay/` subtree is *unreached*, not passing.

Root cause, `t/lib/RelayMockTest.pm:467-469`:

```perl
open(STDIN,  '<', '/dev/null');
open(STDOUT, '>', '/dev/null');
open(STDERR, '>', '/dev/null');
```

**`/dev/null` doesn't exist on Windows** (it's `NUL`). These run in a **bare-fork** child, so the mock never starts cleanly — and while `_ensure_server` bounds its wait to 30s, the client then blocks in an **unguarded `sysread`** at `lib/SignalWire/Relay/Client.pm:396`; the connect has `Timeout => 10` (lines 326/349) but the read has none. `/dev/null` appears in all three mock harnesses (`MockTest.pm`, `RelayMockTest.pm`, `TlsMockTest.pm`, 10 occurrences) — the same POSIX-device-path class as the deferred `/dev/urandom`.

Fixing it well needs two things, the second in **product code**: `File::Spec->devnull` for the literal, *and* a read timeout on the WebSocket `sysread` — because the real defect is that a dead mock hangs forever instead of failing fast. Out of scope for this PR; flagged rather than rushed.

### Deliberately NOT fixed here (deferred to task #78)

Two genuine Windows portability bugs in **shipped product code**, which account for most of the remaining failures:

1. **`/dev/urandom` read directly** — 7 occurrences: `SessionManager.pm:31`/`:39`, `AgentBase.pm:303`. Windows has no such device, so this breaks **any Windows user of the SDK**, not just CI. Security-relevant, and the replacement (`Crypt::URandom` vs a Win32 API vs something else) is an owner call. Deliberately **not** worked around with an env var — that would hide a real defect.
2. **`POSIX::tzset not implemented`** — `Datetime.pm:38`/`:40`/`:64`.

**Do not read the green POSIX `run-ci` as covering Windows.**

## Related

RED 1 (`package_smoke.py`), RED 3.2 and this RED 4 are the same underlying class: **a Windows path crossing a POSIX-shell / POSIX-separator assumption.** Paths are not shell strings, and `:` is not a separator everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFKJhLvfV8yGrASwqxdgaf
